### PR TITLE
chore: make ApplicationSet breadcrumb display deterministic

### DIFF
--- a/cmd/app/view_status.go
+++ b/cmd/app/view_status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,12 +18,13 @@ func (m *Model) renderStatusLine() string {
 	leftText := fmt.Sprintf("<%s>", m.state.Navigation.View)
 	// Show ApplicationSet scope in the breadcrumb when filtering apps by ApplicationSet
 	if m.state.Navigation.View == model.ViewApps && len(m.state.Selections.ScopeApplicationSets) > 0 {
-		// Get the first (and typically only) ApplicationSet name from the scope
-		var appsetName string
+		// Get ApplicationSet names sorted for deterministic display
+		appsetNames := make([]string, 0, len(m.state.Selections.ScopeApplicationSets))
 		for name := range m.state.Selections.ScopeApplicationSets {
-			appsetName = name
-			break
+			appsetNames = append(appsetNames, name)
 		}
+		sort.Strings(appsetNames)
+		appsetName := appsetNames[0] // Use first name alphabetically
 		if m.state.UI.ActiveFilter != "" {
 			leftText = fmt.Sprintf("<apps in %s:%s>", appsetName, m.state.UI.ActiveFilter)
 		} else {


### PR DESCRIPTION
Sort ApplicationSet names before picking one for display to avoid nondeterministic map iteration order in Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic ordering of ApplicationSet scope display to ensure consistent and predictable results across runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->