### PR TITLE
fix: prevent overlapping statuses in resource view

### DIFF
--- a/src/components/ResourceStream.tsx
+++ b/src/components/ResourceStream.tsx
@@ -106,6 +106,7 @@ function ResourceRow({
   const statusColor = colorFor(status);
   const syncVal = syncByKey[keyFor(r)] ?? "-";
   const syncColor = colorFor(syncVal);
+  const pad = (val: string) => val.padStart(12).slice(-12);
   return (
     <Box width="100%">
       <Box width={13} flexShrink={0}>
@@ -122,7 +123,7 @@ function ResourceRow({
           dimColor={syncColor.dimColor as any}
           wrap="truncate"
         >
-          {syncVal}
+          {pad(syncVal)}
         </Text>
       </Box>
       <Box width={1} flexShrink={0} />
@@ -132,7 +133,7 @@ function ResourceRow({
           dimColor={statusColor.dimColor as any}
           wrap="truncate"
         >
-          {status}
+          {pad(status)}
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- pad sync and health status cells so previous text doesn't bleed when rows update

## Testing
- `bun x biome check src/components/ResourceStream.tsx`
- `bun test` *(fails: TypeError: mock.clearAllMocks is not a function in ui tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0244580e88325899fee28898ce475