### PR TITLE
Run mutation tests nightly instead of on PRs

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,24 +1,9 @@
 name: Mutation Testing
 
 on:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - 'src/**'
-      - 'src/__tests__/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'stryker.*.conf.json'
-      - '.github/workflows/mutation-testing.yml'
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - 'src/**'
-      - 'src/__tests__/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'stryker.*.conf.json'
-      - '.github/workflows/mutation-testing.yml'
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   mutation-test:


### PR DESCRIPTION
## Summary
- schedule mutation tests to run nightly
- run at midnight to avoid unsupported randomized cron syntax

## Testing
- `bun install`
- `bun run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b3144f2d4483259fe79367f121a6e9