### PR TITLE
feat: support :q! to quit

### DIFF
--- a/src/__tests__/commands/CommandIntegration.test.ts
+++ b/src/__tests__/commands/CommandIntegration.test.ts
@@ -86,7 +86,7 @@ class MockSyncCommand implements Command {
 }
 
 class MockQuitCommand implements Command {
-  aliases = ["quit", "exit"];
+  aliases = ["quit", "exit", "q!"];
   description = "Exit the application";
 
   execute(context: CommandContext): void {
@@ -258,7 +258,7 @@ describe("Command Integration Tests", () => {
 
     it("should handle multiple aliases for same command", async () => {
       // Act & Assert
-      const aliases = ["quit", "exit"];
+      const aliases = ["quit", "exit", "q!"];
       for (const alias of aliases) {
         mockCleanupAndExit.mockClear();
         const result = await registry.execute(alias, context);

--- a/src/__tests__/commands/SystemCommands.test.ts
+++ b/src/__tests__/commands/SystemCommands.test.ts
@@ -6,7 +6,7 @@ import { createMockContext, createMockState } from "../test-utils";
 
 // Test implementations of system command classes without external dependencies
 class TestQuitCommand implements Command {
-  aliases = ["quit", "exit"];
+  aliases = ["quit", "exit", "q!"];
   description = "Exit the application";
 
   execute(context: CommandContext): void {
@@ -69,7 +69,7 @@ describe("QuitCommand", () => {
 
   describe("properties", () => {
     it("should have correct aliases", () => {
-      expect(quitCommand.aliases).toEqual(["quit", "exit"]);
+      expect(quitCommand.aliases).toEqual(["quit", "exit", "q!"]);
     });
 
     it("should have correct description", () => {

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -2,7 +2,7 @@ import { rulerLineMode } from "../components/OfficeSupplyManager";
 import type { Command, CommandContext } from "./types";
 
 export class QuitCommand implements Command {
-  aliases = ["quit", "exit"];
+  aliases = ["quit", "exit", "q!"];
   description = "Exit the application";
 
   execute(context: CommandContext): void {


### PR DESCRIPTION
## Summary
- allow `:q!` command to quit the TUI
- cover new alias in command tests
- omit `:q!` from help view

## Testing
- `bun run lint src/components/Help.tsx`
- `bun test src/__tests__/commands/SystemCommands.test.ts src/__tests__/commands/CommandIntegration.test.ts`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ede9061c83259962150cda1be97d