### PR TITLE
feat: add what's new notification and :changelog command

### DIFF
--- a/cmd/app/changelog.go
+++ b/cmd/app/changelog.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	cblog "github.com/charmbracelet/log"
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+const changelogURL = "https://raw.githubusercontent.com/darksworm/argonaut/refs/heads/main/CHANGELOG.md"
+
+// fetchChangelog fetches the changelog from GitHub
+func (m *Model) fetchChangelog() tea.Cmd {
+	return func() tea.Msg {
+		logger := cblog.With("component", "changelog")
+		logger.Info("Fetching changelog")
+
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Get(changelogURL)
+		if err != nil {
+			logger.Error("Failed to fetch changelog", "err", err)
+			return model.ChangelogLoadedMsg{
+				Content: "",
+				Error:   fmt.Errorf("network error: %w", err),
+			}
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			logger.Error("Changelog fetch returned non-200", "status", resp.StatusCode)
+			return model.ChangelogLoadedMsg{
+				Content: "",
+				Error:   fmt.Errorf("HTTP %d - changelog unavailable", resp.StatusCode),
+			}
+		}
+
+		// Limit read to 1MB to prevent memory issues
+		limitedReader := io.LimitReader(resp.Body, 1*1024*1024)
+		body, err := io.ReadAll(limitedReader)
+		if err != nil {
+			logger.Error("Failed to read changelog", "err", err)
+			return model.ChangelogLoadedMsg{
+				Content: "",
+				Error:   fmt.Errorf("read error: %w", err),
+			}
+		}
+
+		logger.Info("Changelog fetched successfully", "size", len(body))
+		return model.ChangelogLoadedMsg{
+			Content: string(body),
+			Error:   nil,
+		}
+	}
+}
+
+// FormatChangelog converts markdown changelog to styled terminal output
+func FormatChangelog(content string) string {
+	var result strings.Builder
+	lines := strings.Split(content, "\n")
+
+	// Styles matching app theme
+	h1Style := lipgloss.NewStyle().Foreground(cyanBright).Bold(true)
+	h2Style := lipgloss.NewStyle().Foreground(yellowBright).Bold(true)
+	h3Style := lipgloss.NewStyle().Foreground(syncedColor).Bold(true)
+	bulletStyle := lipgloss.NewStyle().Foreground(cyanBright)
+	linkStyle := lipgloss.NewStyle().Foreground(magentaBright).Underline(true)
+	textStyle := lipgloss.NewStyle().Foreground(whiteBright)
+
+	// Regex patterns
+	linkRe := regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+	codeRe := regexp.MustCompile("`([^`]+)`")
+	boldRe := regexp.MustCompile(`\*\*([^*]+)\*\*`)
+
+	prevWasEmpty := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		var formatted string
+
+		switch {
+		case strings.HasPrefix(trimmed, "# "):
+			// Main title (# Changelog)
+			title := strings.TrimPrefix(trimmed, "# ")
+			formatted = h1Style.Render(title)
+			prevWasEmpty = false
+		case strings.HasPrefix(trimmed, "## "):
+			// Version header (## [2.7.0])
+			version := strings.TrimPrefix(trimmed, "## ")
+			// Strip link markdown from version header
+			version = linkRe.ReplaceAllString(version, "$1")
+			formatted = "\n" + h2Style.Render(version)
+			prevWasEmpty = false
+		case strings.HasPrefix(trimmed, "### "):
+			// Section header (### Features, ### Bug Fixes)
+			section := strings.TrimPrefix(trimmed, "### ")
+			formatted = "  " + h3Style.Render(section)
+			prevWasEmpty = false
+		case strings.HasPrefix(trimmed, "* ") || strings.HasPrefix(trimmed, "- "):
+			// List item
+			item := trimmed[2:]
+			item = processInlineFormatting(item, linkRe, codeRe, boldRe, linkStyle, textStyle)
+			bullet := bulletStyle.Render("•")
+			formatted = "    " + bullet + " " + item
+			prevWasEmpty = false
+		case trimmed == "":
+			// Skip consecutive empty lines
+			if prevWasEmpty {
+				continue
+			}
+			formatted = ""
+			prevWasEmpty = true
+		default:
+			// Regular text
+			formatted = processInlineFormatting(line, linkRe, codeRe, boldRe, linkStyle, textStyle)
+			prevWasEmpty = false
+		}
+
+		result.WriteString(formatted + "\n")
+	}
+
+	return result.String()
+}
+
+// processInlineFormatting applies inline markdown formatting
+func processInlineFormatting(text string, linkRe, codeRe, boldRe *regexp.Regexp, linkStyle, textStyle lipgloss.Style) string {
+	// Replace links: [text](url) -> styled text (hide URL since not clickable)
+	text = linkRe.ReplaceAllStringFunc(text, func(match string) string {
+		parts := linkRe.FindStringSubmatch(match)
+		if len(parts) >= 2 {
+			return linkStyle.Render(parts[1])
+		}
+		return match
+	})
+
+	// Replace bold: **text** -> styled text
+	text = boldRe.ReplaceAllStringFunc(text, func(match string) string {
+		parts := boldRe.FindStringSubmatch(match)
+		if len(parts) >= 2 {
+			return textStyle.Bold(true).Render(parts[1])
+		}
+		return match
+	})
+
+	// Replace inline code: `code` -> styled code
+	codeStyle := lipgloss.NewStyle().Background(mutedBG).Foreground(whiteBright)
+	text = codeRe.ReplaceAllStringFunc(text, func(match string) string {
+		parts := codeRe.FindStringSubmatch(match)
+		if len(parts) >= 2 {
+			return codeStyle.Render(parts[1])
+		}
+		return match
+	})
+
+	return text
+}

--- a/cmd/app/changelog_test.go
+++ b/cmd/app/changelog_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatChangelog(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+		notContains []string
+	}{
+		{
+			name: "formats h1 header",
+			input: "# Changelog",
+			contains: []string{"Changelog"},
+		},
+		{
+			name: "formats h2 version header",
+			input: "## [2.7.0](https://github.com/example/repo/compare/v2.6.1...v2.7.0) (2025-11-14)",
+			contains: []string{"2.7.0", "2025-11-14"},
+			// URL should be stripped from display
+			notContains: []string{"https://github.com"},
+		},
+		{
+			name: "formats h3 section header",
+			input: "### Features",
+			contains: []string{"Features"},
+		},
+		{
+			name: "formats bullet points",
+			input: "* add ArgoCD core mode detection",
+			contains: []string{"•", "add ArgoCD core mode detection"},
+		},
+		{
+			name: "formats dash bullet points",
+			input: "- fix edge case in config loading",
+			contains: []string{"•", "fix edge case in config loading"},
+		},
+		{
+			name: "extracts link text and hides URL",
+			input: "* see [the docs](https://example.com) for details",
+			// Note: "the docs" will have ANSI styling applied, so we check for individual parts
+			contains: []string{"see", "for details"},
+			notContains: []string{"https://example.com"},
+		},
+		{
+			name: "handles inline code",
+			input: "* fix issue with `config.toml` file",
+			contains: []string{"config.toml"},
+		},
+		{
+			name: "handles bold text",
+			input: "* **breaking change**: removed old API",
+			contains: []string{"breaking change", "removed old API"},
+		},
+		{
+			name: "handles empty lines",
+			input: "\n\n",
+			contains: []string{"\n"},
+		},
+		{
+			name: "formats complete changelog section",
+			input: `# Changelog
+
+## [2.8.0](https://github.com/darksworm/argonaut/compare/v2.7.0...v2.8.0) (2025-11-29)
+
+### Features
+
+* add what's new notification on version upgrade
+* add :changelog command to view release notes
+
+### Bug Fixes
+
+* fix status line spacing issue`,
+			contains: []string{
+				"Changelog",
+				"2.8.0",
+				"Features",
+				"Bug Fixes",
+				"what's new notification",
+				":changelog command",
+				"status line spacing",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatChangelog(tt.input)
+
+			for _, expected := range tt.contains {
+				if !strings.Contains(result, expected) {
+					t.Errorf("FormatChangelog() result should contain %q, got:\n%s", expected, result)
+				}
+			}
+
+			for _, unexpected := range tt.notContains {
+				if strings.Contains(result, unexpected) {
+					t.Errorf("FormatChangelog() result should NOT contain %q, got:\n%s", unexpected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestProcessInlineFormatting(t *testing.T) {
+	// Note: These tests verify that text content is preserved after formatting.
+	// ANSI escape codes are inserted by lipgloss, so we check for parts that
+	// don't have character-by-character styling applied.
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+	}{
+		{
+			name:     "handles plain text",
+			input:    "plain text",
+			contains: []string{"plain text"},
+		},
+		{
+			name:     "handles link - surrounding text preserved",
+			input:    "see [docs](https://example.com) here",
+			contains: []string{"see", "here"},
+		},
+		{
+			name:     "handles bold - surrounding text preserved",
+			input:    "this is **important** stuff",
+			contains: []string{"this is", "stuff"},
+		},
+		{
+			name:     "handles code - surrounding text preserved",
+			input:    "edit `code` file",
+			contains: []string{"edit", "file"},
+		},
+		{
+			name:     "handles multiple formats - surrounding text preserved",
+			input:    "check the docs and config for details",
+			contains: []string{"check the", "and", "for"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: We can't easily test the actual styling, but we can verify content is preserved
+			result := FormatChangelog("* " + tt.input)
+
+			for _, expected := range tt.contains {
+				if !strings.Contains(result, expected) {
+					t.Errorf("processInlineFormatting() result should contain %q, got:\n%s", expected, result)
+				}
+			}
+		})
+	}
+}

--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -1020,6 +1020,10 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 		case "upgrade", "update":
 			// Trigger upgrade process
 			return m, func() tea.Msg { return model.UpgradeRequestedMsg{} }
+		case "changelog", "whatsnew", "news":
+			// Fetch and display changelog
+			m.state.Modals.ChangelogLoading = true
+			return m, m.fetchChangelog()
 		default:
 			// Unknown: set status for feedback
 			return m, func() tea.Msg { return model.StatusChangeMsg{Status: "Unknown command: " + raw} }

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -963,6 +963,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.state.Modals.UpgradeLoading = false
 		}
 		return m, nil
+
+	case model.ChangelogLoadedMsg:
+		m.state.Modals.ChangelogLoading = false
+		if msg.Error != nil {
+			return m, func() tea.Msg {
+				return model.StatusChangeMsg{
+					Status: "Could not fetch changelog: " + msg.Error.Error(),
+				}
+			}
+		}
+		// Format and display in pager
+		formatted := FormatChangelog(msg.Content)
+		return m, m.openTextPager("Changelog", formatted)
 	}
 
 	return m, nil

--- a/cmd/app/view_layout.go
+++ b/cmd/app/view_layout.go
@@ -191,6 +191,17 @@ func (m *Model) renderMainLayout() string {
 		canvas := lipgloss.NewCanvas(baseLayer, modalLayer)
 		return canvas.Render()
 	}
+	// Changelog loading modal
+	if m.state.Modals.ChangelogLoading {
+		modal := m.renderChangelogLoadingModal()
+		grayBase := desaturateANSI(baseView)
+		baseLayer := lipgloss.NewLayer(grayBase)
+		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
+		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
+		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
+		canvas := lipgloss.NewCanvas(baseLayer, modalLayer)
+		return canvas.Render()
+	}
 	// Upgrade modal (confirmation, loading, success, or error state)
 	if m.state.Mode == model.ModeUpgrade || m.state.Mode == model.ModeUpgradeError || m.state.Mode == model.ModeUpgradeSuccess {
 		modal := ""

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -146,6 +146,20 @@ func (m *Model) renderSyncLoadingModal() string {
 	return outer.Render(wrapper.Render(content))
 }
 
+func (m *Model) renderChangelogLoadingModal() string {
+	msg := fmt.Sprintf("%s %s", m.spinner.View(), statusStyle.Render("Fetching changelog…"))
+	content := msg
+	wrapper := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(cyanBright).
+		Padding(1, 2)
+	minW := 28
+	w := max(minW, lipgloss.Width(content)+4)
+	wrapper = wrapper.Width(w)
+	outer := lipgloss.NewStyle().Padding(1, 1)
+	return outer.Render(wrapper.Render(content))
+}
+
 func (m *Model) renderInitialLoadingModal() string {
 	msg := fmt.Sprintf("%s %s", m.spinner.View(), statusStyle.Render("Loading..."))
 	content := msg

--- a/cmd/app/view_status_test.go
+++ b/cmd/app/view_status_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+func TestShouldShowWhatsNewNotification(t *testing.T) {
+	tests := []struct {
+		name       string
+		shownAt    *time.Time
+		wantResult bool
+	}{
+		{
+			name:       "returns true when shownAt is nil",
+			shownAt:    nil,
+			wantResult: true,
+		},
+		{
+			name: "returns true when notification was just shown",
+			shownAt: func() *time.Time {
+				t := time.Now()
+				return &t
+			}(),
+			wantResult: true,
+		},
+		{
+			name: "returns true when notification was shown 10 seconds ago",
+			shownAt: func() *time.Time {
+				t := time.Now().Add(-10 * time.Second)
+				return &t
+			}(),
+			wantResult: true,
+		},
+		{
+			name: "returns true when notification was shown 29 seconds ago",
+			shownAt: func() *time.Time {
+				t := time.Now().Add(-29 * time.Second)
+				return &t
+			}(),
+			wantResult: true,
+		},
+		{
+			name: "returns false when notification was shown 31 seconds ago",
+			shownAt: func() *time.Time {
+				t := time.Now().Add(-31 * time.Second)
+				return &t
+			}(),
+			wantResult: false,
+		},
+		{
+			name: "returns false when notification was shown 1 minute ago",
+			shownAt: func() *time.Time {
+				t := time.Now().Add(-60 * time.Second)
+				return &t
+			}(),
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				state: model.NewAppState(),
+			}
+			m.state.UI.WhatsNewShownAt = tt.shownAt
+
+			got := m.shouldShowWhatsNewNotification()
+			if got != tt.wantResult {
+				t.Errorf("shouldShowWhatsNewNotification() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}

--- a/pkg/autocomplete/autocomplete.go
+++ b/pkg/autocomplete/autocomplete.go
@@ -148,6 +148,13 @@ func NewAutocompleteEngine() *AutocompleteEngine {
 			TakesArg:    true,
 			ArgType:     "sort",
 		},
+		{
+			Command:     "changelog",
+			Aliases:     []string{"changelog", "whatsnew", "news"},
+			Description: "View release changelog",
+			TakesArg:    false,
+			ArgType:     "",
+		},
 	}
 
 	// Build alias map

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -14,8 +14,9 @@ const DefaultThemeName = "tokyo-night"
 
 // ArgonautConfig represents the complete Argonaut configuration
 type ArgonautConfig struct {
-	Appearance AppearanceConfig `toml:"appearance"`
-	Sort       SortConfig       `toml:"sort,omitempty"`
+	Appearance      AppearanceConfig `toml:"appearance"`
+	Sort            SortConfig       `toml:"sort,omitempty"`
+	LastSeenVersion string           `toml:"last_seen_version,omitempty"`
 }
 
 // AppearanceConfig holds theme and visual settings
@@ -65,6 +66,13 @@ func EnsureArgonautConfigDir() error {
 		return os.MkdirAll(configDir, 0755)
 	}
 	return nil
+}
+
+// ConfigFileExists returns true if the config file exists on disk
+func ConfigFileExists() bool {
+	configPath := GetArgonautConfigPath()
+	_, err := os.Stat(configPath)
+	return err == nil
 }
 
 // GetDefaultConfig returns a config with sensible defaults

--- a/pkg/model/messages.go
+++ b/pkg/model/messages.go
@@ -409,3 +409,9 @@ type UpgradeCompletedMsg struct {
 	Success bool
 	Error   error
 }
+
+// ChangelogLoadedMsg is sent when changelog has been fetched
+type ChangelogLoadedMsg struct {
+	Content string
+	Error   error
+}

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -99,6 +99,8 @@ type UIState struct {
 	ThemeOriginalName   string      `json:"themeOriginalName,omitempty"`
 	CommandInvalid      bool        `json:"commandInvalid"`
 	Sort                SortConfig  `json:"sort"`
+	ShowWhatsNew        bool        `json:"showWhatsNew"`
+	WhatsNewShownAt     *time.Time  `json:"whatsNewShownAt,omitempty"`
 }
 
 // ModalState holds modal-related state
@@ -119,13 +121,15 @@ type ModalState struct {
 	UpgradeLoading  bool    `json:"upgradeLoading"`
 	UpgradeError    *string `json:"upgradeError,omitempty"` // Error message for upgrade failures
 	// Delete confirmation modal state
-	DeleteAppName     *string `json:"deleteAppName,omitempty"`
-	DeleteAppNamespace *string `json:"deleteAppNamespace,omitempty"`
-	DeleteConfirmationKey string `json:"deleteConfirmationKey"` // Track what user has typed
-	DeleteLoading     bool    `json:"deleteLoading"`
-	DeleteError       *string `json:"deleteError,omitempty"`
-	DeleteCascade     bool    `json:"deleteCascade"` // Default true
+	DeleteAppName          *string `json:"deleteAppName,omitempty"`
+	DeleteAppNamespace     *string `json:"deleteAppNamespace,omitempty"`
+	DeleteConfirmationKey  string  `json:"deleteConfirmationKey"` // Track what user has typed
+	DeleteLoading          bool    `json:"deleteLoading"`
+	DeleteError            *string `json:"deleteError,omitempty"`
+	DeleteCascade          bool    `json:"deleteCascade"`          // Default true
 	DeletePropagationPolicy string `json:"deletePropagationPolicy"` // Default "foreground"
+	// Changelog loading modal state
+	ChangelogLoading bool `json:"changelogLoading"`
 }
 
 // AppState represents the complete application state for Bubbletea


### PR DESCRIPTION
- Show "Upgraded! Run :changelog to see what's new" notification in status bar when user upgrades to a new version (30 second timeout)
- Add :changelog command (aliases: whatsnew, news) to fetch and display CHANGELOG.md from GitHub with nice formatting
- Store last_seen_version in config to track upgrades
- Show spinner modal while fetching changelog
- Distinguish between fresh install (no notification) and existing user upgrading to version with this feature (show notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `changelog`, `whatsnew`, and `news` commands to view release information
  * Introduced "What's New" notification that displays on version updates
  * Changelog content is fetched and rendered in a styled terminal view with proper formatting
  * Added loading modal while changelog is being fetched

* **Tests**
  * Added tests for changelog formatting and version detection logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->