### PR TITLE
fix: expand rollback view

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -68,12 +68,13 @@ const AppContent: React.FC = () => {
         />
       );
 
-    default:
-      // Handle modal states directly in the main layout
-      if (state.mode === "help") {
-        return <HelpModal />;
-      }
+    case "help":
+      return <HelpModal />;
 
+    case "rollback":
+      return <RollbackModal />;
+
+    default:
       return (
         <MainLayout
           visibleItems={visibleItems}
@@ -82,11 +83,7 @@ const AppContent: React.FC = () => {
           onExecuteCommand={executeCommand}
           status={status}
           modal={
-            state.mode === "confirm-sync" ? (
-              <ConfirmSyncModal />
-            ) : state.mode === "rollback" ? (
-              <RollbackModal />
-            ) : null
+            state.mode === "confirm-sync" ? <ConfirmSyncModal /> : null
           }
         />
       );

--- a/src/components/modals/RollbackModal.tsx
+++ b/src/components/modals/RollbackModal.tsx
@@ -33,7 +33,12 @@ export const RollbackModal: React.FC = () => {
   };
 
   return (
-    <Box flexDirection="column" paddingX={1} height={terminal.rows - 1}>
+    <Box
+      flexDirection="column"
+      paddingX={1}
+      height={terminal.rows - 1}
+      flexGrow={1}
+    >
       <ArgoNautBanner
         server={server ? hostFromUrl(server.config.baseUrl) : null}
         clusterScope={fmtScope(scopeClusters)}


### PR DESCRIPTION
## Summary
- render rollback view as standalone screen instead of modal in MainLayout
- expand rollback modal container to fill available space

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68c1889e51e88325a894c74a95bcd79d