### PR TITLE
chore: add vt10x terminal emulator to E2E test framework

### DIFF
--- a/e2e/pageupdown_test.go
+++ b/e2e/pageupdown_test.go
@@ -55,59 +55,29 @@ func MockArgoServerManyApps(numApps int) (*httptest.Server, error) {
 	return srv, nil
 }
 
-// extractCursorPosition extracts the current cursor position from status line like "Ready • 30/35" or "Ready • 30"
-// Returns the current position (1-indexed) or 0 if not found
-func extractCursorPosition(snapshot string) int {
-	// Match both "Ready • N/M" and "Ready • N" patterns
-	// We want the LAST occurrence in the buffer since that's the most recent screen state
+// extractCursorPosition extracts the current cursor position from screen content.
+// Expects the screen content from tf.Screen() which properly interprets cursor positioning.
+// Returns the current position (1-indexed) or 0 if not found.
+func extractCursorPosition(screen string) int {
+	// Match "Ready • N/M" pattern - the standard format in apps view
 	reWithTotal := regexp.MustCompile(`Ready • (\d+)/(\d+)`)
-	reSimple := regexp.MustCompile(`Ready • (\d+)`)
 
-	// Find the last index of each pattern type
-	matchesWithTotal := reWithTotal.FindAllStringSubmatchIndex(snapshot, -1)
-	matchesSimple := reSimple.FindAllStringSubmatchIndex(snapshot, -1)
-
-	var lastPos int
-	var lastIndex int = -1
-
-	// Check "N/M" format matches (filter out 1/1 from clusters)
-	for _, matchIdx := range matchesWithTotal {
-		// matchIdx[2:4] is the position number, matchIdx[4:6] is the total
-		posStr := snapshot[matchIdx[2]:matchIdx[3]]
-		totalStr := snapshot[matchIdx[4]:matchIdx[5]]
-		var total int
-		fmt.Sscanf(totalStr, "%d", &total)
-		if total > 1 && matchIdx[0] > lastIndex {
-			lastIndex = matchIdx[0]
-			fmt.Sscanf(posStr, "%d", &lastPos)
-		}
-	}
-
-	// Check simple "N" format matches - always consider if later, even for position 1
-	// The "Ready • N" format without total is used in apps view
-	for _, matchIdx := range matchesSimple {
-		// Only consider if this is later in the buffer than our current best
-		if matchIdx[0] > lastIndex {
-			posStr := snapshot[matchIdx[2]:matchIdx[3]]
-			var pos int
-			fmt.Sscanf(posStr, "%d", &pos)
-			lastIndex = matchIdx[0]
-			lastPos = pos
-		}
-	}
-
-	// Also check for "N/" pattern at the very end (truncated status line)
-	rePartial := regexp.MustCompile(`(\d+)/$`)
-	if partialMatch := rePartial.FindStringSubmatch(snapshot); partialMatch != nil {
+	// Find the match (should be unique in rendered screen)
+	if match := reWithTotal.FindStringSubmatch(screen); match != nil {
 		var pos int
-		fmt.Sscanf(partialMatch[1], "%d", &pos)
-		// This is at the very end, so it's the most recent
-		if pos > 0 {
-			return pos
-		}
+		fmt.Sscanf(match[1], "%d", &pos)
+		return pos
 	}
 
-	return lastPos
+	// Fallback: try simple "Ready • N" pattern
+	reSimple := regexp.MustCompile(`Ready • (\d+)`)
+	if match := reSimple.FindStringSubmatch(screen); match != nil {
+		var pos int
+		fmt.Sscanf(match[1], "%d", &pos)
+		return pos
+	}
+
+	return 0
 }
 
 // waitForCursorPosition waits until the cursor position changes to a value >= minPos
@@ -116,8 +86,8 @@ func waitForCursorPosition(tf *TUITestFramework, minPos int, timeout time.Durati
 	var lastPos int
 	var iterations int
 	for time.Now().Before(deadline) {
-		snap := tf.SnapshotPlain()
-		pos := extractCursorPosition(snap)
+		screen := tf.Screen()
+		pos := extractCursorPosition(screen)
 		lastPos = pos
 		iterations++
 		if pos >= minPos {
@@ -134,7 +104,7 @@ func waitForCursorPosition(tf *TUITestFramework, minPos int, timeout time.Durati
 func waitForCursorPositionExact(tf *TUITestFramework, target int, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		pos := extractCursorPosition(tf.SnapshotPlain())
+		pos := extractCursorPosition(tf.Screen())
 		if pos == target {
 			return true
 		}
@@ -202,8 +172,8 @@ func TestPageDownFromStart(t *testing.T) {
 
 	// Verify initial state - cursor should be at position 1
 	if !waitForCursorPositionExact(tf, 1, 3*time.Second) {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor at position 1 initially, got %d\nSnapshot:\n%s", extractCursorPosition(snap), snap)
+		screen := tf.Screen()
+		t.Fatalf("expected cursor at position 1 initially, got %d\nScreen:\n%s", extractCursorPosition(screen), screen)
 	}
 
 	// Wait for UI to stabilize before sending PageDown
@@ -216,8 +186,8 @@ func TestPageDownFromStart(t *testing.T) {
 	// The exact amount depends on viewport height, but should be substantial
 	// Using a lower threshold (10) to be more robust across different environments
 	if !waitForCursorPosition(tf, 10, 5*time.Second) {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor position >= 10 after PageDown, got %d\nSnapshot:\n%s", extractCursorPosition(snap), snap)
+		screen := tf.Screen()
+		t.Fatalf("expected cursor position >= 10 after PageDown, got %d\nScreen:\n%s", extractCursorPosition(screen), screen)
 	}
 }
 
@@ -315,10 +285,10 @@ func TestPageUpFromEnd(t *testing.T) {
 
 	// After PageUp from the end, we should see earlier apps (around app-01 to app-10)
 	// Check cursor position moved to a lower value
-	pos := extractCursorPosition(tf.SnapshotPlain())
+	screen := tf.Screen()
+	pos := extractCursorPosition(screen)
 	if pos > 10 {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor position <= 10 after PageUp from end, got %d\nSnapshot:\n%s", pos, snap)
+		t.Fatalf("expected cursor position <= 10 after PageUp from end, got %d\nScreen:\n%s", pos, screen)
 	}
 }
 
@@ -350,28 +320,28 @@ func TestPageUpAtStart(t *testing.T) {
 
 	// Verify we start at position 1
 	if !waitForCursorPositionExact(tf, 1, 2*time.Second) {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor at position 1 initially, got %d\nSnapshot:\n%s", extractCursorPosition(snap), snap)
+		screen := tf.Screen()
+		t.Fatalf("expected cursor at position 1 initially, got %d\nScreen:\n%s", extractCursorPosition(screen), screen)
 	}
 
 	// Press PageUp at the start - should not crash or go negative, should stay at 1
 	_ = tf.Send("\x1b[5~")
 	time.Sleep(200 * time.Millisecond)
 
-	pos := extractCursorPosition(tf.SnapshotPlain())
+	screen := tf.Screen()
+	pos := extractCursorPosition(screen)
 	if pos != 1 {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor to stay at position 1 after PageUp at start, got %d\nSnapshot:\n%s", pos, snap)
+		t.Fatalf("expected cursor to stay at position 1 after PageUp at start, got %d\nScreen:\n%s", pos, screen)
 	}
 
 	// Press PageUp again - still should stay at 1
 	_ = tf.Send("\x1b[5~")
 	time.Sleep(200 * time.Millisecond)
 
-	pos = extractCursorPosition(tf.SnapshotPlain())
+	screen = tf.Screen()
+	pos = extractCursorPosition(screen)
 	if pos != 1 {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor to stay at position 1 after multiple PageUps at start, got %d\nSnapshot:\n%s", pos, snap)
+		t.Fatalf("expected cursor to stay at position 1 after multiple PageUps at start, got %d\nScreen:\n%s", pos, screen)
 	}
 }
 
@@ -403,8 +373,8 @@ func TestPageUpDownRoundTrip(t *testing.T) {
 
 	// Verify initial state - cursor at position 1
 	if !waitForCursorPositionExact(tf, 1, 3*time.Second) {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor at position 1 initially, got %d\nSnapshot:\n%s", extractCursorPosition(snap), snap)
+		screen := tf.Screen()
+		t.Fatalf("expected cursor at position 1 initially, got %d\nScreen:\n%s", extractCursorPosition(screen), screen)
 	}
 
 	// Wait for UI to stabilize
@@ -415,8 +385,8 @@ func TestPageUpDownRoundTrip(t *testing.T) {
 
 	// Should move to a higher position (at least 10)
 	if !waitForCursorPosition(tf, 10, 5*time.Second) {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor position >= 10 after PageDown, got %d\nSnapshot:\n%s", extractCursorPosition(snap), snap)
+		screen := tf.Screen()
+		t.Fatalf("expected cursor position >= 10 after PageDown, got %d\nScreen:\n%s", extractCursorPosition(screen), screen)
 	}
 
 	// Wait before PageUp
@@ -427,7 +397,7 @@ func TestPageUpDownRoundTrip(t *testing.T) {
 
 	// Should be back at position 1
 	if !waitForCursorPositionExact(tf, 1, 5*time.Second) {
-		snap := tf.SnapshotPlain()
-		t.Fatalf("expected cursor at position 1 after PageDown+PageUp round trip, got %d\nSnapshot:\n%s", extractCursorPosition(snap), snap)
+		screen := tf.Screen()
+		t.Fatalf("expected cursor at position 1 after PageDown+PageUp round trip, got %d\nScreen:\n%s", extractCursorPosition(screen), screen)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,12 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
 	github.com/charmbracelet/log v0.4.2
 	github.com/creack/pty v1.1.24
+	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	golang.org/x/oauth2 v0.31.0
+	golang.org/x/term v0.37.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -34,7 +37,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.17 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
@@ -42,6 +44,5 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/term v0.37.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs104wLj8l5GEththEw6+F79YsIY=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -81,8 +83,6 @@ golang.org/x/oauth2 v0.31.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwE
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=


### PR DESCRIPTION
Integrate vt10x terminal emulator into TUITestFramework for accurate screen state capture. This properly interprets cursor positioning and ANSI sequences, giving us the actual rendered screen content instead of just raw output.

- Add Screen() method that returns the real terminal display
- Add WaitForScreen() to wait for content in rendered output
- Update pageupdown tests to use the new Screen() method
- Add hinshun/vt10x dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E testing framework with improved terminal screen capture and accurate state tracking, improving test reliability.
  * Added new testing utilities for asserting on rendered screen content and providing comprehensive failure diagnostics with visual screen snapshots.

* **Chores**
  * Updated dependencies to support improved terminal emulation features in testing infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

BEGIN_COMMIT_OVERRIDE
chore: add vt10x terminal emulator to E2E test framework
END_COMMIT_OVERRIDE