### PR TITLE
test: ensure http clients are cleared after tests

### DIFF
--- a/src/__tests__/services/http-client.test.ts
+++ b/src/__tests__/services/http-client.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { getHttpClient, httpClientManager } from "../../services/http-client";
 import type { ServerConfig } from "../../types/server";
+
+afterEach(() => {
+  httpClientManager.clearClients();
+});
 
 describe("httpClientManager", () => {
   const mockServerConfig: ServerConfig = {


### PR DESCRIPTION
## Summary
- clear cached HTTP clients after each test run

## Testing
- `bun test src/__tests__/services/http-client.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b49ae0b1a88325af41bb426b39112f