### PR TITLE
fix: sync command now targets correctly selected app

### DIFF
--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -438,8 +438,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 		m.state.UI.Command = ""
 		m.inputComponents.ClearCommandInput()
 
-		// Reset navigation basics
-		m.state.Navigation.SelectedIdx = 0
+		// Clear UI state for all commands
 		m.state.UI.ActiveFilter = ""
 		m.state.UI.SearchQuery = ""
 
@@ -698,6 +697,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			m.state.UI.TreeAppName = nil
 			m.treeLoading = false
 			m.state.Selections.SelectedApps = model.NewStringSet()
+			m.state.Navigation.SelectedIdx = 0  // Reset navigation for view change
 			m = m.safeChangeView(model.ViewClusters)
 			if arg != "" {
 				// Validate cluster exists
@@ -730,6 +730,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 		case "namespace", "namespaces", "ns":
 			m.state.UI.TreeAppName = nil
 			m.treeLoading = false
+			m.state.Navigation.SelectedIdx = 0  // Reset navigation for view change
 			m = m.safeChangeView(model.ViewNamespaces)
 			m.state.Selections.SelectedApps = model.NewStringSet()
 			if arg != "" {
@@ -760,6 +761,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 		case "project", "projects", "proj":
 			m.state.UI.TreeAppName = nil
 			m.treeLoading = false
+			m.state.Navigation.SelectedIdx = 0  // Reset navigation for view change
 			m = m.safeChangeView(model.ViewProjects)
 			m.state.Selections.SelectedApps = model.NewStringSet()
 			if arg != "" {
@@ -786,6 +788,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			}
 			return m, nil
 		case "app", "apps":
+			m.state.Navigation.SelectedIdx = 0  // Reset navigation for view change
 			m = m.safeChangeView(model.ViewApps)
 			if arg != "" {
 				// Select the app and move cursor to it if found

--- a/e2e/sync_test.go
+++ b/e2e/sync_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -157,5 +158,87 @@ func TestSyncMultipleApps(t *testing.T) {
 	}
 	if !names["demo"] || !names["demo2"] {
 		t.Fatalf("expected sync calls for demo and demo2, got: %+v", names)
+	}
+}
+
+// Test for the bug where selecting the last app and typing :sync shows a popup asking to sync the first app
+func TestSyncLastAppShowsCorrectConfirmation(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, rec, err := MockArgoServerSync("valid-token")
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate deterministically via commands to apps
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	_ = tf.Send(":")
+	if !tf.WaitForPlain("> ", 2*time.Second) {
+		t.Fatal("command bar not ready")
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	_ = tf.Send(":")
+	if !tf.WaitForPlain("> ", 2*time.Second) {
+		t.Fatal("command bar not ready")
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo2", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	// Navigate to the last app (demo2) by pressing 'j' to move down from first app (demo)
+	_ = tf.Send("j")
+
+	// Type `:sync` instead of using the 's' key
+	_ = tf.Send(":")
+	if !tf.WaitForPlain("> ", 2*time.Second) {
+		t.Fatal("command bar not ready")
+	}
+	_ = tf.Send("sync")
+	_ = tf.Enter()
+
+	// The modal should show demo2 as the target, not demo
+	// Check that the confirmation modal displays the correct app name (demo2)
+	if !tf.WaitForPlain("demo2", 500*time.Millisecond) {
+		// If we don't see demo2 in the modal, this indicates the bug
+		snapshot := tf.SnapshotPlain()
+		if strings.Contains(snapshot, "demo") && !strings.Contains(snapshot, "demo2") {
+			t.Fatalf("BUG REPRODUCED: Modal shows 'demo' instead of 'demo2' when last app is selected\nSnapshot:\n%s", snapshot)
+		}
+		t.Fatalf("Expected sync confirmation modal to show 'demo2', but it's not visible\nSnapshot:\n%s", snapshot)
+	}
+
+	// Confirm the sync to verify it targets the correct app
+	_ = tf.Send("\r") // Enter to confirm "Yes"
+
+	// Wait for one sync call
+	if !waitUntil(t, func() bool { return rec.len() == 1 }, 2*time.Second) {
+		t.Fatalf("expected 1 sync call, got %d\n%s", rec.len(), tf.SnapshotPlain())
+	}
+	call := rec.Calls[0]
+	if call.Name != "demo2" {
+		t.Fatalf("BUG CONFIRMED: expected sync for 'demo2', got %q - the wrong app was synced!", call.Name)
 	}
 }


### PR DESCRIPTION
# Fix: sync command now targets correctly selected app

## Summary
- Fix sync command targeting wrong app when using `:sync` after selecting last app
- Add comprehensive E2E test coverage for the fix
- Preserve cursor position for action commands while maintaining proper navigation reset for view-changing commands

## Problem
When a user selected the last app in the list and typed `:sync`, the confirmation popup would incorrectly ask to sync the first app instead of the selected app.

## Root Cause
The command handler in `cmd/app/input_components.go:442` was resetting `m.state.Navigation.SelectedIdx = 0` for ALL commands before processing them, which meant the cursor position was lost before the sync command could use it.

## Solution
- Moved navigation index reset to only apply to view-changing commands (`:cluster`, `:namespace`, `:project`, `:apps`) that actually need cursor reset
- Preserved cursor position for action commands like `:sync`, `:delete`, `:rollback` that should operate on the currently selected item

## Changes
- `cmd/app/input_components.go`: Remove global navigation reset, add targeted reset for view-changing commands
- `e2e/sync_test.go`: Add `TestSyncLastAppShowsCorrectConfirmation` E2E test

## Test Plan
- [x] Created E2E test that reproduces the bug and validates the fix
- [x] Test initially failed (confirming bug exists)
- [x] Test now passes after fix
- [x] All existing E2E tests continue to pass (no regressions)

🤖 Generated with [Claude Code](https://claude.ai/code)