### PR TITLE
feat(docker): add container build and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# VCS
+.git
+.github
+.gitignore
+
+# IDE/editor
+.idea
+.vscode
+
+# OS
+.DS_Store
+
+# Dependencies and builds
+node_modules
+dist
+out
+
+# Local binaries and artifacts
+main
+argonaut
+argonaut-bin
+
+# Misc
+*.log
+coverage
+*.lcov

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -83,6 +83,12 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lockb') }}
           restore-keys: bun-${{ runner.os }}-
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Setup SSH key for AUR
         if: env.AUR_SSH_PRIVATE_KEY != ''
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -143,6 +143,25 @@ nix:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
 
+dockers_v2:
+  - id: docker-multi
+    dockerfile: Dockerfile.v2
+    ids: [bun-musl]
+    images:
+      - ghcr.io/darksworm/argonaut
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "https://github.com/darksworm/argonaut"
+
 nfpms:
   - id: linux-packages-standard
     ids: [bun-standard]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* **docker:** add Dockerfiles, Docker scripts, and documentation for container usage
+
 ## [1.14.0](https://github.com/darksworm/argonaut/compare/v1.13.0...v1.14.0) (2025-08-29)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+###########
+# Builder #
+###########
+# Build a static Linux binary with Bun in an Alpine (musl) environment
+FROM oven/bun:alpine AS builder
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile
+
+# Copy the rest of the sources
+COPY . .
+
+# Compile to a single binary
+# Output directly to /out to avoid copying node_modules into the final image
+RUN mkdir -p /out \
+ && bun build --compile --minify --sourcemap src/main.tsx --outfile /out/argonaut
+
+#############
+# Runtime   #
+#############
+# Use Alpine (musl) to match the compiled binary's dynamic linker
+FROM alpine:3.20
+
+ARG TARGETARCH
+
+# Add required runtimes and tools for the compiled binary
+# - ca-certificates: HTTPS requests
+# - libstdc++, libgcc: C++ runtime and unwinder needed by the bun-compiled binary
+# - curl, git: fetch Argo CD CLI and provide git diff fallback
+RUN apk add --no-cache ca-certificates libstdc++ libgcc curl git \
+  && curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${TARGETARCH} \
+  && chmod +x /usr/local/bin/argocd \
+  && adduser -D -u 10001 appuser
+
+# Copy the compiled binary from the builder stage
+COPY --from=builder /out/argonaut /usr/local/bin/argonaut
+
+# Run as non-root for safety
+USER 10001:10001
+
+# Ensure colors render nicely by default when attached to a TTY
+ENV TERM=xterm-256color
+
+# Default entrypoint (pass CLI flags at runtime)
+ENTRYPOINT ["/usr/local/bin/argonaut"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,23 @@
+FROM alpine:3.20
+
+ARG TARGETARCH
+
+# Minimal runtime deps for the compiled binary and Argo CD CLI
+RUN apk add --no-cache \
+    ca-certificates \
+    libstdc++ \
+    libgcc \
+    curl \
+    git \
+  && curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${TARGETARCH} \
+  && chmod +x /usr/local/bin/argocd \
+  && adduser -D -u 10001 appuser
+
+# Copy the prebuilt binary produced by GoReleaser
+COPY argonaut /usr/local/bin/argonaut
+
+# Non-root execution and proper TTY colors
+USER 10001:10001
+ENV TERM=xterm-256color
+
+ENTRYPOINT ["/usr/local/bin/argonaut"]

--- a/Dockerfile.v2
+++ b/Dockerfile.v2
@@ -1,0 +1,22 @@
+FROM alpine:3.20
+
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
+RUN apk add --no-cache \
+    ca-certificates \
+    libstdc++ \
+    libgcc \
+    curl \
+    git \
+  && curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-${TARGETARCH} \
+  && chmod +x /usr/local/bin/argocd \
+  && adduser -D -u 10001 appuser
+
+# GoReleaser dockers_v2 places binaries under $TARGETPLATFORM/
+COPY ${TARGETPLATFORM}/argonaut /usr/local/bin/argonaut
+
+USER 10001:10001
+ENV TERM=xterm-256color
+
+ENTRYPOINT ["/usr/local/bin/argonaut"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ curl -sSL https://raw.githubusercontent.com/darksworm/argonaut/main/install.sh |
 </details>
 
 <details>
+  <summary><strong>Docker (Linux/macOS)</strong></summary>
+
+Pull and run the prebuilt image from GHCR:
+
+```bash
+docker run --rm -it ghcr.io/darksworm/argonaut:latest
+```
+
+Use your existing Argo CD credentials by mounting the config directory:
+
+```bash
+docker run --rm -it -v ~/.config/argocd:/home/appuser/.config/argocd ghcr.io/darksworm/argonaut:latest
+```
+
+Build locally instead of pulling:
+
+```bash
+bun run docker:build
+bun run docker:run
+```
+
+</details>
+
+<details>
   <summary><strong>npm (Linux/macOS)</strong></summary>
 
 ```bash
@@ -120,3 +144,31 @@ argonaut
 
 ### **Rollback**  
 <img src="assets/argonaut_rollback.png" alt="Rollback flow"/>
+
+## Docker
+- Prebuilt images are published for releases to `ghcr.io/darksworm/argonaut`.
+- Local builds work cross-platform via a multi-stage Dockerfile.
+
+Pull and run:
+
+```bash
+docker run --rm -it ghcr.io/darksworm/argonaut:latest
+```
+
+Build locally and run:
+
+```bash
+# Build (uses buildx automatically if enabled)
+bun run docker:build
+
+# Run (pass CLI flags after image name)
+bun run docker:run
+```
+
+Multi-arch build with buildx (optional):
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t ghcr.io/darksworm/argonaut:dev .
+```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "logs": "bun tools/logs.ts --session=latest",
     "build:node": "bun run generate:licenses && rollup -c rollup.config.js --configPlugin typescript2",
     "build:binary": "bun run generate:licenses && bun build --compile --minify --sourcemap src/main.tsx",
+    "docker:build": "docker buildx build -t argonaut:dev .",
+    "docker:run": "docker run --rm -it -e TERM=xterm-256color argonaut:dev",
     "generate:licenses": "mkdir -p dist && bun x generate-license-file --input package.json --output dist/third-party-licenses.txt --overwrite && bun scripts/generate-licenses.cjs",
     "tsx": "tsx src/main.tsx",
     "lint": "biome check",


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile and runtime variants with Argo CD CLI
- document Docker usage and add build/run scripts
- configure GoReleaser for publishing container images
- set up buildx in CI for multi-arch image builds

## Testing
- `bun run lint`
- `bun run generate:licenses`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f652919083258a0f1e1c9f7ddbed