### PR TITLE
Add 's' shortcut to open sync modal in apps view

### DIFF
--- a/src/__tests__/handlers/NavigationInputHandler.test.ts
+++ b/src/__tests__/handlers/NavigationInputHandler.test.ts
@@ -408,6 +408,72 @@ describe("NavigationInputHandler", () => {
       expect(mockExecuteCommand).not.toHaveBeenCalled();
     });
 
+    it("should handle 's' key (sync) in apps view", () => {
+      const mockExecuteCommand = mock();
+      const context = createMockContext({
+        state: createMockState({
+          navigation: {
+            view: "apps",
+            selectedIdx: 0,
+            lastGPressed: 0,
+            lastEscPressed: 0,
+          },
+          selections: {
+            scopeClusters: new Set(),
+            scopeNamespaces: new Set(),
+            scopeProjects: new Set(),
+            selectedApps: new Set(["app1", "app2"]), // Multiple apps allowed
+          },
+        }),
+        executeCommand: mockExecuteCommand,
+      });
+
+      const result = handler.handleInput("s", {}, context);
+
+      expect(result).toBe(true);
+      expect(mockExecuteCommand).toHaveBeenCalledWith("sync");
+    });
+
+    it("should not handle 's' key in non-apps views", () => {
+      const mockExecuteCommand = mock();
+      const context = createMockContext({
+        state: createMockState({
+          navigation: {
+            view: "clusters",
+            selectedIdx: 0,
+            lastGPressed: 0,
+            lastEscPressed: 0,
+          },
+        }),
+        executeCommand: mockExecuteCommand,
+      });
+
+      const result = handler.handleInput("s", {}, context);
+
+      expect(result).toBe(false);
+      expect(mockExecuteCommand).not.toHaveBeenCalled();
+    });
+
+    it("should not handle 'S' key (case sensitive)", () => {
+      const mockExecuteCommand = mock();
+      const context = createMockContext({
+        state: createMockState({
+          navigation: {
+            view: "apps",
+            selectedIdx: 0,
+            lastGPressed: 0,
+            lastEscPressed: 0,
+          },
+        }),
+        executeCommand: mockExecuteCommand,
+      });
+
+      const result = handler.handleInput("S", {}, context);
+
+      expect(result).toBe(false);
+      expect(mockExecuteCommand).not.toHaveBeenCalled();
+    });
+
     it("should handle Escape (clear current view selections) - clusters", () => {
       const mockDispatch = mock();
       const context = createMockContext({

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -95,6 +95,15 @@ export class NavigationInputHandler implements InputHandler {
       return true;
     }
 
+    // 's' key to open sync modal - only in apps view
+    if (input === "s") {
+      if (navigation.view !== "apps") {
+        return false;
+      }
+      void context.executeCommand("sync");
+      return true;
+    }
+
     if (key.escape) {
       const now = Date.now();
       // Debounce escape key to prevent rapid firing

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -66,6 +66,9 @@ const Help: React.FC = () => {
           <Text>
             <Text color="cyan">:up</Text> go up level
           </Text>
+          <Text>
+            <Text color="cyan">s</Text> sync modal (apps view)
+          </Text>
         </Box>
       </HelpSection>
 


### PR DESCRIPTION
## Summary
- add `s` key binding in navigation handler to trigger sync modal in apps view
- test `s` shortcut for apps view, non-apps view, and case sensitivity
- document `s` shortcut in in-app help view

## Testing
- `bun test src/__tests__/handlers/NavigationInputHandler.test.ts`
- `CI=1 bun test` *(fails: SyntaxError: Export named 'createContext' not found in module 'react/index.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68b30201699c8325a71b44eb872612f7