### PR TITLE
Avoid handling diff view mouse scroll in TUI

### DIFF
--- a/cmd/app/input_mouse.go
+++ b/cmd/app/input_mouse.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/darksworm/argonaut/pkg/model"
+	"github.com/darksworm/argonaut/pkg/tui/treeview"
+)
+
+const mouseScrollAmount = 3
+
+func (m *Model) handleMouseWheelMsg(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
+	direction := 0
+	switch msg.Button {
+	case tea.MouseWheelUp:
+		direction = -1
+	case tea.MouseWheelDown:
+		direction = 1
+	default:
+		return m, nil
+	}
+
+	if direction == 0 {
+		return m, nil
+	}
+
+	// Theme overlay consumes scrolling events
+	if m.state.Mode == model.ModeTheme {
+		return m.handleThemeMouseWheel(direction)
+	}
+
+	// Block scrolling when non-scrollable overlays are active
+	if m.hasBlockingOverlay() {
+		return m, nil
+	}
+
+	// Diff view is rendered through an external pager (less), so Bubble Tea
+	// should not attempt to adjust any offsets here.
+	if m.state.Mode == model.ModeDiff {
+		return m, nil
+	}
+
+	// When tree loading overlay is active, ignore scrolling
+	if m.treeLoading {
+		return m, nil
+	}
+
+	if m.state.Navigation.View == model.ViewTree {
+		m.scrollTreeBy(direction * mouseScrollAmount)
+	} else {
+		m.scrollListBy(direction * mouseScrollAmount)
+	}
+
+	return m, nil
+}
+
+func (m *Model) handleThemeMouseWheel(direction int) (tea.Model, tea.Cmd) {
+	m.ensureThemeOptionsLoaded()
+	if len(m.themeOptions) == 0 {
+		return m, nil
+	}
+
+	steps := mouseScrollAmount
+	for i := 0; i < steps; i++ {
+		if direction < 0 {
+			if m.state.UI.ThemeSelectedIndex <= 0 {
+				break
+			}
+			m.state.UI.ThemeSelectedIndex--
+		} else {
+			if m.state.UI.ThemeSelectedIndex >= len(m.themeOptions)-1 {
+				break
+			}
+			m.state.UI.ThemeSelectedIndex++
+		}
+		m.adjustThemeScrollOffset()
+		selectedTheme := m.themeOptions[m.state.UI.ThemeSelectedIndex].Name
+		m.applyThemePreview(selectedTheme)
+	}
+
+	return m, nil
+}
+
+func (m *Model) scrollListBy(lines int) {
+	if lines == 0 {
+		return
+	}
+
+	steps := lines
+	direction := 1
+	if lines < 0 {
+		direction = -1
+		steps = -lines
+	}
+
+	for i := 0; i < steps; i++ {
+		if direction < 0 {
+			m.handleNavigationUp()
+		} else {
+			m.handleNavigationDown()
+		}
+	}
+}
+
+func (m *Model) scrollTreeBy(lines int) {
+	if lines == 0 || m.treeView == nil {
+		return
+	}
+
+	steps := lines
+	direction := 1
+	if lines < 0 {
+		direction = -1
+		steps = -lines
+	}
+
+	for i := 0; i < steps; i++ {
+		var key tea.KeyPressMsg
+		if direction < 0 {
+			key = tea.KeyPressMsg{Text: "k", Code: 'k'}
+		} else {
+			key = tea.KeyPressMsg{Text: "j", Code: 'j'}
+		}
+
+		oldLine := m.treeView.SelectedIndex()
+		if s, ok := interface{}(m.treeView).(interface{ SelectedLineIndex() int }); ok {
+			oldLine = s.SelectedLineIndex()
+		}
+
+		updatedModel, _ := m.treeView.Update(key)
+		m.treeView = updatedModel.(*treeview.TreeView)
+
+		newLine := m.treeView.SelectedIndex()
+		if s, ok := interface{}(m.treeView).(interface{ SelectedLineIndex() int }); ok {
+			newLine = s.SelectedLineIndex()
+		}
+
+		if newLine == oldLine {
+			break
+		}
+
+		viewportHeight := m.treeViewportHeight()
+		if viewportHeight <= 0 {
+			m.treeScrollOffset = 0
+			continue
+		}
+
+		if direction < 0 {
+			if newLine < m.treeScrollOffset {
+				m.treeScrollOffset = newLine
+			}
+		} else {
+			if newLine >= m.treeScrollOffset+viewportHeight {
+				m.treeScrollOffset = newLine - viewportHeight + 1
+			}
+		}
+	}
+}
+
+func (m *Model) hasBlockingOverlay() bool {
+	switch m.state.Mode {
+	case model.ModeHelp,
+		model.ModeConfirmSync,
+		model.ModeRollback,
+		model.ModeConfirmAppDelete,
+		model.ModeUpgrade,
+		model.ModeUpgradeError,
+		model.ModeUpgradeSuccess,
+		model.ModeNoDiff,
+		model.ModeLoading,
+		model.ModeAuthRequired,
+		model.ModeError,
+		model.ModeConnectionError:
+		return true
+	}
+	if m.state.Diff != nil && m.state.Diff.Loading {
+		return true
+	}
+	return false
+}

--- a/cmd/app/input_mouse_test.go
+++ b/cmd/app/input_mouse_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/darksworm/argonaut/pkg/api"
+	"github.com/darksworm/argonaut/pkg/model"
+	"github.com/darksworm/argonaut/pkg/theme"
+	"github.com/darksworm/argonaut/pkg/tui/treeview"
+)
+
+func TestHandleMouseWheelListViewScrollsSelection(t *testing.T) {
+	m := NewModel()
+	m.state.Navigation.View = model.ViewApps
+	m.state.Apps = []model.App{
+		{Name: "app-1", Sync: "Synced", Health: "Healthy"},
+		{Name: "app-2", Sync: "Synced", Health: "Healthy"},
+		{Name: "app-3", Sync: "Synced", Health: "Healthy"},
+		{Name: "app-4", Sync: "Synced", Health: "Healthy"},
+		{Name: "app-5", Sync: "Synced", Health: "Healthy"},
+	}
+
+	initialIdx := m.state.Navigation.SelectedIdx
+	if initialIdx != 0 {
+		t.Fatalf("expected initial selection 0, got %d", initialIdx)
+	}
+
+	_, _ = m.handleMouseWheelMsg(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	expected := min(mouseScrollAmount, len(m.state.Apps)-1)
+	if m.state.Navigation.SelectedIdx != expected {
+		t.Fatalf("expected selection %d after scroll, got %d", expected, m.state.Navigation.SelectedIdx)
+	}
+}
+
+func TestHandleMouseWheelListViewBlockedByOverlay(t *testing.T) {
+	m := NewModel()
+	m.state.Navigation.View = model.ViewApps
+	m.state.Apps = []model.App{{Name: "app-1", Sync: "Synced", Health: "Healthy"}, {Name: "app-2", Sync: "Synced", Health: "Healthy"}}
+	m.state.Mode = model.ModeConfirmSync
+
+	_, _ = m.handleMouseWheelMsg(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	if m.state.Navigation.SelectedIdx != 0 {
+		t.Fatalf("expected selection to remain 0 when overlay active, got %d", m.state.Navigation.SelectedIdx)
+	}
+}
+
+func TestHandleMouseWheelThemeOverlay(t *testing.T) {
+	m := NewModel()
+	m.state.Mode = model.ModeTheme
+	defer func() {
+		applyTheme(theme.Default())
+		m.applyThemeToModel()
+	}()
+	m.ensureThemeOptionsLoaded()
+
+	if len(m.themeOptions) == 0 {
+		t.Fatal("expected theme options to be loaded")
+	}
+
+	_, _ = m.handleMouseWheelMsg(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	if m.state.UI.ThemeSelectedIndex <= 0 {
+		t.Fatalf("expected theme selection to advance, got %d", m.state.UI.ThemeSelectedIndex)
+	}
+}
+
+func TestHandleMouseWheelDiffViewNoop(t *testing.T) {
+	m := NewModel()
+	m.state.Mode = model.ModeDiff
+	m.state.Diff = &model.DiffState{
+		Title:  "Example",
+		Offset: 5,
+	}
+
+	_, _ = m.handleMouseWheelMsg(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+	if m.state.Diff.Offset != 5 {
+		t.Fatalf("expected diff offset to remain unchanged, got %d", m.state.Diff.Offset)
+	}
+
+	_, _ = m.handleMouseWheelMsg(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if m.state.Diff.Offset != 5 {
+		t.Fatalf("expected diff offset to remain unchanged after scroll up, got %d", m.state.Diff.Offset)
+	}
+}
+
+func TestHandleMouseWheelTreeView(t *testing.T) {
+	m := NewModel()
+	m.state.Navigation.View = model.ViewTree
+	m.treeView = treeview.NewTreeView(0, 0)
+	m.treeView.SetSize(m.state.Terminal.Cols, m.state.Terminal.Rows)
+
+	ns := "default"
+	tree := &api.ResourceTree{
+		Nodes: []api.ResourceNode{
+			{
+				UID:         "root",
+				Kind:        "Application",
+				Name:        "app",
+				Group:       "argoproj.io",
+				Status:      "Synced",
+				Version:     "v1",
+				ResourceRef: api.ResourceRef{UID: "root", Kind: "Application", Name: "app", Group: "argoproj.io", Version: "v1"},
+			},
+			{
+				UID:         "deploy",
+				Kind:        "Deployment",
+				Name:        "app",
+				Group:       "apps",
+				Status:      "Synced",
+				Version:     "v1",
+				ResourceRef: api.ResourceRef{UID: "deploy", Kind: "Deployment", Name: "app", Group: "apps", Version: "v1"},
+				ParentRefs:  []api.ResourceRef{{UID: "root", Kind: "Application", Name: "app", Group: "argoproj.io", Version: "v1"}},
+			},
+			{
+				UID:         "rs",
+				Kind:        "ReplicaSet",
+				Name:        "app",
+				Group:       "apps",
+				Status:      "Synced",
+				Version:     "v1",
+				ResourceRef: api.ResourceRef{UID: "rs", Kind: "ReplicaSet", Name: "app", Group: "apps", Version: "v1"},
+				ParentRefs:  []api.ResourceRef{{UID: "deploy", Kind: "Deployment", Name: "app", Group: "apps", Version: "v1"}},
+			},
+			{
+				UID:         "pod",
+				Kind:        "Pod",
+				Name:        "app-123",
+				Group:       "",
+				Status:      "Running",
+				Version:     "v1",
+				Namespace:   &ns,
+				ResourceRef: api.ResourceRef{UID: "pod", Kind: "Pod", Name: "app-123", Version: "v1", Namespace: &ns},
+				ParentRefs:  []api.ResourceRef{{UID: "rs", Kind: "ReplicaSet", Name: "app", Group: "apps", Version: "v1"}},
+			},
+		},
+	}
+
+	m.treeView.UpsertAppTree("app", tree)
+
+	_, _ = m.handleMouseWheelMsg(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	if m.treeView.SelectedIndex() == 0 {
+		t.Fatal("expected tree selection to advance after scrolling")
+	}
+}

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -102,6 +102,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m.handleKeyMsg(msg)
 
+	case tea.MouseWheelMsg:
+		return m.handleMouseWheelMsg(msg)
+
 	// Tree stream messages from watcher goroutine
 	case model.ResourceTreeStreamMsg:
 		cblog.With("component", "ui").Debug("Processing tree stream message", "app", msg.AppName, "hasData", len(msg.TreeJSON) > 0)


### PR DESCRIPTION
## Summary
- ignore mouse wheel events while in diff mode so the external pager handles scrolling
- update the mouse wheel tests to assert diff mode remains unchanged when scrolling

## Testing
- go test ./...
- make e2e *(fails: TestSimpleInvalidCommand expecting invalid command messaging)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69123f7554bc8325ab46ecb660e03389)