### PR TITLE
ci: upload junit test results to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,14 @@ jobs:
           bun-version-file: .bun-version
       - run: bun install --frozen-lockfile
       - run: bun run generate:licenses
-      - run: bun run test:ci
-      - run: test -f junit.xml || echo '<testsuites></testsuites>' > junit.xml
+      - run: bun run test:ci --reporter-outfile=junit.xml
       - name: Upload test results to Codecov
         # Send JUnit results for Test Analytics
-        if: ${{ always() && !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: junit.xml
       - name: Upload coverage reports to Codecov
-        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- upload JUnit results to Codecov before coverage upload
- ignore generated `junit.xml` files
- produce JUnit output in `test:ci` script and workflow
- document the test-results upload step
- remove fallback empty JUnit file creation

## Testing
- `bun run lint` *(fails: biome import/format issues)*
- `bun test --reporter=junit --reporter-outfile=junit.xml src/__tests__/cli.version.test.ts`
- `ls -l junit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b3be5e98ac832596c9deedc33969d5