### PR TITLE
feat: add ApplicationSet view #139

### DIFF
--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -158,6 +158,10 @@ func (m *Model) handleDrillDown() (tea.Model, tea.Cmd) {
 		m.state.Selections.ScopeProjects = result.ScopeProjects
 	}
 
+	if result.ScopeApplicationSets != nil {
+		m.state.Selections.ScopeApplicationSets = result.ScopeApplicationSets
+	}
+
 	if result.SelectedApps != nil {
 		m.state.Selections.SelectedApps = result.SelectedApps
 	}
@@ -362,10 +366,22 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 
 		switch curr {
 		case model.ViewApps:
+			// Check if scoped by ApplicationSet (separate hierarchy)
+			if len(m.state.Selections.ScopeApplicationSets) > 0 {
+				m.state.Selections.SelectedApps = model.NewStringSet()
+				m.state.Selections.ScopeApplicationSets = model.NewStringSet()
+				m = m.safeChangeView(model.ViewApplicationSets)
+				m.state.Navigation.SelectedIdx = 0
+				return m, nil
+			}
 			// Clear current level (selected apps) and prior (projects), go up to Projects
 			m.state.Selections.SelectedApps = model.NewStringSet()
 			m.state.Selections.ScopeProjects = model.NewStringSet()
 			m = m.safeChangeView(model.ViewProjects)
+			m.state.Navigation.SelectedIdx = 0
+		case model.ViewApplicationSets:
+			// At ApplicationSets view, escape just clears the scope (stay in place)
+			m.state.Selections.ScopeApplicationSets = model.NewStringSet()
 			m.state.Navigation.SelectedIdx = 0
 		case model.ViewProjects:
 			// Clear current (projects) and prior (namespaces), go up to Namespaces

--- a/cmd/app/testdata/snapshots/modal_help.golden
+++ b/cmd/app/testdata/snapshots/modal_help.golden
@@ -6,7 +6,7 @@
  │               PgUp / PgDn  page up/down                                                        │ 
  │                                                                                                │ 
  │ VIEWS        :cls|:clusters • :ns|:namespaces • :proj|:projects • :apps                        │ 
- │              :theme • :logs                                                                    │ 
+ │              :appsets|:applicationsets • :theme • :logs                                        │ 
  │                                                                                                │ 
  │ APPS VIEW     s  sync •  R  rollback •  r  resources •  d  diff •  Ctrl+D  delete              │ 
  │              :diff [app] • :sync [app] • :rollback [app] • :delete [app]                       │ 

--- a/cmd/app/testdata/snapshots/status_line_appset_scope.golden
+++ b/cmd/app/testdata/snapshots/status_line_appset_scope.golden
@@ -1,0 +1,1 @@
+<apps in nerdy-demo>                                                                   Ready • 0/0

--- a/cmd/app/testdata/snapshots/status_line_appset_scope_filter.golden
+++ b/cmd/app/testdata/snapshots/status_line_appset_scope_filter.golden
@@ -1,0 +1,1 @@
+<apps in nerdy-demo:test>                                                              Ready • 0/0

--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -489,6 +489,17 @@ func (m *Model) getVisibleItems() []interface{} {
 		apps = filtered
 	}
 
+	// Filter by ApplicationSet scope
+	if len(m.state.Selections.ScopeApplicationSets) > 0 {
+		filtered := make([]model.App, 0, len(apps))
+		for _, a := range apps {
+			if a.ApplicationSet != nil && model.HasInStringSet(m.state.Selections.ScopeApplicationSets, *a.ApplicationSet) {
+				filtered = append(filtered, a)
+			}
+		}
+		apps = filtered
+	}
+
 	// 2) Build base list depending on current view
 	var base []interface{}
 	switch m.state.Navigation.View {
@@ -554,6 +565,23 @@ func (m *Model) getVisibleItems() []interface{} {
 		sortStrings(projs)
 		for _, pj := range projs {
 			base = append(base, pj)
+		}
+	case model.ViewApplicationSets:
+		// Unique ApplicationSet names from all apps
+		appsets := make([]string, 0)
+		seen := map[string]bool{}
+		for _, a := range m.state.Apps {
+			if a.ApplicationSet == nil || *a.ApplicationSet == "" {
+				continue
+			}
+			if !seen[*a.ApplicationSet] {
+				seen[*a.ApplicationSet] = true
+				appsets = append(appsets, *a.ApplicationSet)
+			}
+		}
+		sortStrings(appsets)
+		for _, as := range appsets {
+			base = append(base, as)
 		}
 	case model.ViewApps:
 		// Ensure consistent, stable ordering without mutating state

--- a/cmd/app/view_golden_test.go
+++ b/cmd/app/view_golden_test.go
@@ -56,6 +56,23 @@ func TestGolden_StatusLine(t *testing.T) {
 	compareWithGolden(t, "status_line", line)
 }
 
+func TestGolden_StatusLine_AppSetScope(t *testing.T) {
+	m := buildTestModelWithApps(100, 24)
+	// Set up ApplicationSet scope
+	m.state.Selections.ScopeApplicationSets = map[string]bool{"nerdy-demo": true}
+	line := stripANSI(m.renderStatusLine())
+	compareWithGolden(t, "status_line_appset_scope", line)
+}
+
+func TestGolden_StatusLine_AppSetScopeWithFilter(t *testing.T) {
+	m := buildTestModelWithApps(100, 24)
+	// Set up ApplicationSet scope with active filter
+	m.state.Selections.ScopeApplicationSets = map[string]bool{"nerdy-demo": true}
+	m.state.UI.ActiveFilter = "test"
+	line := stripANSI(m.renderStatusLine())
+	compareWithGolden(t, "status_line_appset_scope_filter", line)
+}
+
 func TestLogHighlighting(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/app/view_lists.go
+++ b/cmd/app/view_lists.go
@@ -70,7 +70,7 @@ func (m *Model) renderListView(availableRows int) string {
 			}
 			tableView = b.String()
 
-		case model.ViewClusters, model.ViewNamespaces, model.ViewProjects:
+		case model.ViewClusters, model.ViewNamespaces, model.ViewProjects, model.ViewApplicationSets:
 			// Custom-render single-column lists with full-row highlight
 			total := len(visibleItems)
 			visibleRows := max(0, tableHeight-1)

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -36,7 +36,7 @@ func (m *Model) renderHelpModal() string {
 	views := strings.Join([]string{
 		mono(":cls"), "|", mono(":clusters"), " ", bullet(), " ", mono(":ns"), "|", mono(":namespaces"), " ", bullet(), " ", mono(":proj"), "|", mono(":projects"), " ", bullet(), " ", mono(":apps"),
 		"\n",
-		mono(":theme"), " ", bullet(), " ", mono(":logs"),
+		mono(":appsets"), "|", mono(":applicationsets"), " ", bullet(), " ", mono(":theme"), " ", bullet(), " ", mono(":logs"),
 	}, "")
 
 	// COMMANDS

--- a/cmd/app/view_status.go
+++ b/cmd/app/view_status.go
@@ -15,7 +15,20 @@ func (m *Model) renderStatusLine() string {
 
 	// Left side: view and filter info (matches MainLayout left Box)
 	leftText := fmt.Sprintf("<%s>", m.state.Navigation.View)
-	if m.state.UI.ActiveFilter != "" && m.state.Navigation.View == model.ViewApps {
+	// Show ApplicationSet scope in the breadcrumb when filtering apps by ApplicationSet
+	if m.state.Navigation.View == model.ViewApps && len(m.state.Selections.ScopeApplicationSets) > 0 {
+		// Get the first (and typically only) ApplicationSet name from the scope
+		var appsetName string
+		for name := range m.state.Selections.ScopeApplicationSets {
+			appsetName = name
+			break
+		}
+		if m.state.UI.ActiveFilter != "" {
+			leftText = fmt.Sprintf("<apps in %s:%s>", appsetName, m.state.UI.ActiveFilter)
+		} else {
+			leftText = fmt.Sprintf("<apps in %s>", appsetName)
+		}
+	} else if m.state.UI.ActiveFilter != "" && m.state.Navigation.View == model.ViewApps {
 		leftText = fmt.Sprintf("<%s:%s>", m.state.Navigation.View, m.state.UI.ActiveFilter)
 	}
 	// Show tree filter info if active

--- a/e2e/appset_test.go
+++ b/e2e/appset_test.go
@@ -1,0 +1,275 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// MockArgoServerWithAppSets creates a mock server with apps that have ApplicationSet ownerReferences
+func MockArgoServerWithAppSets() (*httptest.Server, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/session/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/api/v1/applications", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Return apps with ownerReferences linking them to ApplicationSets
+		_, _ = w.Write([]byte(`{"items":[
+			{
+				"metadata":{
+					"name":"app-from-appset-1",
+					"namespace":"argocd",
+					"ownerReferences":[{"apiVersion":"argoproj.io/v1alpha1","kind":"ApplicationSet","name":"nerdy-demo","uid":"123"}]
+				},
+				"spec":{"project":"default","destination":{"name":"cluster-a","namespace":"default"}},
+				"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}
+			},
+			{
+				"metadata":{
+					"name":"app-from-appset-2",
+					"namespace":"argocd",
+					"ownerReferences":[{"apiVersion":"argoproj.io/v1alpha1","kind":"ApplicationSet","name":"nerdy-demo","uid":"123"}]
+				},
+				"spec":{"project":"default","destination":{"name":"cluster-a","namespace":"default"}},
+				"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}
+			},
+			{
+				"metadata":{
+					"name":"prod-app",
+					"namespace":"argocd",
+					"ownerReferences":[{"apiVersion":"argoproj.io/v1alpha1","kind":"ApplicationSet","name":"production-apps","uid":"456"}]
+				},
+				"spec":{"project":"default","destination":{"name":"cluster-a","namespace":"default"}},
+				"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Degraded"}}
+			},
+			{
+				"metadata":{"name":"standalone-app","namespace":"argocd"},
+				"spec":{"project":"default","destination":{"name":"cluster-a","namespace":"default"}},
+				"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}
+			}
+		]}`))
+	})
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"version":"e2e"}`))
+	})
+	mux.HandleFunc("/api/v1/stream/applications", func(w http.ResponseWriter, r *http.Request) {
+		fl, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "application/json")
+		// Send a heartbeat to keep the stream open
+		_, _ = w.Write([]byte(`{"result":{"type":"MODIFIED","application":{"metadata":{"name":"app-from-appset-1","namespace":"argocd","ownerReferences":[{"kind":"ApplicationSet","name":"nerdy-demo"}]},"spec":{"project":"default","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}}}}` + "\n"))
+		if fl != nil {
+			fl.Flush()
+		}
+	})
+	srv := httptest.NewServer(mux)
+	return srv, nil
+}
+
+func TestAppSetsCommand_ShowsApplicationSetsList(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServerWithAppSets()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Wait for initial clusters view
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Fatal("initial view not ready")
+	}
+
+	// Navigate to ApplicationSets view
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("appsets")
+	_ = tf.Enter()
+
+	// Verify ApplicationSets list shows unique ApplicationSet names
+	if !tf.WaitForPlain("nerdy-demo", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected to see nerdy-demo ApplicationSet")
+	}
+	if !tf.WaitForPlain("production-apps", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected to see production-apps ApplicationSet")
+	}
+
+	// Verify standalone apps don't appear in the list
+	snapshot := tf.SnapshotPlain()
+	if strings.Contains(snapshot, "standalone-app") {
+		t.Fatal("standalone-app should not appear in ApplicationSets view")
+	}
+}
+
+func TestAppSetCommand_NavigatesToFilteredApps(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServerWithAppSets()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Wait for initial view
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Fatal("initial view not ready")
+	}
+
+	// Navigate via :appset nerdy-demo to filter apps
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("appset nerdy-demo")
+	_ = tf.Enter()
+
+	// Verify filtered apps view shows only apps from nerdy-demo ApplicationSet
+	if !tf.WaitForPlain("app-from-appset-1", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected to see app-from-appset-1")
+	}
+	if !tf.WaitForPlain("app-from-appset-2", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected to see app-from-appset-2")
+	}
+
+	// Verify apps from other ApplicationSets and standalone apps are NOT shown
+	snapshot := tf.SnapshotPlain()
+	if strings.Contains(snapshot, "prod-app") {
+		t.Fatal("prod-app should not appear when filtered by nerdy-demo")
+	}
+	if strings.Contains(snapshot, "standalone-app") {
+		t.Fatal("standalone-app should not appear when filtered by ApplicationSet")
+	}
+}
+
+func TestAppSetCommand_DrillDown(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServerWithAppSets()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Wait for initial view
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Fatal("initial view not ready")
+	}
+
+	// Navigate to ApplicationSets view
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("appsets")
+	_ = tf.Enter()
+
+	// Wait for ApplicationSets to appear
+	if !tf.WaitForPlain("nerdy-demo", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("ApplicationSets view not ready")
+	}
+
+	// Drill down with Enter on selected ApplicationSet
+	_ = tf.Enter()
+
+	// Should now be in apps view filtered by the selected ApplicationSet
+	if !tf.WaitForPlain("app-from-appset", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected drill-down to show apps from ApplicationSet")
+	}
+}
+
+func TestAppSetCommand_InvalidAppSet(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServerWithAppSets()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Wait for initial view
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Fatal("initial view not ready")
+	}
+
+	// Try to navigate to non-existent ApplicationSet
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("appset nonexistent")
+	_ = tf.Enter()
+
+	// The validateCommand() function marks unknown arguments as invalid,
+	// so the command bar shows "unknown command" visual indicator.
+	// The command is still sent but validation prevents execution.
+	// We verify the UI rejects invalid input.
+	if !tf.WaitForPlain("unknown command", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected unknown command indicator for invalid ApplicationSet")
+	}
+}

--- a/pkg/api/applications_test.go
+++ b/pkg/api/applications_test.go
@@ -1,0 +1,248 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConvertToApp_WithApplicationSet(t *testing.T) {
+	svc := &ApplicationService{}
+
+	argoApp := ArgoApplication{
+		Metadata: struct {
+			Name            string           `json:"name"`
+			Namespace       string           `json:"namespace,omitempty"`
+			OwnerReferences []OwnerReference `json:"ownerReferences,omitempty"`
+		}{
+			Name:      "test-app",
+			Namespace: "argocd",
+			OwnerReferences: []OwnerReference{
+				{
+					APIVersion: "argoproj.io/v1alpha1",
+					Kind:       "ApplicationSet",
+					Name:       "my-appset",
+					UID:        "12345",
+				},
+			},
+		},
+		Status: struct {
+			Sync struct {
+				Status     string `json:"status,omitempty"`
+				ComparedTo struct {
+					Source *struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"source,omitempty"`
+					Sources []struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"sources,omitempty"`
+				} `json:"comparedTo"`
+				Revision  string   `json:"revision,omitempty"`
+				Revisions []string `json:"revisions,omitempty"`
+			} `json:"sync"`
+			Health struct {
+				Status  string `json:"status,omitempty"`
+				Message string `json:"message,omitempty"`
+			} `json:"health"`
+			OperationState struct {
+				Phase      string    `json:"phase,omitempty"`
+				StartedAt  time.Time `json:"startedAt,omitempty"`
+				FinishedAt time.Time `json:"finishedAt,omitempty"`
+			} `json:"operationState,omitempty"`
+			History []DeploymentHistory `json:"history,omitempty"`
+		}{
+			Sync: struct {
+				Status     string `json:"status,omitempty"`
+				ComparedTo struct {
+					Source *struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"source,omitempty"`
+					Sources []struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"sources,omitempty"`
+				} `json:"comparedTo"`
+				Revision  string   `json:"revision,omitempty"`
+				Revisions []string `json:"revisions,omitempty"`
+			}{Status: "Synced"},
+			Health: struct {
+				Status  string `json:"status,omitempty"`
+				Message string `json:"message,omitempty"`
+			}{Status: "Healthy"},
+		},
+	}
+
+	app := svc.ConvertToApp(argoApp)
+
+	if app.Name != "test-app" {
+		t.Errorf("Expected name 'test-app', got %s", app.Name)
+	}
+
+	if app.ApplicationSet == nil {
+		t.Fatal("Expected ApplicationSet to be set")
+	}
+
+	if *app.ApplicationSet != "my-appset" {
+		t.Errorf("Expected ApplicationSet 'my-appset', got %s", *app.ApplicationSet)
+	}
+}
+
+func TestConvertToApp_WithoutApplicationSet(t *testing.T) {
+	svc := &ApplicationService{}
+
+	argoApp := ArgoApplication{
+		Metadata: struct {
+			Name            string           `json:"name"`
+			Namespace       string           `json:"namespace,omitempty"`
+			OwnerReferences []OwnerReference `json:"ownerReferences,omitempty"`
+		}{
+			Name:            "standalone-app",
+			Namespace:       "argocd",
+			OwnerReferences: nil,
+		},
+		Status: struct {
+			Sync struct {
+				Status     string `json:"status,omitempty"`
+				ComparedTo struct {
+					Source *struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"source,omitempty"`
+					Sources []struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"sources,omitempty"`
+				} `json:"comparedTo"`
+				Revision  string   `json:"revision,omitempty"`
+				Revisions []string `json:"revisions,omitempty"`
+			} `json:"sync"`
+			Health struct {
+				Status  string `json:"status,omitempty"`
+				Message string `json:"message,omitempty"`
+			} `json:"health"`
+			OperationState struct {
+				Phase      string    `json:"phase,omitempty"`
+				StartedAt  time.Time `json:"startedAt,omitempty"`
+				FinishedAt time.Time `json:"finishedAt,omitempty"`
+			} `json:"operationState,omitempty"`
+			History []DeploymentHistory `json:"history,omitempty"`
+		}{
+			Sync: struct {
+				Status     string `json:"status,omitempty"`
+				ComparedTo struct {
+					Source *struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"source,omitempty"`
+					Sources []struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"sources,omitempty"`
+				} `json:"comparedTo"`
+				Revision  string   `json:"revision,omitempty"`
+				Revisions []string `json:"revisions,omitempty"`
+			}{Status: "Synced"},
+			Health: struct {
+				Status  string `json:"status,omitempty"`
+				Message string `json:"message,omitempty"`
+			}{Status: "Healthy"},
+		},
+	}
+
+	app := svc.ConvertToApp(argoApp)
+
+	if app.ApplicationSet != nil {
+		t.Errorf("Expected ApplicationSet to be nil for standalone app, got %v", *app.ApplicationSet)
+	}
+}
+
+func TestConvertToApp_WithOtherOwnerReference(t *testing.T) {
+	svc := &ApplicationService{}
+
+	// Test that apps with non-ApplicationSet owner references don't get an ApplicationSet field
+	argoApp := ArgoApplication{
+		Metadata: struct {
+			Name            string           `json:"name"`
+			Namespace       string           `json:"namespace,omitempty"`
+			OwnerReferences []OwnerReference `json:"ownerReferences,omitempty"`
+		}{
+			Name:      "app-with-other-owner",
+			Namespace: "argocd",
+			OwnerReferences: []OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "ConfigMap", // Not an ApplicationSet
+					Name:       "some-configmap",
+					UID:        "67890",
+				},
+			},
+		},
+		Status: struct {
+			Sync struct {
+				Status     string `json:"status,omitempty"`
+				ComparedTo struct {
+					Source *struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"source,omitempty"`
+					Sources []struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"sources,omitempty"`
+				} `json:"comparedTo"`
+				Revision  string   `json:"revision,omitempty"`
+				Revisions []string `json:"revisions,omitempty"`
+			} `json:"sync"`
+			Health struct {
+				Status  string `json:"status,omitempty"`
+				Message string `json:"message,omitempty"`
+			} `json:"health"`
+			OperationState struct {
+				Phase      string    `json:"phase,omitempty"`
+				StartedAt  time.Time `json:"startedAt,omitempty"`
+				FinishedAt time.Time `json:"finishedAt,omitempty"`
+			} `json:"operationState,omitempty"`
+			History []DeploymentHistory `json:"history,omitempty"`
+		}{
+			Sync: struct {
+				Status     string `json:"status,omitempty"`
+				ComparedTo struct {
+					Source *struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"source,omitempty"`
+					Sources []struct {
+						RepoURL        string `json:"repoURL,omitempty"`
+						Path           string `json:"path,omitempty"`
+						TargetRevision string `json:"targetRevision,omitempty"`
+					} `json:"sources,omitempty"`
+				} `json:"comparedTo"`
+				Revision  string   `json:"revision,omitempty"`
+				Revisions []string `json:"revisions,omitempty"`
+			}{Status: "Synced"},
+			Health: struct {
+				Status  string `json:"status,omitempty"`
+				Message string `json:"message,omitempty"`
+			}{Status: "Healthy"},
+		},
+	}
+
+	app := svc.ConvertToApp(argoApp)
+
+	if app.ApplicationSet != nil {
+		t.Errorf("Expected ApplicationSet to be nil for app with non-ApplicationSet owner, got %v", *app.ApplicationSet)
+	}
+}

--- a/pkg/autocomplete/autocomplete.go
+++ b/pkg/autocomplete/autocomplete.go
@@ -58,6 +58,13 @@ func NewAutocompleteEngine() *AutocompleteEngine {
 			ArgType:     "app",
 		},
 		{
+			Command:     "appset",
+			Aliases:     []string{"appset", "appsets", "applicationset", "applicationsets", "as"},
+			Description: "Navigate to ApplicationSets view",
+			TakesArg:    true,
+			ArgType:     "appset",
+		},
+		{
 			Command:     "sync",
 			Aliases:     []string{"sync", "s"},
 			Description: "Sync selected applications",
@@ -300,6 +307,8 @@ func (e *AutocompleteEngine) getArgumentSuggestions(command, argPrefix string, s
 		suggestions = e.getProjectSuggestions(argPrefix, state)
 	case "app":
 		suggestions = e.getAppSuggestions(argPrefix, state)
+	case "appset":
+		suggestions = e.getAppSetSuggestions(argPrefix, state)
 	case "theme":
 		suggestions = e.getThemeSuggestions(argPrefix)
 	case "sort":
@@ -391,6 +400,27 @@ func (e *AutocompleteEngine) getProjectSuggestions(prefix string, state *model.A
 		if strings.HasPrefix(project, prefix) && !seen[project] {
 			suggestions = append(suggestions, *app.Project)
 			seen[project] = true
+		}
+	}
+
+	sort.Strings(suggestions)
+	return suggestions
+}
+
+// getAppSetSuggestions returns unique ApplicationSet name suggestions
+func (e *AutocompleteEngine) getAppSetSuggestions(prefix string, state *model.AppState) []string {
+	var suggestions []string
+	seen := make(map[string]bool)
+
+	for _, app := range state.Apps {
+		if app.ApplicationSet == nil {
+			continue
+		}
+
+		appset := strings.ToLower(*app.ApplicationSet)
+		if strings.HasPrefix(appset, prefix) && !seen[appset] {
+			suggestions = append(suggestions, *app.ApplicationSet)
+			seen[appset] = true
 		}
 	}
 

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -17,19 +17,21 @@ type NavigationState struct {
 
 // SelectionState holds selection-related state using map[string]bool for sets
 type SelectionState struct {
-	ScopeClusters   map[string]bool `json:"scopeClusters"`
-	ScopeNamespaces map[string]bool `json:"scopeNamespaces"`
-	ScopeProjects   map[string]bool `json:"scopeProjects"`
-	SelectedApps    map[string]bool `json:"selectedApps"`
+	ScopeClusters        map[string]bool `json:"scopeClusters"`
+	ScopeNamespaces      map[string]bool `json:"scopeNamespaces"`
+	ScopeProjects        map[string]bool `json:"scopeProjects"`
+	ScopeApplicationSets map[string]bool `json:"scopeApplicationSets"`
+	SelectedApps         map[string]bool `json:"selectedApps"`
 }
 
 // NewSelectionState creates a new SelectionState with empty sets
 func NewSelectionState() *SelectionState {
 	return &SelectionState{
-		ScopeClusters:   NewStringSet(),
-		ScopeNamespaces: NewStringSet(),
-		ScopeProjects:   NewStringSet(),
-		SelectedApps:    NewStringSet(),
+		ScopeClusters:        NewStringSet(),
+		ScopeNamespaces:      NewStringSet(),
+		ScopeProjects:        NewStringSet(),
+		ScopeApplicationSets: NewStringSet(),
+		SelectedApps:         NewStringSet(),
 	}
 }
 
@@ -63,6 +65,16 @@ func (s *SelectionState) AddProject(project string) {
 // HasProject checks if a project is in scope
 func (s *SelectionState) HasProject(project string) bool {
 	return HasInStringSet(s.ScopeProjects, project)
+}
+
+// AddApplicationSet adds an application set to the scope
+func (s *SelectionState) AddApplicationSet(appset string) {
+	s.ScopeApplicationSets = AddToStringSet(s.ScopeApplicationSets, appset)
+}
+
+// HasApplicationSet checks if an application set is in scope
+func (s *SelectionState) HasApplicationSet(appset string) bool {
+	return HasInStringSet(s.ScopeApplicationSets, appset)
 }
 
 // AddSelectedApp adds an app to the selected apps
@@ -193,10 +205,11 @@ func (s *AppState) SaveNavigationState() {
 		LastZPressed:   s.Navigation.LastZPressed,
 	}
 	s.SavedSelections = &SelectionState{
-		ScopeClusters:   copyStringSet(s.Selections.ScopeClusters),
-		ScopeNamespaces: copyStringSet(s.Selections.ScopeNamespaces),
-		ScopeProjects:   copyStringSet(s.Selections.ScopeProjects),
-		SelectedApps:    copyStringSet(s.Selections.SelectedApps),
+		ScopeClusters:        copyStringSet(s.Selections.ScopeClusters),
+		ScopeNamespaces:      copyStringSet(s.Selections.ScopeNamespaces),
+		ScopeProjects:        copyStringSet(s.Selections.ScopeProjects),
+		ScopeApplicationSets: copyStringSet(s.Selections.ScopeApplicationSets),
+		SelectedApps:         copyStringSet(s.Selections.SelectedApps),
 	}
 }
 

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -8,11 +8,12 @@ import (
 type View string
 
 const (
-	ViewClusters   View = "clusters"
-	ViewNamespaces View = "namespaces"
-	ViewProjects   View = "projects"
-	ViewApps       View = "apps"
-	ViewTree       View = "tree"
+	ViewClusters        View = "clusters"
+	ViewNamespaces      View = "namespaces"
+	ViewProjects        View = "projects"
+	ViewApps            View = "apps"
+	ViewTree            View = "tree"
+	ViewApplicationSets View = "applicationsets"
 )
 
 // Mode represents the current application mode
@@ -43,15 +44,16 @@ const (
 
 // App represents an ArgoCD application
 type App struct {
-	Name         string     `json:"name"`
-	Sync         string     `json:"sync"`
-	Health       string     `json:"health"`
-	LastSyncAt   *time.Time `json:"lastSyncAt,omitempty"`
-	Project      *string    `json:"project,omitempty"`
-	ClusterID    *string    `json:"clusterId,omitempty"`
-	ClusterLabel *string    `json:"clusterLabel,omitempty"`
-	Namespace    *string    `json:"namespace,omitempty"`
-	AppNamespace *string    `json:"appNamespace,omitempty"`
+	Name           string     `json:"name"`
+	Sync           string     `json:"sync"`
+	Health         string     `json:"health"`
+	LastSyncAt     *time.Time `json:"lastSyncAt,omitempty"`
+	Project        *string    `json:"project,omitempty"`
+	ClusterID      *string    `json:"clusterId,omitempty"`
+	ClusterLabel   *string    `json:"clusterLabel,omitempty"`
+	Namespace      *string    `json:"namespace,omitempty"`
+	AppNamespace   *string    `json:"appNamespace,omitempty"`
+	ApplicationSet *string    `json:"applicationSet,omitempty"`
 }
 
 // Server represents an ArgoCD server configuration

--- a/pkg/services/navigation.go
+++ b/pkg/services/navigation.go
@@ -44,6 +44,7 @@ type NavigationUpdate struct {
 	ScopeClusters                   map[string]bool `json:"scopeClusters,omitempty"`
 	ScopeNamespaces                 map[string]bool `json:"scopeNamespaces,omitempty"`
 	ScopeProjects                   map[string]bool `json:"scopeProjects,omitempty"`
+	ScopeApplicationSets            map[string]bool `json:"scopeApplicationSets,omitempty"`
 	SelectedApps                    map[string]bool `json:"selectedApps,omitempty"`
 	ShouldResetNavigation           bool            `json:"shouldResetNavigation"`
 	ShouldClearLowerLevelSelections bool            `json:"shouldClearLowerLevelSelections"`
@@ -94,6 +95,10 @@ func (s *NavigationServiceImpl) DrillDown(currentView model.View, selectedItem i
 		newView := model.ViewApps
 		result.NewView = &newView
 		result.ScopeProjects = next
+	case model.ViewApplicationSets:
+		newView := model.ViewApps
+		result.NewView = &newView
+		result.ScopeApplicationSets = next
 	default:
 		return nil // Can't drill down from apps view
 	}


### PR DESCRIPTION
Add a new ApplicationSet view that allows users to navigate and filter applications by their parent ApplicationSet. This provides a way to drill-down from ApplicationSets to their managed applications.

Features:
- New :appsets/:applicationsets command to show list of ApplicationSets
- New :appset <name> command to filter apps by ApplicationSet
- Drill-down navigation from ApplicationSets list to filtered apps
- Escape navigation returns from filtered apps to ApplicationSets
- Breadcrumb shows <apps in appsetname> when scoped by ApplicationSet
- Search/filter works in ApplicationSets view

Implementation:
- Parse ownerReferences from ArgoCD API to extract ApplicationSet name
- Add ViewApplicationSets view type and ScopeApplicationSets state
- Add appset command with aliases: appset, appsets, applicationset, applicationsets, as
- Update help modal to show new commands

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* ApplicationSet view with new navigation commands (:appset, :appsets, :applicationset, :applicationsets, :as)
* Scope-based filtering to display only apps associated with selected ApplicationSets
* Drill-down navigation from ApplicationSets to filtered applications
* Enhanced status display showing active ApplicationSet scope with filter context
* Input validation for ApplicationSet selection with user-friendly error messages

**Tests**
* Added comprehensive end-to-end and unit tests for ApplicationSet workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->