### PR TITLE
Move env vars to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,107 @@ argonaut --ca-cert=/path/to/ca.crt
 
 ---
 
+## ⚙️ Configuration
+
+Argonaut stores its configuration in a TOML file at:
+- **Linux/macOS**: `~/.config/argonaut/config.toml` (or `$XDG_CONFIG_HOME/argonaut/config.toml`)
+- **Windows**: `%APPDATA%\argonaut\config.toml`
+
+You can override the config path with the `ARGONAUT_CONFIG` environment variable.
+
+### Example Configuration
+
+```toml
+[appearance]
+theme = "tokyo-night"
+
+[appearance.overrides]
+# Override individual theme colors (hex format)
+# accent = "#ff79c6"
+# success = "#50fa7b"
+
+[sort]
+field = "name"      # name, sync, health
+direction = "asc"   # asc, desc
+
+[k9s]
+command = "k9s"           # Path to k9s executable
+context = ""              # Override Kubernetes context for k9s
+
+[diff]
+viewer = ""               # Interactive diff viewer (e.g., "code --diff {left} {right}", "meld {left} {right}")
+formatter = ""            # Diff formatter command (e.g., "delta --side-by-side")
+```
+
+### Configuration Options
+
+#### `[appearance]`
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `theme` | Color theme name (see available themes below) | `tokyo-night` |
+
+**Available themes:**
+- **Dark themes**: `catppuccin-mocha`, `dracula`, `gruvbox-dark`, `monokai`, `nord`, `one-dark`, `oxocarbon`, `solarized-dark`, `tokyo-night`, `tokyo-storm`
+- **Light themes**: `catppuccin-latte`, `gruvbox-light`, `one-light`, `onehalf-light`, `solarized-light`
+- **Accessibility**: `colorblind-safe`, `grayscale-lowchroma`, `high-contrast`
+- **Special**: `inherit-terminal` (uses your terminal's ANSI color palette)
+
+You can also change the theme at runtime using the `:theme <name>` command.
+
+#### `[appearance.overrides]`
+
+Override individual theme colors with hex values. Available color keys:
+- `accent`, `warning`, `dim`, `success`, `danger`, `progress`, `unknown`, `info`, `text`, `gray`
+- `selected_bg`, `cursor_selected_bg`, `cursor_bg`, `border`, `muted_bg`, `shade_bg`, `dark_bg`
+
+#### `[sort]`
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `field` | Sort field (`name`, `sync`, `health`) | `name` |
+| `direction` | Sort direction (`asc`, `desc`) | `asc` |
+
+You can also change sorting at runtime using the `:sort <field> <direction>` command.
+
+#### `[k9s]`
+
+Integration settings for [k9s](https://k9scli.io), the Kubernetes TUI.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `command` | Path to k9s executable | `k9s` |
+| `context` | Override Kubernetes context when launching k9s | (none) |
+
+Press `K` on a resource in the tree view to open it in k9s.
+
+#### `[diff]`
+
+Settings for diff viewing and formatting.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `viewer` | Interactive diff viewer command. Use `{left}` and `{right}` as placeholders for file paths. | (none) |
+| `formatter` | Non-interactive diff formatter piped through before display | (none, falls back to `delta` if installed) |
+
+**Examples:**
+
+```toml
+[diff]
+# Use VS Code as diff viewer
+viewer = "code --diff {left} {right} --wait"
+
+# Use meld as diff viewer
+viewer = "meld {left} {right}"
+
+# Use delta with custom options
+formatter = "delta --side-by-side --line-numbers"
+```
+
+If no `viewer` is set, diffs are shown in an internal pager. If no `formatter` is set but [delta](https://dandavison.github.io/delta/) is installed, it will be used automatically.
+
+---
+
 ## 🤝 Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.

--- a/README.md
+++ b/README.md
@@ -193,9 +193,7 @@ argonaut --ca-cert=/path/to/ca.crt
 
 ## ⚙️ Configuration
 
-Argonaut stores its configuration in a TOML file at:
-- **Linux/macOS**: `~/.config/argonaut/config.toml` (or `$XDG_CONFIG_HOME/argonaut/config.toml`)
-- **Windows**: `%APPDATA%\argonaut\config.toml`
+Argonaut stores its configuration in a TOML file at `~/.config/argonaut/config.toml` (or `$XDG_CONFIG_HOME/argonaut/config.toml`).
 
 You can override the config path with the `ARGONAUT_CONFIG` environment variable.
 

--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -279,7 +279,7 @@ func (m *Model) startDiffSession(appName string) tea.Cmd {
 		m.state.Diff.Loading = false
 
 		// 1) Interactive diff viewer: replace the terminal (e.g., vimdiff, meld)
-		if viewer := os.Getenv("ARGONAUT_DIFF_VIEWER"); viewer != "" {
+		if viewer := m.config.GetDiffViewer(); viewer != "" {
 			return m.openInteractiveDiffViewer(leftFile, rightFile, viewer)
 		}
 
@@ -370,7 +370,7 @@ func (m *Model) startResourceDiffSession(appName, group, kind, namespace, name s
 		m.state.Diff.Loading = false
 
 		// Support interactive diff viewer
-		if viewer := os.Getenv("ARGONAUT_DIFF_VIEWER"); viewer != "" {
+		if viewer := m.config.GetDiffViewer(); viewer != "" {
 			return m.openInteractiveDiffViewer(leftFile, rightFile, viewer)
 		}
 

--- a/cmd/app/input_handlers_delete_test.go
+++ b/cmd/app/input_handlers_delete_test.go
@@ -32,7 +32,7 @@ func testKeyMsg(s string) tea.KeyMsg {
 
 // Test helper to create model for delete testing
 func buildDeleteTestModel(cols, rows int) *Model {
-	m := NewModel()
+	m := NewModel(nil)
 	m.ready = true
 	m.state.Terminal.Cols = cols
 	m.state.Terminal.Rows = rows

--- a/cmd/app/k9s_sandbox.go
+++ b/cmd/app/k9s_sandbox.go
@@ -38,10 +38,7 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 		}()
 
 		// Check if k9s is available
-		k9sCmd := os.Getenv("ARGONAUT_K9S_COMMAND")
-		if k9sCmd == "" {
-			k9sCmd = "k9s"
-		}
+		k9sCmd := m.config.GetK9sCommand()
 		if !inPath(k9sCmd) {
 			cblog.With("component", "k9s").Error("k9s not found in PATH")
 			return k9sDoneMsg{Err: fmt.Errorf("k9s not found in PATH")}
@@ -61,9 +58,9 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 			args = append(args, "-n", namespace)
 		}
 
-		// Allow context override via environment variable
-		if envCtx := os.Getenv("ARGONAUT_K9S_CONTEXT"); envCtx != "" {
-			context = envCtx
+		// Allow context override via config
+		if cfgCtx := m.config.GetK9sContext(); cfgCtx != "" {
+			context = cfgCtx
 		}
 		if context != "" {
 			args = append(args, "--context", context)

--- a/cmd/app/k9s_sandbox_other.go
+++ b/cmd/app/k9s_sandbox_other.go
@@ -31,10 +31,7 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 		}()
 
 		// Check if k9s is available
-		k9sCmd := os.Getenv("ARGONAUT_K9S_COMMAND")
-		if k9sCmd == "" {
-			k9sCmd = "k9s"
-		}
+		k9sCmd := m.config.GetK9sCommand()
 		if !inPath(k9sCmd) {
 			cblog.With("component", "k9s").Error("k9s not found in PATH")
 			return k9sDoneMsg{Err: fmt.Errorf("k9s not found in PATH")}
@@ -54,9 +51,9 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 			args = append(args, "-n", namespace)
 		}
 
-		// Allow context override via environment variable
-		if envCtx := os.Getenv("ARGONAUT_K9S_CONTEXT"); envCtx != "" {
-			context = envCtx
+		// Allow context override via config
+		if cfgCtx := m.config.GetK9sContext(); cfgCtx != "" {
+			context = cfgCtx
 		}
 		if context != "" {
 			args = append(args, "--context", context)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -201,7 +201,7 @@ func main() {
 	applyTheme(palette)
 
 	// Create the initial model
-	m := NewModel()
+	m := NewModel(argonautConfig)
 
 	// Check if this is a new version (for "what's new" notification)
 	if appVersion != "dev" {

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -12,6 +12,7 @@ import (
 	cblog "github.com/charmbracelet/log"
 	"github.com/darksworm/argonaut/pkg/api"
 	"github.com/darksworm/argonaut/pkg/autocomplete"
+	"github.com/darksworm/argonaut/pkg/config"
 	apperrors "github.com/darksworm/argonaut/pkg/errors"
 	"github.com/darksworm/argonaut/pkg/model"
 	"github.com/darksworm/argonaut/pkg/services"
@@ -30,6 +31,9 @@ type Model struct {
 	navigationService services.NavigationService
 	statusService     services.StatusService
 	updateService     services.UpdateService
+
+	// Configuration
+	config *config.ArgonautConfig
 
 	// Interactive input components using bubbles
 	inputComponents *InputComponentState

--- a/cmd/app/model_init.go
+++ b/cmd/app/model_init.go
@@ -12,13 +12,19 @@ import (
 	cblog "github.com/charmbracelet/log"
 	"github.com/darksworm/argonaut/pkg/api"
 	"github.com/darksworm/argonaut/pkg/autocomplete"
+	"github.com/darksworm/argonaut/pkg/config"
 	"github.com/darksworm/argonaut/pkg/model"
 	"github.com/darksworm/argonaut/pkg/services"
 	"github.com/darksworm/argonaut/pkg/tui/listnav"
 	"github.com/darksworm/argonaut/pkg/tui/treeview"
 )
 
-func NewModel() *Model {
+func NewModel(cfg *config.ArgonautConfig) *Model {
+	// Use default config if none provided
+	if cfg == nil {
+		cfg = config.GetDefaultConfig()
+	}
+
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(magentaBright)
@@ -42,6 +48,7 @@ func NewModel() *Model {
 		navigationService:  services.NewNavigationService(),
 		statusService:      services.NewStatusService(services.StatusServiceConfig{Handler: createFileStatusHandler(), DebugEnabled: true}),
 		updateService:      updateService,
+		config:             cfg,
 		inputComponents:    NewInputComponents(),
 		autocompleteEngine: autocomplete.NewAutocompleteEngine(),
 		ready:              false,

--- a/cmd/app/model_pager.go
+++ b/cmd/app/model_pager.go
@@ -87,7 +87,7 @@ func (m *Model) runDiffFormatter(diffText string) (string, error) {
 
 // runDiffFormatterWithTitle runs a diff formatter with optional resource name for better headers
 func (m *Model) runDiffFormatterWithTitle(diffText string, resourceName string) (string, error) {
-	cmdStr := os.Getenv("ARGONAUT_DIFF_FORMATTER")
+	cmdStr := m.config.GetDiffFormatter()
 	cols := 0
 	if m.state != nil {
 		cols = m.state.Terminal.Cols

--- a/cmd/app/view_modals_golden_test.go
+++ b/cmd/app/view_modals_golden_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func buildBaseModel(cols, rows int) *Model {
-	m := NewModel()
+	m := NewModel(nil)
 	m.ready = true
 	m.state.Terminal.Cols = cols
 	m.state.Terminal.Rows = rows

--- a/cmd/app/view_render_test.go
+++ b/cmd/app/view_render_test.go
@@ -14,7 +14,7 @@ func stringPtr(s string) *string {
 
 // buildTestModelWithApps creates a minimal model configured for a deterministic list view.
 func buildTestModelWithApps(cols, rows int) *Model {
-	m := NewModel()
+	m := NewModel(nil)
 	m.ready = true
 	m.state.Terminal.Cols = cols
 	m.state.Terminal.Rows = rows

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -163,8 +163,12 @@ func GetConfigPathForHelp() string {
 	return GetArgonautConfigPath()
 }
 
-// GetK9sCommand returns the k9s command path, defaulting to "k9s" if not configured
+// GetK9sCommand returns the k9s command path, defaulting to "k9s" if not configured.
+// Priority: ARGONAUT_K9S_COMMAND env var > config file > default "k9s"
 func (c *ArgonautConfig) GetK9sCommand() string {
+	if envCmd := os.Getenv("ARGONAUT_K9S_COMMAND"); envCmd != "" {
+		return envCmd
+	}
 	if c.K9s.Command != "" {
 		return c.K9s.Command
 	}

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -16,6 +16,8 @@ const DefaultThemeName = "tokyo-night"
 type ArgonautConfig struct {
 	Appearance      AppearanceConfig `toml:"appearance"`
 	Sort            SortConfig       `toml:"sort,omitempty"`
+	K9s             K9sConfig        `toml:"k9s,omitempty"`
+	Diff            DiffConfig       `toml:"diff,omitempty"`
 	LastSeenVersion string           `toml:"last_seen_version,omitempty"`
 }
 
@@ -29,6 +31,18 @@ type AppearanceConfig struct {
 type SortConfig struct {
 	Field     string `toml:"field"`
 	Direction string `toml:"direction"`
+}
+
+// K9sConfig holds k9s integration settings
+type K9sConfig struct {
+	Command string `toml:"command,omitempty"` // Path to k9s executable (default: "k9s")
+	Context string `toml:"context,omitempty"` // Override Kubernetes context for k9s
+}
+
+// DiffConfig holds diff viewer/formatter settings
+type DiffConfig struct {
+	Viewer    string `toml:"viewer,omitempty"`    // External diff viewer command (e.g., "code --diff {left} {right}")
+	Formatter string `toml:"formatter,omitempty"` // Diff formatter command (e.g., "delta")
 }
 
 
@@ -147,4 +161,27 @@ func SaveArgonautConfig(config *ArgonautConfig) error {
 // GetConfigPathForHelp returns the config path for display in help text
 func GetConfigPathForHelp() string {
 	return GetArgonautConfigPath()
+}
+
+// GetK9sCommand returns the k9s command path, defaulting to "k9s" if not configured
+func (c *ArgonautConfig) GetK9sCommand() string {
+	if c.K9s.Command != "" {
+		return c.K9s.Command
+	}
+	return "k9s"
+}
+
+// GetK9sContext returns the k9s context override, or empty string if not configured
+func (c *ArgonautConfig) GetK9sContext() string {
+	return c.K9s.Context
+}
+
+// GetDiffViewer returns the external diff viewer command, or empty string if not configured
+func (c *ArgonautConfig) GetDiffViewer() string {
+	return c.Diff.Viewer
+}
+
+// GetDiffFormatter returns the diff formatter command, or empty string if not configured
+func (c *ArgonautConfig) GetDiffFormatter() string {
+	return c.Diff.Formatter
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now reads k9s command/context and diff viewer/formatter from the configuration file, with defaults preserved when unset; settings persist across runs.

* **Documentation**
  * README gains a comprehensive "Configuration" section with examples, option tables, and usage notes.

* **Tests**
  * Added tests validating k9s and diff configuration and save/load behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

BEGIN_COMMIT_OVERRIDE
feat: Move env vars to config
END_COMMIT_OVERRIDE