### PR TITLE
ci: upload junit test results to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,13 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run generate:licenses
       - run: bun run test:ci
+      - name: Upload test results to Codecov
+        # Send JUnit results for Test Analytics
+        if: ${{ always() && !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage/
 *.lcov
 coverage-final.json
 clover.xml
+junit.xml
 
 # Mutation testing reports
 reports/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage --coverage-reporter=lcov",
-    "test:ci": "bun test --coverage --coverage-reporter=lcov",
+    "test:ci": "bun test --coverage --coverage-reporter=lcov --reporter=junit --reporter-outfile=junit.xml",
     "test:mutation": "bunx stryker run",
     "test:mutation:ci": "bunx stryker run stryker.ci.conf.json",
     "test:mutation:navigation": "bunx stryker run --mutate=\"src/commands/navigation.ts\" --commandRunner.command=\"bun test src/__tests__/commands/NavigationViewCommands.test.ts src/__tests__/commands/ClearCommands.test.ts src/__tests__/commands/CommandStateIntegration.test.ts\"",


### PR DESCRIPTION
## Summary
- upload JUnit results to Codecov before coverage upload
- ignore generated `junit.xml` files
- produce JUnit output in `test:ci` script
- document the test-results upload step

## Testing
- `bun install`
- `bun run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b32f468edc8325a5da955746a8e48c