### PR TITLE
feat: add command autocomplete

### DIFF
--- a/src/__tests__/commands/ApplicationCommandLogic.test.ts
+++ b/src/__tests__/commands/ApplicationCommandLogic.test.ts
@@ -873,7 +873,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -934,7 +934,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -995,7 +995,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -1067,7 +1067,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -1129,7 +1129,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "backend", // Search for backend
             activeFilter: "frontend", // This should be ignored in search mode
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -1191,7 +1191,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "backend", // This should be ignored in normal mode
             activeFilter: "web", // Filter for web
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -1241,7 +1241,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "production-api", // Lowercase filter should match uppercase app name
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -1279,7 +1279,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -1318,7 +1318,7 @@ describe("Application Commands (:diff, :sync, :rollback, :resources)", () => {
           ui: {
             searchQuery: "",
             activeFilter: "",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },

--- a/src/__tests__/commands/CommandArgumentHandling.test.ts
+++ b/src/__tests__/commands/CommandArgumentHandling.test.ts
@@ -68,17 +68,34 @@ describe("Command Argument Handling", () => {
       });
     });
 
-    test(":app with app argument should select specific app", () => {
+    test(":app with app argument should navigate and focus on that app", () => {
       const context = createMockContext({
-        state: createMockState({ mode: "command" }),
+        state: createMockState({
+          mode: "command",
+          navigation: {
+            view: "clusters",
+            selectedIdx: 0,
+            lastGPressed: 0,
+            lastEscPressed: 0,
+          },
+          apps: createMockApps(),
+        }),
       });
 
       const appCommand = new NavigationCommand("apps", "app", ["apps"]);
-      appCommand.execute(context, "my-application");
+      appCommand.execute(context, "app2");
 
       expect(context.dispatch).toHaveBeenCalledWith({
+        type: "RESET_NAVIGATION",
+        payload: { view: "apps" },
+      });
+      expect(context.dispatch).toHaveBeenCalledWith({
+        type: "SET_SELECTED_IDX",
+        payload: 1,
+      });
+      expect(context.dispatch).toHaveBeenCalledWith({
         type: "SET_SELECTED_APPS",
-        payload: new Set(["my-application"]),
+        payload: new Set(["app2"]),
       });
     });
   });

--- a/src/__tests__/commands/CommandStateIntegration.test.ts
+++ b/src/__tests__/commands/CommandStateIntegration.test.ts
@@ -294,7 +294,7 @@ describe("Command Execution with Different App States", () => {
           ui: {
             searchQuery: "search-term",
             activeFilter: "filter-term",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -330,7 +330,7 @@ describe("Command Execution with Different App States", () => {
           ui: {
             searchQuery: "active-search",
             activeFilter: "active-filter",
-            command: ":some-command",
+            command: "some-command",
             isVersionOutdated: false,
             latestVersion: undefined,
           },

--- a/src/__tests__/commands/EdgeCaseCoverage.test.ts
+++ b/src/__tests__/commands/EdgeCaseCoverage.test.ts
@@ -52,7 +52,7 @@ describe("Edge Case Coverage for Mutation Testing", () => {
           ui: {
             searchQuery: "",
             activeFilter: "healthy",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -84,7 +84,7 @@ describe("Edge Case Coverage for Mutation Testing", () => {
           ui: {
             searchQuery: "app1",
             activeFilter: "different-filter",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -152,7 +152,7 @@ describe("Edge Case Coverage for Mutation Testing", () => {
           ui: {
             searchQuery: "",
             activeFilter: "APP1", // uppercase filter
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -183,7 +183,7 @@ describe("Edge Case Coverage for Mutation Testing", () => {
           ui: {
             searchQuery: "",
             activeFilter: "in-cluster",
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -310,7 +310,7 @@ describe("Edge Case Coverage for Mutation Testing", () => {
           ui: {
             searchQuery: "",
             activeFilter: "", // empty filter
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },
@@ -341,7 +341,7 @@ describe("Edge Case Coverage for Mutation Testing", () => {
           ui: {
             searchQuery: "",
             activeFilter: "false", // string "false" should still filter
-            command: ":",
+            command: "",
             isVersionOutdated: false,
             latestVersion: undefined,
           },

--- a/src/__tests__/commands/NavigationCommands.test.ts
+++ b/src/__tests__/commands/NavigationCommands.test.ts
@@ -770,7 +770,7 @@ describe("ClearAllCommand", () => {
           ui: {
             searchQuery: "test-search",
             activeFilter: "health=Healthy",
-            command: ":test",
+            command: "test",
             isVersionOutdated: false,
             latestVersion: undefined,
           },

--- a/src/__tests__/contexts/AppStateContext.test.ts
+++ b/src/__tests__/contexts/AppStateContext.test.ts
@@ -222,10 +222,10 @@ describe("appStateReducer", () => {
     });
 
     it("should handle command input state", () => {
-      const action: AppAction = { type: "SET_COMMAND", payload: ":sync myapp" };
+      const action: AppAction = { type: "SET_COMMAND", payload: "sync myapp" };
       const newState = appStateReducer(initialState, action);
 
-      expect(newState.ui.command).toBe(":sync myapp");
+      expect(newState.ui.command).toBe("sync myapp");
     });
 
     it("should handle terminal resize events", () => {

--- a/src/__tests__/handlers/InputHandlers.test.ts
+++ b/src/__tests__/handlers/InputHandlers.test.ts
@@ -253,6 +253,50 @@ describe("CommandInputHandler", () => {
         payload: ":",
       });
     });
+
+    it("should prevent deleting the leading colon", () => {
+      const mockDispatch = mock();
+      const context = createMockContext({
+        state: createMockState({
+          mode: "command",
+          ui: {
+            command: ":",
+            searchQuery: "",
+            activeFilter: "",
+            isVersionOutdated: false,
+            latestVersion: undefined,
+          },
+        }),
+        dispatch: mockDispatch,
+      });
+
+      const result = handler.handleInput("", { backspace: true }, context);
+
+      expect(result).toBe(true);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it("should allow deleting characters after the colon", () => {
+      const mockDispatch = mock();
+      const context = createMockContext({
+        state: createMockState({
+          mode: "command",
+          ui: {
+            command: ":a",
+            searchQuery: "",
+            activeFilter: "",
+            isVersionOutdated: false,
+            latestVersion: undefined,
+          },
+        }),
+        dispatch: mockDispatch,
+      });
+
+      const result = handler.handleInput("", { backspace: true }, context);
+
+      expect(result).toBe(false);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
   describe("autocomplete", () => {

--- a/src/__tests__/handlers/InputHandlers.test.ts
+++ b/src/__tests__/handlers/InputHandlers.test.ts
@@ -255,6 +255,118 @@ describe("CommandInputHandler", () => {
     });
   });
 
+  describe("autocomplete", () => {
+    it("should complete cluster names on Tab", () => {
+      const mockDispatch = mock();
+      const context = createMockContext({
+        state: createMockState({
+          mode: "command",
+          ui: {
+            command: ":cluster pro",
+            searchQuery: "",
+            activeFilter: "",
+            isVersionOutdated: false,
+            latestVersion: undefined,
+          },
+          apps: [
+            {
+              name: "a",
+              sync: "Synced",
+              health: "Healthy",
+              clusterLabel: "production",
+              namespace: "default",
+              project: "proj1",
+            },
+          ],
+        }),
+        dispatch: mockDispatch,
+      });
+
+      const result = handler.handleInput("", { tab: true }, context);
+
+      expect(result).toBe(true);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "SET_COMMAND",
+        payload: ":cluster production",
+      });
+    });
+
+    it("should complete namespace names on Tab", () => {
+      const mockDispatch = mock();
+      const context = createMockContext({
+        state: createMockState({
+          mode: "command",
+          ui: {
+            command: ":ns ku",
+            searchQuery: "",
+            activeFilter: "",
+            isVersionOutdated: false,
+            latestVersion: undefined,
+          },
+          apps: [
+            {
+              name: "a",
+              sync: "Synced",
+              health: "Healthy",
+              clusterLabel: "prod",
+              namespace: "kube-system",
+              project: "proj1",
+            },
+            {
+              name: "b",
+              sync: "Synced",
+              health: "Healthy",
+              clusterLabel: "prod",
+              namespace: "default",
+              project: "proj1",
+            },
+          ],
+        }),
+        dispatch: mockDispatch,
+      });
+
+      const result = handler.handleInput("", { tab: true }, context);
+
+      expect(result).toBe(true);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "SET_COMMAND",
+        payload: ":ns kube-system",
+      });
+    });
+
+    it("should swallow Tab when no completion available", () => {
+      const mockDispatch = mock();
+      const context = createMockContext({
+        state: createMockState({
+          mode: "command",
+          ui: {
+            command: ":cluster xyz",
+            searchQuery: "",
+            activeFilter: "",
+            isVersionOutdated: false,
+            latestVersion: undefined,
+          },
+          apps: [
+            {
+              name: "a",
+              sync: "Synced",
+              health: "Healthy",
+              clusterLabel: "production",
+              namespace: "default",
+              project: "proj1",
+            },
+          ],
+        }),
+        dispatch: mockDispatch,
+      });
+
+      const result = handler.handleInput("", { tab: true }, context);
+
+      expect(result).toBe(true);
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+  });
+
   describe("priority", () => {
     it("should have highest priority (30)", () => {
       expect(handler.priority).toBe(30);

--- a/src/__tests__/handlers/InputHandlers.test.ts
+++ b/src/__tests__/handlers/InputHandlers.test.ts
@@ -334,8 +334,7 @@ describe("CommandInputHandler", () => {
         payload: ":cluster production",
       });
       expect(mockDispatch).toHaveBeenCalledWith({
-        type: "SET_COMMAND_CURSOR_OFFSET",
-        payload: 0,
+        type: "BUMP_COMMAND_INPUT_KEY",
       });
     });
 
@@ -381,8 +380,7 @@ describe("CommandInputHandler", () => {
         payload: ":ns kube-system",
       });
       expect(mockDispatch).toHaveBeenCalledWith({
-        type: "SET_COMMAND_CURSOR_OFFSET",
-        payload: 0,
+        type: "BUMP_COMMAND_INPUT_KEY",
       });
     });
 

--- a/src/__tests__/handlers/InputHandlers.test.ts
+++ b/src/__tests__/handlers/InputHandlers.test.ts
@@ -333,6 +333,10 @@ describe("CommandInputHandler", () => {
         type: "SET_COMMAND",
         payload: ":cluster production",
       });
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "SET_COMMAND_CURSOR_OFFSET",
+        payload: 0,
+      });
     });
 
     it("should complete namespace names on Tab", () => {
@@ -375,6 +379,10 @@ describe("CommandInputHandler", () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "SET_COMMAND",
         payload: ":ns kube-system",
+      });
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "SET_COMMAND_CURSOR_OFFSET",
+        payload: 0,
       });
     });
 

--- a/src/__tests__/handlers/InputHandlers.test.ts
+++ b/src/__tests__/handlers/InputHandlers.test.ts
@@ -254,7 +254,7 @@ describe("CommandInputHandler", () => {
       });
     });
 
-    it("should prevent deleting the leading colon", () => {
+    it("should reset cursor when backspacing at the leading colon", () => {
       const mockDispatch = mock();
       const context = createMockContext({
         state: createMockState({
@@ -273,7 +273,9 @@ describe("CommandInputHandler", () => {
       const result = handler.handleInput("", { backspace: true }, context);
 
       expect(result).toBe(true);
-      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "BUMP_COMMAND_INPUT_KEY",
+      });
     });
 
     it("should allow deleting characters after the colon", () => {

--- a/src/__tests__/handlers/InputHandlers.test.ts
+++ b/src/__tests__/handlers/InputHandlers.test.ts
@@ -82,7 +82,7 @@ describe("ModeInputHandler", () => {
       });
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "SET_COMMAND",
-        payload: ":",
+        payload: "",
       });
     });
   });
@@ -250,54 +250,8 @@ describe("CommandInputHandler", () => {
       });
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "SET_COMMAND",
-        payload: ":",
+        payload: "",
       });
-    });
-
-    it("should reset cursor when backspacing at the leading colon", () => {
-      const mockDispatch = mock();
-      const context = createMockContext({
-        state: createMockState({
-          mode: "command",
-          ui: {
-            command: ":",
-            searchQuery: "",
-            activeFilter: "",
-            isVersionOutdated: false,
-            latestVersion: undefined,
-          },
-        }),
-        dispatch: mockDispatch,
-      });
-
-      const result = handler.handleInput("", { backspace: true }, context);
-
-      expect(result).toBe(true);
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: "BUMP_COMMAND_INPUT_KEY",
-      });
-    });
-
-    it("should allow deleting characters after the colon", () => {
-      const mockDispatch = mock();
-      const context = createMockContext({
-        state: createMockState({
-          mode: "command",
-          ui: {
-            command: ":a",
-            searchQuery: "",
-            activeFilter: "",
-            isVersionOutdated: false,
-            latestVersion: undefined,
-          },
-        }),
-        dispatch: mockDispatch,
-      });
-
-      const result = handler.handleInput("", { backspace: true }, context);
-
-      expect(result).toBe(false);
-      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
 
@@ -308,7 +262,7 @@ describe("CommandInputHandler", () => {
         state: createMockState({
           mode: "command",
           ui: {
-            command: ":cluster pro",
+            command: "cluster pro",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -333,7 +287,7 @@ describe("CommandInputHandler", () => {
       expect(result).toBe(true);
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "SET_COMMAND",
-        payload: ":cluster production",
+        payload: "cluster production",
       });
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "BUMP_COMMAND_INPUT_KEY",
@@ -346,7 +300,7 @@ describe("CommandInputHandler", () => {
         state: createMockState({
           mode: "command",
           ui: {
-            command: ":ns ku",
+            command: "ns ku",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -379,7 +333,7 @@ describe("CommandInputHandler", () => {
       expect(result).toBe(true);
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "SET_COMMAND",
-        payload: ":ns kube-system",
+        payload: "ns kube-system",
       });
       expect(mockDispatch).toHaveBeenCalledWith({
         type: "BUMP_COMMAND_INPUT_KEY",
@@ -392,7 +346,7 @@ describe("CommandInputHandler", () => {
         state: createMockState({
           mode: "command",
           ui: {
-            command: ":cluster xyz",
+            command: "cluster xyz",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -64,6 +64,7 @@ export function createMockState(overrides: Partial<AppState> = {}): AppState {
       command: ":",
       isVersionOutdated: false,
       latestVersion: undefined,
+      commandCursorOffset: undefined,
     },
     modals: {
       confirmTarget: null,

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -40,18 +40,10 @@ export function createMockContext(
 }
 
 export function createMockState(overrides: Partial<AppState> = {}): AppState {
-  return {
+  const base: AppState = {
     mode: "normal" as Mode,
-    terminal: {
-      rows: 24,
-      cols: 80,
-    },
-    navigation: {
-      view: "apps" as View,
-      selectedIdx: 0,
-      lastGPressed: 0,
-      lastEscPressed: 0,
-    },
+    terminal: { rows: 24, cols: 80 },
+    navigation: { view: "apps" as View, selectedIdx: 0, lastGPressed: 0, lastEscPressed: 0 },
     selections: {
       scopeClusters: new Set(),
       scopeNamespaces: new Set(),
@@ -64,7 +56,7 @@ export function createMockState(overrides: Partial<AppState> = {}): AppState {
       command: ":",
       isVersionOutdated: false,
       latestVersion: undefined,
-      commandCursorOffset: undefined,
+      commandInputKey: 0,
     },
     modals: {
       confirmTarget: null,
@@ -74,15 +66,21 @@ export function createMockState(overrides: Partial<AppState> = {}): AppState {
       syncViewApp: null,
     },
     server: {
-      config: {
-        baseUrl: "https://test-server.com",
-      },
+      config: { baseUrl: "https://test-server.com" },
       token: "test-token",
     },
     apps: [],
     apiVersion: "v2.9.0",
     loadingAbortController: null,
+  };
+
+  return {
+    ...base,
     ...overrides,
+    navigation: { ...base.navigation, ...(overrides.navigation ?? {}) },
+    selections: { ...base.selections, ...(overrides.selections ?? {}) },
+    ui: { ...base.ui, ...(overrides.ui ?? {}) },
+    modals: { ...base.modals, ...(overrides.modals ?? {}) },
   };
 }
 

--- a/src/__tests__/test-utils.ts
+++ b/src/__tests__/test-utils.ts
@@ -53,7 +53,7 @@ export function createMockState(overrides: Partial<AppState> = {}): AppState {
     ui: {
       searchQuery: "",
       activeFilter: "",
-      command: ":",
+      command: "",
       isVersionOutdated: false,
       latestVersion: undefined,
       commandInputKey: 0,

--- a/src/__tests__/ui/command-search-bars.ui.test.tsx
+++ b/src/__tests__/ui/command-search-bars.ui.test.tsx
@@ -37,7 +37,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandModeState = {
           mode: "command" as const,
           ui: {
-            command: ":sync",
+            command: "sync",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -64,7 +64,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const normalModeState = {
           mode: "normal" as const,
           ui: {
-            command: ":sync",
+            command: "sync",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -90,7 +90,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const searchModeState = {
           mode: "search" as const,
           ui: {
-            command: ":sync",
+            command: "sync",
             searchQuery: "test",
             activeFilter: "",
             isVersionOutdated: false,
@@ -116,7 +116,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":sync frontend-app",
+            command: "sync frontend-app",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -143,7 +143,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const emptyCommandState = {
           mode: "command" as const,
           ui: {
-            command: ":",
+            command: "",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -163,6 +163,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
 
         expect(frame).toContain("CMD");
         expect(frame).toContain("Enter to run, Esc to cancel");
+        expect(frame).toContain(":");
       });
     });
 
@@ -176,7 +177,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":sync frontend-app",
+            command: "sync frontend-app",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -216,7 +217,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":",
+            command: "",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -251,7 +252,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":rollback myapp v1.2.3 --force",
+            command: "rollback myapp v1.2.3 --force",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -287,7 +288,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":cluster pro",
+            command: "cluster pro",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -326,7 +327,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":cluster pro",
+            command: "cluster pro",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -367,7 +368,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":cluster production",
+            command: "cluster production",
             commandInputKey: 1,
             searchQuery: "",
             activeFilter: "",
@@ -397,7 +398,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":help",
+            command: "help",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -439,7 +440,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "frontend",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -469,7 +470,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "frontend",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -497,7 +498,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "frontend-web",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -525,7 +526,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -553,7 +554,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "api",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -581,7 +582,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "prod",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -609,7 +610,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "frontend",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -639,7 +640,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "production",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -668,7 +669,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "frontend",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -699,7 +700,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "web-platform",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -732,7 +733,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         const commandState = {
           mode: "command" as const,
           ui: {
-            command: ":",
+            command: "",
             searchQuery: "",
             activeFilter: "",
             isVersionOutdated: false,
@@ -769,7 +770,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           },
           ui: {
             searchQuery: "",
-            command: ":",
+            command: "",
             activeFilter: "",
             isVersionOutdated: false,
           },
@@ -793,7 +794,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
       const commandState = {
         mode: "command" as const,
         ui: {
-          command: ":help",
+          command: "help",
           searchQuery: "",
           activeFilter: "",
           isVersionOutdated: false,
@@ -819,7 +820,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         // Missing navigation property
         ui: {
           searchQuery: "test",
-          command: ":",
+          command: "",
           activeFilter: "",
           isVersionOutdated: false,
         },
@@ -874,7 +875,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
         },
         ui: {
           searchQuery: longQuery,
-          command: ":",
+          command: "",
           activeFilter: "",
           isVersionOutdated: false,
         },

--- a/src/__tests__/ui/command-search-bars.ui.test.tsx
+++ b/src/__tests__/ui/command-search-bars.ui.test.tsx
@@ -362,6 +362,7 @@ describe("CommandBar and SearchBar UI Tests", () => {
           "production",
         );
       });
+
     });
 
     describe("UI Styling and Layout", () => {

--- a/src/__tests__/ui/command-search-bars.ui.test.tsx
+++ b/src/__tests__/ui/command-search-bars.ui.test.tsx
@@ -363,6 +363,33 @@ describe("CommandBar and SearchBar UI Tests", () => {
         );
       });
 
+      it("allows deleting autocompleted text", () => {
+        const commandState = {
+          mode: "command" as const,
+          ui: {
+            command: ":cluster production",
+            commandInputKey: 1,
+            searchQuery: "",
+            activeFilter: "",
+            isVersionOutdated: false,
+          },
+        };
+
+        const { stdin, lastFrame } = render(
+          <AppStateProvider initialState={commandState}>
+            <CommandBar
+              commandRegistry={mockCommandRegistry}
+              onExecuteCommand={mockOnExecuteCommand}
+            />
+          </AppStateProvider>,
+        );
+
+        stdin.write("\u0008");
+
+        const frame = stripAnsi(lastFrame());
+        expect(frame).toContain(":cluster productio");
+      });
+
     });
 
     describe("UI Styling and Layout", () => {

--- a/src/__tests__/ui/confirm-sync-modal.ui.test.tsx
+++ b/src/__tests__/ui/confirm-sync-modal.ui.test.tsx
@@ -53,7 +53,7 @@ describe("ConfirmSyncModal UI Tests", () => {
     ui: {
       searchQuery: "",
       activeFilter: "",
-      command: ":",
+      command: "",
       isVersionOutdated: false,
     },
     modals: {

--- a/src/__tests__/ui/list-view-success.ui.test.tsx
+++ b/src/__tests__/ui/list-view-success.ui.test.tsx
@@ -63,7 +63,7 @@ describe("ListView Success UI Tests", () => {
     ui: {
       searchQuery: "",
       activeFilter: "",
-      command: ":",
+      command: "",
       isVersionOutdated: false,
     },
   };

--- a/src/__tests__/ui/loading-view.ui.test.tsx
+++ b/src/__tests__/ui/loading-view.ui.test.tsx
@@ -23,7 +23,7 @@ describe("LoadingView UI Tests", () => {
     ui: {
       searchQuery: "",
       activeFilter: "",
-      command: ":",
+      command: "",
       isVersionOutdated: false,
     },
     modals: {

--- a/src/commands/autocomplete.ts
+++ b/src/commands/autocomplete.ts
@@ -1,0 +1,75 @@
+import type { AppState } from "../contexts/AppStateContext";
+import { uniqueSorted } from "../utils";
+
+// Map command aliases to their corresponding data set keys
+const aliasMap: Record<string, keyof ReturnType<typeof buildLists>> = {
+  cluster: "clusters",
+  clusters: "clusters",
+  cls: "clusters",
+  namespace: "namespaces",
+  namespaces: "namespaces",
+  ns: "namespaces",
+  project: "projects",
+  projects: "projects",
+  proj: "projects",
+  app: "apps",
+  apps: "apps",
+};
+
+function buildLists(state: AppState) {
+  const { apps, selections } = state;
+  const { scopeClusters, scopeNamespaces, scopeProjects } = selections;
+
+  const clusters = uniqueSorted(
+    apps.map((a) => a.clusterLabel || "").filter(Boolean),
+  );
+
+  const appsByCluster = scopeClusters.size
+    ? apps.filter((a) => scopeClusters.has(a.clusterLabel || ""))
+    : apps;
+
+  const namespaces = uniqueSorted(
+    appsByCluster.map((a) => a.namespace || "").filter(Boolean),
+  );
+
+  const appsByNs = scopeNamespaces.size
+    ? appsByCluster.filter((a) => scopeNamespaces.has(a.namespace || ""))
+    : appsByCluster;
+
+  const projects = uniqueSorted(
+    appsByNs.map((a) => a.project || "").filter(Boolean),
+  );
+
+  const appsByProj = scopeProjects.size
+    ? appsByNs.filter((a) => scopeProjects.has(a.project || ""))
+    : appsByNs;
+
+  const appNames = uniqueSorted(appsByProj.map((a) => a.name));
+
+  return { clusters, namespaces, projects, apps: appNames };
+}
+
+export function getCommandAutocomplete(
+  line: string,
+  state: AppState,
+): { completed: string; suggestion: string } | null {
+  const firstSpace = line.indexOf(" ");
+  if (!line.startsWith(":") || firstSpace === -1) return null;
+
+  const cmdRaw = line.slice(1, firstSpace);
+  const listKey = aliasMap[cmdRaw.toLowerCase()];
+  if (!listKey) return null;
+
+  const arg = line.slice(firstSpace + 1);
+  const lists = buildLists(state);
+  const options = lists[listKey];
+  if (!options.length) return null;
+
+  const match = options.find((o) =>
+    o.toLowerCase().startsWith(arg.toLowerCase()),
+  );
+  if (!match || match.toLowerCase() === arg.toLowerCase()) return null;
+
+  const prefix = line.slice(0, firstSpace + 1);
+  return { completed: prefix + match, suggestion: match.slice(arg.length) };
+}

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -352,7 +352,7 @@ export class CommandInputHandler implements InputHandler {
       const auto = getCommandAutocomplete(state.ui.command, state);
       if (auto) {
         dispatch({ type: "SET_COMMAND", payload: auto.completed });
-        dispatch({ type: "SET_COMMAND_CURSOR_OFFSET", payload: 0 });
+        dispatch({ type: "BUMP_COMMAND_INPUT_KEY" });
       }
       return true;
     }

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -1,5 +1,6 @@
 import { UpCommand } from "../navigation";
 import type { CommandContext, InputHandler } from "../types";
+import { getCommandAutocomplete } from "../autocomplete";
 
 export class NavigationInputHandler implements InputHandler {
   priority = 10; // High priority for navigation
@@ -335,11 +336,19 @@ export class CommandInputHandler implements InputHandler {
   }
 
   handleInput(_input: string, key: any, context: CommandContext): boolean {
-    const { dispatch } = context;
+    const { dispatch, state } = context;
 
     if (key.escape) {
       dispatch({ type: "SET_MODE", payload: "normal" });
       dispatch({ type: "SET_COMMAND", payload: ":" });
+      return true;
+    }
+
+    if (key.tab) {
+      const auto = getCommandAutocomplete(state.ui.command, state);
+      if (auto) {
+        dispatch({ type: "SET_COMMAND", payload: auto.completed });
+      }
       return true;
     }
 

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -272,7 +272,7 @@ export class ModeInputHandler implements InputHandler {
 
     if (input === ":") {
       dispatch({ type: "SET_MODE", payload: "command" });
-      dispatch({ type: "SET_COMMAND", payload: ":" });
+      dispatch({ type: "SET_COMMAND", payload: "" });
       return true;
     }
 
@@ -340,19 +340,14 @@ export class CommandInputHandler implements InputHandler {
 
     if (key.escape) {
       dispatch({ type: "SET_MODE", payload: "normal" });
-      dispatch({ type: "SET_COMMAND", payload: ":" });
-      return true;
-    }
-
-    if (key.backspace && state.ui.command === ":") {
-      dispatch({ type: "BUMP_COMMAND_INPUT_KEY" });
+      dispatch({ type: "SET_COMMAND", payload: "" });
       return true;
     }
 
     if (key.tab) {
-      const auto = getCommandAutocomplete(state.ui.command, state);
+      const auto = getCommandAutocomplete(`:${state.ui.command}`, state);
       if (auto) {
-        dispatch({ type: "SET_COMMAND", payload: auto.completed });
+        dispatch({ type: "SET_COMMAND", payload: auto.completed.slice(1) });
         dispatch({ type: "BUMP_COMMAND_INPUT_KEY" });
       }
       return true;

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -344,6 +344,10 @@ export class CommandInputHandler implements InputHandler {
       return true;
     }
 
+    if (key.backspace && state.ui.command === ":") {
+      return true;
+    }
+
     if (key.tab) {
       const auto = getCommandAutocomplete(state.ui.command, state);
       if (auto) {

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -345,6 +345,7 @@ export class CommandInputHandler implements InputHandler {
     }
 
     if (key.backspace && state.ui.command === ":") {
+      dispatch({ type: "BUMP_COMMAND_INPUT_KEY" });
       return true;
     }
 

--- a/src/commands/handlers/keyboard.ts
+++ b/src/commands/handlers/keyboard.ts
@@ -352,6 +352,7 @@ export class CommandInputHandler implements InputHandler {
       const auto = getCommandAutocomplete(state.ui.command, state);
       if (auto) {
         dispatch({ type: "SET_COMMAND", payload: auto.completed });
+        dispatch({ type: "SET_COMMAND_CURSOR_OFFSET", payload: 0 });
       }
       return true;
     }

--- a/src/commands/navigation.ts
+++ b/src/commands/navigation.ts
@@ -42,6 +42,10 @@ export class NavigationCommand implements Command {
           break;
         case "apps":
           dispatch({ type: "SET_SELECTED_APPS", payload: new Set([arg]) });
+          const idx = context.state.apps.findIndex((a) => a.name === arg);
+          if (idx !== -1) {
+            dispatch({ type: "SET_SELECTED_IDX", payload: idx });
+          }
           // Apps is the deepest level, no further navigation
           break;
       }

--- a/src/components/views/CommandBar.tsx
+++ b/src/components/views/CommandBar.tsx
@@ -3,6 +3,7 @@ import TextInput from "ink-text-input";
 import type React from "react";
 import type { CommandRegistry } from "../../commands";
 import { useAppState } from "../../contexts/AppStateContext";
+import { getCommandAutocomplete } from "../../commands/autocomplete";
 
 interface CommandBarProps {
   commandRegistry: CommandRegistry;
@@ -20,9 +21,12 @@ export const CommandBar: React.FC<CommandBarProps> = ({
   }
 
   const handleSubmit = (val: string) => {
+    const auto = getCommandAutocomplete(val, state);
+    const completed = auto ? auto.completed : val;
+
     dispatch({ type: "SET_MODE", payload: "normal" });
 
-    const { command, args } = commandRegistry.parseCommandLine(val);
+    const { command, args } = commandRegistry.parseCommandLine(completed);
     if (command) {
       onExecuteCommand(command, ...args);
     }
@@ -41,6 +45,10 @@ export const CommandBar: React.FC<CommandBarProps> = ({
         onChange={(value) => dispatch({ type: "SET_COMMAND", payload: value })}
         onSubmit={handleSubmit}
       />
+      {(() => {
+        const auto = getCommandAutocomplete(state.ui.command, state);
+        return auto ? <Text dimColor>{auto.suggestion}</Text> : null;
+      })()}
       <Box width={2} />
       <Text dimColor>(Enter to run, Esc to cancel)</Text>
     </Box>

--- a/src/components/views/CommandBar.tsx
+++ b/src/components/views/CommandBar.tsx
@@ -42,8 +42,14 @@ export const CommandBar: React.FC<CommandBarProps> = ({
       <Box width={1} />
       <TextInput
         value={state.ui.command}
-        onChange={(value) => dispatch({ type: "SET_COMMAND", payload: value })}
+        onChange={(value) =>
+          dispatch({
+            type: "SET_COMMAND",
+            payload: value.startsWith(":") ? value : `:${value}`,
+          })
+        }
         onSubmit={handleSubmit}
+        showCursor={false}
       />
       {(() => {
         const auto = getCommandAutocomplete(state.ui.command, state);

--- a/src/components/views/CommandBar.tsx
+++ b/src/components/views/CommandBar.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import TextInput from "ink-text-input";
-import type React from "react";
+import React, { useEffect } from "react";
 import type { CommandRegistry } from "../../commands";
 import { useAppState } from "../../contexts/AppStateContext";
 import { getCommandAutocomplete } from "../../commands/autocomplete";
@@ -15,6 +15,12 @@ export const CommandBar: React.FC<CommandBarProps> = ({
   onExecuteCommand,
 }) => {
   const { state, dispatch } = useAppState();
+
+  useEffect(() => {
+    if (state.ui.commandCursorOffset !== undefined) {
+      dispatch({ type: "SET_COMMAND_CURSOR_OFFSET", payload: undefined });
+    }
+  }, [state.ui.commandCursorOffset, dispatch]);
 
   if (state.mode !== "command") {
     return null;
@@ -50,6 +56,7 @@ export const CommandBar: React.FC<CommandBarProps> = ({
         }
         onSubmit={handleSubmit}
         showCursor={false}
+        cursorOffset={state.ui.commandCursorOffset}
       />
       {(() => {
         const auto = getCommandAutocomplete(state.ui.command, state);

--- a/src/components/views/CommandBar.tsx
+++ b/src/components/views/CommandBar.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import TextInput from "ink-text-input";
-import React, { useEffect } from "react";
+import React from "react";
 import type { CommandRegistry } from "../../commands";
 import { useAppState } from "../../contexts/AppStateContext";
 import { getCommandAutocomplete } from "../../commands/autocomplete";
@@ -15,12 +15,6 @@ export const CommandBar: React.FC<CommandBarProps> = ({
   onExecuteCommand,
 }) => {
   const { state, dispatch } = useAppState();
-
-  useEffect(() => {
-    if (state.ui.commandCursorOffset !== undefined) {
-      dispatch({ type: "SET_COMMAND_CURSOR_OFFSET", payload: undefined });
-    }
-  }, [state.ui.commandCursorOffset, dispatch]);
 
   if (state.mode !== "command") {
     return null;
@@ -47,6 +41,7 @@ export const CommandBar: React.FC<CommandBarProps> = ({
       </Text>
       <Box width={1} />
       <TextInput
+        key={state.ui.commandInputKey}
         value={state.ui.command}
         onChange={(value) =>
           dispatch({
@@ -56,7 +51,6 @@ export const CommandBar: React.FC<CommandBarProps> = ({
         }
         onSubmit={handleSubmit}
         showCursor={false}
-        cursorOffset={state.ui.commandCursorOffset}
       />
       {(() => {
         const auto = getCommandAutocomplete(state.ui.command, state);

--- a/src/components/views/CommandBar.tsx
+++ b/src/components/views/CommandBar.tsx
@@ -21,8 +21,9 @@ export const CommandBar: React.FC<CommandBarProps> = ({
   }
 
   const handleSubmit = (val: string) => {
-    const auto = getCommandAutocomplete(val, state);
-    const completed = auto ? auto.completed : val;
+    const line = `:${val}`;
+    const auto = getCommandAutocomplete(line, state);
+    const completed = auto ? auto.completed : line;
 
     dispatch({ type: "SET_MODE", payload: "normal" });
 
@@ -31,7 +32,7 @@ export const CommandBar: React.FC<CommandBarProps> = ({
       onExecuteCommand(command, ...args);
     }
 
-    dispatch({ type: "SET_COMMAND", payload: ":" });
+    dispatch({ type: "SET_COMMAND", payload: "" });
   };
 
   return (
@@ -40,20 +41,21 @@ export const CommandBar: React.FC<CommandBarProps> = ({
         CMD
       </Text>
       <Box width={1} />
+      <Text color="white">:</Text>
       <TextInput
         key={state.ui.commandInputKey}
         value={state.ui.command}
         onChange={(value) =>
           dispatch({
             type: "SET_COMMAND",
-            payload: value.startsWith(":") ? value : `:${value}`,
+            payload: value,
           })
         }
         onSubmit={handleSubmit}
         showCursor={false}
       />
       {(() => {
-        const auto = getCommandAutocomplete(state.ui.command, state);
+        const auto = getCommandAutocomplete(`:${state.ui.command}`, state);
         return auto ? <Text dimColor>{auto.suggestion}</Text> : null;
       })()}
       <Box width={2} />

--- a/src/contexts/AppStateContext.tsx
+++ b/src/contexts/AppStateContext.tsx
@@ -33,6 +33,7 @@ export interface UIState {
   command: string;
   isVersionOutdated: boolean;
   latestVersion?: string;
+  commandCursorOffset?: number;
 }
 
 export interface ModalState {
@@ -73,6 +74,7 @@ export type AppAction =
   | { type: "SET_SEARCH_QUERY"; payload: string }
   | { type: "SET_ACTIVE_FILTER"; payload: string }
   | { type: "SET_COMMAND"; payload: string }
+  | { type: "SET_COMMAND_CURSOR_OFFSET"; payload: number | undefined }
   | { type: "SET_SCOPE_CLUSTERS"; payload: Set<string> }
   | { type: "SET_SCOPE_NAMESPACES"; payload: Set<string> }
   | { type: "SET_SCOPE_PROJECTS"; payload: Set<string> }
@@ -117,6 +119,7 @@ export const initialState: AppState = {
     command: ":",
     isVersionOutdated: false,
     latestVersion: undefined,
+    commandCursorOffset: undefined,
   },
   modals: {
     confirmTarget: null,
@@ -180,6 +183,12 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
       return {
         ...state,
         ui: { ...state.ui, command: action.payload },
+      };
+
+    case "SET_COMMAND_CURSOR_OFFSET":
+      return {
+        ...state,
+        ui: { ...state.ui, commandCursorOffset: action.payload },
       };
 
     case "SET_SCOPE_CLUSTERS":

--- a/src/contexts/AppStateContext.tsx
+++ b/src/contexts/AppStateContext.tsx
@@ -33,7 +33,7 @@ export interface UIState {
   command: string;
   isVersionOutdated: boolean;
   latestVersion?: string;
-  commandCursorOffset?: number;
+  commandInputKey: number;
 }
 
 export interface ModalState {
@@ -74,7 +74,7 @@ export type AppAction =
   | { type: "SET_SEARCH_QUERY"; payload: string }
   | { type: "SET_ACTIVE_FILTER"; payload: string }
   | { type: "SET_COMMAND"; payload: string }
-  | { type: "SET_COMMAND_CURSOR_OFFSET"; payload: number | undefined }
+  | { type: "BUMP_COMMAND_INPUT_KEY" }
   | { type: "SET_SCOPE_CLUSTERS"; payload: Set<string> }
   | { type: "SET_SCOPE_NAMESPACES"; payload: Set<string> }
   | { type: "SET_SCOPE_PROJECTS"; payload: Set<string> }
@@ -119,7 +119,7 @@ export const initialState: AppState = {
     command: ":",
     isVersionOutdated: false,
     latestVersion: undefined,
-    commandCursorOffset: undefined,
+    commandInputKey: 0,
   },
   modals: {
     confirmTarget: null,
@@ -185,10 +185,10 @@ export function appStateReducer(state: AppState, action: AppAction): AppState {
         ui: { ...state.ui, command: action.payload },
       };
 
-    case "SET_COMMAND_CURSOR_OFFSET":
+    case "BUMP_COMMAND_INPUT_KEY":
       return {
         ...state,
-        ui: { ...state.ui, commandCursorOffset: action.payload },
+        ui: { ...state.ui, commandInputKey: state.ui.commandInputKey + 1 },
       };
 
     case "SET_SCOPE_CLUSTERS":
@@ -353,7 +353,20 @@ export const AppStateProvider: React.FC<AppStateProviderProps> = ({
   initialState: providedInitialState,
 }) => {
   const finalInitialState = providedInitialState
-    ? { ...initialState, ...providedInitialState }
+    ? {
+        ...initialState,
+        ...providedInitialState,
+        ui: { ...initialState.ui, ...(providedInitialState.ui ?? {}) },
+        navigation: {
+          ...initialState.navigation,
+          ...(providedInitialState.navigation ?? {}),
+        },
+        selections: {
+          ...initialState.selections,
+          ...(providedInitialState.selections ?? {}),
+        },
+        modals: { ...initialState.modals, ...(providedInitialState.modals ?? {}) },
+      }
     : initialState;
 
   const [state, dispatch] = useReducer(appStateReducer, finalInitialState);

--- a/src/contexts/AppStateContext.tsx
+++ b/src/contexts/AppStateContext.tsx
@@ -116,7 +116,7 @@ export const initialState: AppState = {
   ui: {
     searchQuery: "",
     activeFilter: "",
-    command: ":",
+    command: "",
     isVersionOutdated: false,
     latestVersion: undefined,
     commandInputKey: 0,


### PR DESCRIPTION
## Summary
- add autocomplete engine for cluster, namespace, project and app commands
- complete suggestion with Tab and show remainder in command bar
- execute suggestions on submit and cover behavior with tests

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b31b66c3f8832584e6369461864aff