### PR TITLE
chore: require exact context match for k9s to prevent wrong cluster access

### DIFF
--- a/e2e/k9s_test.go
+++ b/e2e/k9s_test.go
@@ -32,8 +32,8 @@ func TestK9s_NotFound_ShowsErrorModal(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	// Setup kubeconfig with single context (to skip context picker)
-	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "test-context")
+	// Setup kubeconfig with context matching the ArgoCD cluster name for exact match
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
 
 	// Start app with non-existent k9s command
 	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
@@ -122,7 +122,7 @@ func TestK9s_NoResourceSelected_ShowsStatus(t *testing.T) {
 
 	// Create mock k9s (we shouldn't need it, but set it up anyway)
 	mockK9s, argsFile := createMockK9s(t, tf.workspace, 0)
-	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "test-context")
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
 
 	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
 		"ARGONAUT_K9S_COMMAND="+mockK9s,
@@ -197,7 +197,7 @@ func TestK9s_OpenDeploymentResource(t *testing.T) {
 	}
 
 	mockK9s, argsFile := createMockK9s(t, tf.workspace, 0)
-	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "test-context")
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
 
 	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
 		"ARGONAUT_K9S_COMMAND="+mockK9s,
@@ -263,9 +263,9 @@ func TestK9s_OpenDeploymentResource(t *testing.T) {
 		t.Errorf("expected args to contain '-n default', got: %s", args)
 	}
 
-	// Should contain --context test-context
-	if !strings.Contains(args, "--context test-context") {
-		t.Errorf("expected args to contain '--context test-context', got: %s", args)
+	// Should contain --context cluster-a (matches ArgoCD cluster name)
+	if !strings.Contains(args, "--context cluster-a") {
+		t.Errorf("expected args to contain '--context cluster-a', got: %s", args)
 	}
 }
 
@@ -291,7 +291,7 @@ func TestK9s_OpenServiceResource(t *testing.T) {
 	}
 
 	mockK9s, argsFile := createMockK9s(t, tf.workspace, 0)
-	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "test-context")
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
 
 	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
 		"ARGONAUT_K9S_COMMAND="+mockK9s,
@@ -379,7 +379,7 @@ func TestK9s_TerminalRestoredAfterExit(t *testing.T) {
 	}
 
 	mockK9s, _ := createMockK9s(t, tf.workspace, 0)
-	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "test-context")
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
 
 	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
 		"ARGONAUT_K9S_COMMAND="+mockK9s,
@@ -732,7 +732,7 @@ func TestK9s_KeyboardInputForwarded(t *testing.T) {
 
 	// Use interactive mock that captures stdin
 	mockK9s, _, inputFile := createInteractiveMockK9s(t, tf.workspace)
-	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "test-context")
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
 
 	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
 		"ARGONAUT_K9S_COMMAND="+mockK9s,


### PR DESCRIPTION
- Remove substring URL matching that could match similar clusters
- Remove fallback to current kubeconfig context
- Always show context picker when no exact match (even with single context)
- User must explicitly confirm context selection for safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Context picker now always appears and requires explicit user selection before launching K9s, even when only one context exists.
  * Context lookup uses strict exact matching for cluster IDs; fuzzy/partial matches and automatic fallbacks are removed.

* **Tests**
  * Test suite updated to validate mandatory context selection and exact-match context resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->