### PR TITLE
feat: add support for ArgoCD CLI --port-forward access mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,29 @@ If your Argo CD server uses a self-signed certificate, you can provide a custom 
 argonaut --ca-cert=/path/to/ca.crt
 ```
 
+### Port-forward mode
+
+If your Argo CD server isn't directly accessible (e.g., running in a private cluster), Argonaut can connect via kubectl port-forward:
+
+```bash
+# Configure ArgoCD CLI for port-forward mode
+argocd login --port-forward --port-forward-namespace argocd
+
+# Start Argonaut (automatically detects port-forward mode)
+argonaut
+```
+
+**Requirements:**
+- `kubectl` configured with access to the cluster
+- ArgoCD server pod running in the target namespace
+
+**Custom namespace:** If ArgoCD is installed in a different namespace, add to your config:
+```toml
+# ~/.config/argonaut/config.toml
+[port_forward]
+namespace = "my-argocd-namespace"
+```
+
 ---
 
 ## ⚙️ Configuration
@@ -287,6 +310,14 @@ formatter = "delta --side-by-side --line-numbers"
 ```
 
 If no `viewer` is set, diffs are shown in an internal pager. If no `formatter` is set but [delta](https://dandavison.github.io/delta/) is installed, it will be used automatically.
+
+#### `[port_forward]`
+
+Settings for port-forward mode (when ArgoCD CLI is configured with `server: port-forward`).
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `namespace` | Kubernetes namespace where ArgoCD is installed | `argocd` |
 
 ---
 

--- a/e2e/portforward_test.go
+++ b/e2e/portforward_test.go
@@ -1,0 +1,205 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPortForward_HappyPath verifies the complete port-forward flow:
+// - Config detection (server: port-forward)
+// - kubectl mock finds pod and outputs port
+// - App connects to mock ArgoCD server via that port
+// - App displays application list normally
+func TestPortForward_HappyPath(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	// Setup mock ArgoCD server (this is what we'll actually connect to)
+	srv, err := MockArgoServer()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+
+	// Write port-forward ArgoCD config
+	if err := WriteArgoConfigPortForward(cfgPath, "test-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Create mock kubectl - report the mock server's port so traffic routes correctly
+	opts := DefaultMockKubectlOptions()
+	opts.LocalPort = extractPortFromURL(srv.URL)
+
+	mockKubectl, argsFile := createMockKubectl(t, tf.workspace, opts)
+
+	// Start app with mock kubectl first in PATH
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
+		"PATH="+filepath.Dir(mockKubectl)+":"+os.Getenv("PATH"),
+	); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Should see cluster from mock server (proves tunnel worked)
+	// The app initially shows clusters view with "cluster-a" from our mock server
+	if !tf.WaitForPlain("cluster-a", 10*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected to see 'cluster-a' after port-forward established")
+	}
+
+	// Verify kubectl was called correctly
+	args := readMockKubectlArgs(t, argsFile)
+	if len(args) < 2 {
+		t.Fatalf("expected at least 2 kubectl calls (version + get pods), got %d: %v", len(args), args)
+	}
+
+	// Verify get pods was called with correct selector
+	foundGetPods := false
+	for _, arg := range args {
+		if strings.Contains(arg, "get") &&
+			strings.Contains(arg, "pods") &&
+			strings.Contains(arg, "-n argocd") &&
+			strings.Contains(arg, "app.kubernetes.io/name=argocd-server") {
+			foundGetPods = true
+			break
+		}
+	}
+	if !foundGetPods {
+		t.Errorf("expected kubectl get pods with argocd namespace and selector, got: %v", args)
+	}
+
+	// Verify port-forward was called
+	foundPortForward := false
+	for _, arg := range args {
+		if strings.Contains(arg, "port-forward") &&
+			strings.Contains(arg, "argocd-server") {
+			foundPortForward = true
+			break
+		}
+	}
+	if !foundPortForward {
+		t.Errorf("expected kubectl port-forward call, got: %v", args)
+	}
+}
+
+// TestPortForward_NoPodFound verifies error handling when no ArgoCD server pod is found.
+// The app should show helpful troubleshooting tips.
+func TestPortForward_NoPodFound(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+
+	if err := WriteArgoConfigPortForward(cfgPath, "test-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Create mock kubectl that returns empty pod list
+	opts := DefaultMockKubectlOptions()
+	opts.PodName = "" // No pods found
+
+	mockKubectl, _ := createMockKubectl(t, tf.workspace, opts)
+
+	// Start app with mock kubectl first in PATH
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
+		"PATH="+filepath.Dir(mockKubectl)+":"+os.Getenv("PATH"),
+	); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Wait for error output - the app should exit with error
+	// Give it time to fail
+	time.Sleep(3 * time.Second)
+
+	snapshot := tf.SnapshotPlain()
+
+	// Should have troubleshooting tips or error about no pods
+	if !strings.Contains(snapshot, "Troubleshooting") && !strings.Contains(snapshot, "no ready pods") {
+		t.Logf("Output: %s", snapshot)
+		t.Error("expected troubleshooting tips or 'no ready pods' error message")
+	}
+}
+
+// TestPortForward_Reconnection verifies that the app handles disconnection and reconnects.
+// The mock kubectl port-forward exits after a delay, simulating a pod restart.
+func TestPortForward_Reconnection(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	// Setup mock ArgoCD server
+	srv, err := MockArgoServer()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+
+	if err := WriteArgoConfigPortForward(cfgPath, "test-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Create mock kubectl that exits after 3 seconds (simulates pod restart)
+	opts := DefaultMockKubectlOptions()
+	opts.LocalPort = extractPortFromURL(srv.URL)
+	opts.PFExitAfter = 3 // Exit after 3 seconds
+
+	mockKubectl, argsFile := createMockKubectl(t, tf.workspace, opts)
+
+	// Start app
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
+		"PATH="+filepath.Dir(mockKubectl)+":"+os.Getenv("PATH"),
+	); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// First, verify app starts successfully (cluster-a appears in clusters view)
+	if !tf.WaitForPlain("cluster-a", 10*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected to see 'cluster-a' initially")
+	}
+
+	// Wait for reconnection to happen (kubectl exits after 3s, then reconnect attempt)
+	// The reconnect delay is 2 seconds, plus time for re-establishing
+	time.Sleep(8 * time.Second)
+
+	// After reconnection, the app should still be functional
+	// Check that port-forward was called multiple times (initial + reconnection)
+	args := readMockKubectlArgs(t, argsFile)
+
+	portForwardCount := 0
+	for _, arg := range args {
+		if strings.Contains(arg, "port-forward") {
+			portForwardCount++
+		}
+	}
+
+	if portForwardCount < 2 {
+		t.Errorf("expected at least 2 port-forward calls (initial + reconnection), got %d. Args: %v", portForwardCount, args)
+	}
+
+	// App should still show content (either reconnected successfully or showing error)
+	snapshot := tf.SnapshotPlain()
+	// Either the app recovered and shows apps, or it shows reconnection-related output
+	if len(snapshot) < 10 {
+		t.Errorf("expected app to have some output after reconnection attempt, got: %s", snapshot)
+	}
+}

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -197,11 +197,7 @@ func (c *ArgonautConfig) GetDiffFormatter() string {
 }
 
 // GetPortForwardNamespace returns the namespace for kubectl port-forward, defaulting to "argocd"
-// Priority: ARGONAUT_PORT_FORWARD_NAMESPACE env var > config file > default "argocd"
 func (c *ArgonautConfig) GetPortForwardNamespace() string {
-	if envNs := os.Getenv("ARGONAUT_PORT_FORWARD_NAMESPACE"); envNs != "" {
-		return envNs
-	}
 	if c.PortForward.Namespace != "" {
 		return c.PortForward.Namespace
 	}

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -14,11 +14,12 @@ const DefaultThemeName = "tokyo-night"
 
 // ArgonautConfig represents the complete Argonaut configuration
 type ArgonautConfig struct {
-	Appearance      AppearanceConfig `toml:"appearance"`
-	Sort            SortConfig       `toml:"sort,omitempty"`
-	K9s             K9sConfig        `toml:"k9s,omitempty"`
-	Diff            DiffConfig       `toml:"diff,omitempty"`
-	LastSeenVersion string           `toml:"last_seen_version,omitempty"`
+	Appearance      AppearanceConfig  `toml:"appearance"`
+	Sort            SortConfig        `toml:"sort,omitempty"`
+	K9s             K9sConfig         `toml:"k9s,omitempty"`
+	Diff            DiffConfig        `toml:"diff,omitempty"`
+	PortForward     PortForwardConfig `toml:"port_forward,omitempty"`
+	LastSeenVersion string            `toml:"last_seen_version,omitempty"`
 }
 
 // AppearanceConfig holds theme and visual settings
@@ -43,6 +44,11 @@ type K9sConfig struct {
 type DiffConfig struct {
 	Viewer    string `toml:"viewer,omitempty"`    // External diff viewer command (e.g., "code --diff {left} {right}")
 	Formatter string `toml:"formatter,omitempty"` // Diff formatter command (e.g., "delta")
+}
+
+// PortForwardConfig holds settings for kubectl port-forward mode
+type PortForwardConfig struct {
+	Namespace string `toml:"namespace,omitempty"` // Kubernetes namespace where ArgoCD is installed (default: "argocd")
 }
 
 
@@ -188,4 +194,16 @@ func (c *ArgonautConfig) GetDiffViewer() string {
 // GetDiffFormatter returns the diff formatter command, or empty string if not configured
 func (c *ArgonautConfig) GetDiffFormatter() string {
 	return c.Diff.Formatter
+}
+
+// GetPortForwardNamespace returns the namespace for kubectl port-forward, defaulting to "argocd"
+// Priority: ARGONAUT_PORT_FORWARD_NAMESPACE env var > config file > default "argocd"
+func (c *ArgonautConfig) GetPortForwardNamespace() string {
+	if envNs := os.Getenv("ARGONAUT_PORT_FORWARD_NAMESPACE"); envNs != "" {
+		return envNs
+	}
+	if c.PortForward.Namespace != "" {
+		return c.PortForward.Namespace
+	}
+	return "argocd"
 }

--- a/pkg/config/argonaut_config_test.go
+++ b/pkg/config/argonaut_config_test.go
@@ -404,14 +404,9 @@ func TestSaveAndLoadK9sAndDiffConfig(t *testing.T) {
 }
 
 func TestPortForwardConfigGetters(t *testing.T) {
-	// Save original env var
-	originalEnv := os.Getenv("ARGONAUT_PORT_FORWARD_NAMESPACE")
-	defer os.Setenv("ARGONAUT_PORT_FORWARD_NAMESPACE", originalEnv)
-
 	tests := []struct {
 		name            string
 		config          *ArgonautConfig
-		envNamespace    string
 		expectNamespace string
 	}{
 		{
@@ -428,33 +423,10 @@ func TestPortForwardConfigGetters(t *testing.T) {
 			},
 			expectNamespace: "custom-ns",
 		},
-		{
-			name: "env var takes precedence over config",
-			config: &ArgonautConfig{
-				PortForward: PortForwardConfig{
-					Namespace: "config-ns",
-				},
-			},
-			envNamespace:    "env-ns",
-			expectNamespace: "env-ns",
-		},
-		{
-			name:            "env var with empty config",
-			config:          &ArgonautConfig{},
-			envNamespace:    "env-only-ns",
-			expectNamespace: "env-only-ns",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up env var for this test
-			if tt.envNamespace != "" {
-				os.Setenv("ARGONAUT_PORT_FORWARD_NAMESPACE", tt.envNamespace)
-			} else {
-				os.Unsetenv("ARGONAUT_PORT_FORWARD_NAMESPACE")
-			}
-
 			if got := tt.config.GetPortForwardNamespace(); got != tt.expectNamespace {
 				t.Errorf("GetPortForwardNamespace() = %q, want %q", got, tt.expectNamespace)
 			}

--- a/pkg/config/cli_config.go
+++ b/pkg/config/cli_config.go
@@ -137,6 +137,16 @@ func (c *ArgoCLIConfig) IsCurrentServerCore() (bool, error) {
 	return serverConfig.Core, nil
 }
 
+// IsPortForwardMode returns true if the current server is configured for port-forward mode
+// This is indicated by the server URL being exactly "port-forward"
+func (c *ArgoCLIConfig) IsPortForwardMode() (bool, error) {
+	server, err := c.GetCurrentServer()
+	if err != nil {
+		return false, err
+	}
+	return server == "port-forward", nil
+}
+
 // GetCurrentToken returns the auth token for the current context
 func (c *ArgoCLIConfig) GetCurrentToken() (string, error) {
 	if c.CurrentContext == "" {

--- a/pkg/portforward/kubectl.go
+++ b/pkg/portforward/kubectl.go
@@ -247,6 +247,7 @@ func (m *Manager) startPortForward(ctx context.Context, podName string) (*exec.C
 	defer func() {
 		if started && cmd.Process != nil {
 			_ = cmd.Process.Kill()
+			_ = cmd.Wait() // Reap the child process to avoid zombies
 		}
 	}()
 

--- a/pkg/portforward/kubectl.go
+++ b/pkg/portforward/kubectl.go
@@ -119,7 +119,7 @@ func (m *Manager) Start(ctx context.Context) (int, error) {
 	m.monitorDone = make(chan struct{})
 
 	// Start monitoring goroutine
-	go m.monitor(podName)
+	go m.monitor()
 
 	return port, nil
 }
@@ -294,7 +294,7 @@ func (m *Manager) startPortForward(ctx context.Context, podName string) (*exec.C
 }
 
 // monitor watches the port-forward process and handles reconnection
-func (m *Manager) monitor(lastPodName string) {
+func (m *Manager) monitor() {
 	defer close(m.monitorDone)
 
 	for {

--- a/pkg/portforward/kubectl.go
+++ b/pkg/portforward/kubectl.go
@@ -1,0 +1,353 @@
+// Package portforward provides kubectl port-forward management for ArgoCD access
+package portforward
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	cblog "github.com/charmbracelet/log"
+)
+
+const (
+	// DefaultServerName is the default ArgoCD server app name used in label selector
+	DefaultServerName = "argocd-server"
+
+	// DefaultTargetPort is the ArgoCD server port to forward to
+	DefaultTargetPort = 8080
+
+	// reconnectDelay is the delay between reconnection attempts
+	reconnectDelay = 2 * time.Second
+
+	// maxReconnectAttempts is the maximum number of consecutive reconnection attempts
+	maxReconnectAttempts = 5
+)
+
+// portRegex matches kubectl port-forward output like "Forwarding from 127.0.0.1:12345 -> 8080"
+var portRegex = regexp.MustCompile(`Forwarding from 127\.0\.0\.1:(\d+)`)
+
+// Manager handles kubectl port-forward lifecycle
+type Manager struct {
+	namespace  string
+	serverName string
+	targetPort int
+
+	mu              sync.RWMutex
+	cmd             *exec.Cmd
+	localPort       int
+	running         bool
+	stopCh          chan struct{}
+	reconnectCount  int
+	onReconnect     func(port int)
+	onDisconnect    func(err error)
+}
+
+// Options configures the port-forward manager
+type Options struct {
+	// Namespace is the Kubernetes namespace where ArgoCD is installed
+	Namespace string
+
+	// ServerName is the ArgoCD server app name (default: "argocd-server")
+	ServerName string
+
+	// TargetPort is the port to forward to on the ArgoCD server (default: 8080)
+	TargetPort int
+
+	// OnReconnect is called when port-forward is re-established with the new port
+	OnReconnect func(port int)
+
+	// OnDisconnect is called when port-forward fails permanently
+	OnDisconnect func(err error)
+}
+
+// NewManager creates a new port-forward manager
+func NewManager(opts Options) *Manager {
+	if opts.Namespace == "" {
+		opts.Namespace = "argocd"
+	}
+	if opts.ServerName == "" {
+		opts.ServerName = DefaultServerName
+	}
+	if opts.TargetPort == 0 {
+		opts.TargetPort = DefaultTargetPort
+	}
+
+	return &Manager{
+		namespace:    opts.Namespace,
+		serverName:   opts.ServerName,
+		targetPort:   opts.TargetPort,
+		stopCh:       make(chan struct{}),
+		onReconnect:  opts.OnReconnect,
+		onDisconnect: opts.OnDisconnect,
+	}
+}
+
+// Start initiates the port-forward connection and returns the local port
+func (m *Manager) Start(ctx context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running {
+		return m.localPort, nil
+	}
+
+	// Find a ready pod
+	podName, err := m.findReadyPod(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find ArgoCD server pod: %w", err)
+	}
+
+	cblog.With("component", "portforward").Info("Found ArgoCD server pod", "pod", podName, "namespace", m.namespace)
+
+	// Start port-forward
+	port, err := m.startPortForward(ctx, podName)
+	if err != nil {
+		return 0, err
+	}
+
+	m.localPort = port
+	m.running = true
+	m.reconnectCount = 0
+
+	// Start monitoring goroutine
+	go m.monitor(podName)
+
+	return port, nil
+}
+
+// Stop terminates the port-forward connection
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		return
+	}
+
+	close(m.stopCh)
+	m.running = false
+
+	if m.cmd != nil && m.cmd.Process != nil {
+		_ = m.cmd.Process.Kill()
+		_ = m.cmd.Wait()
+	}
+
+	cblog.With("component", "portforward").Info("Port-forward stopped")
+}
+
+// LocalPort returns the current local port
+func (m *Manager) LocalPort() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.localPort
+}
+
+// IsRunning returns true if port-forward is active
+func (m *Manager) IsRunning() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.running
+}
+
+// ServerAddress returns the local server address (e.g., "127.0.0.1:12345")
+func (m *Manager) ServerAddress() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return fmt.Sprintf("127.0.0.1:%d", m.localPort)
+}
+
+// findReadyPod finds a ready ArgoCD server pod using kubectl
+func (m *Manager) findReadyPod(ctx context.Context) (string, error) {
+	// Use label selector like ArgoCD CLI: app.kubernetes.io/name=argocd-server
+	labelSelector := fmt.Sprintf("app.kubernetes.io/name=%s", m.serverName)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "pods",
+		"-n", m.namespace,
+		"-l", labelSelector,
+		"--field-selector=status.phase=Running",
+		"-o", "jsonpath={.items[?(@.status.containerStatuses[0].ready==true)].metadata.name}",
+	)
+
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("kubectl error: %s", string(exitErr.Stderr))
+		}
+		return "", err
+	}
+
+	pods := strings.Fields(string(output))
+	if len(pods) == 0 {
+		return "", fmt.Errorf("no ready pods found with selector %s in namespace %s", labelSelector, m.namespace)
+	}
+
+	// Return first ready pod
+	return pods[0], nil
+}
+
+// startPortForward starts kubectl port-forward and returns the allocated local port
+func (m *Manager) startPortForward(ctx context.Context, podName string) (int, error) {
+	// Use :0 to let kubectl pick an available port
+	portSpec := fmt.Sprintf(":%d", m.targetPort)
+
+	m.cmd = exec.CommandContext(ctx, "kubectl", "port-forward",
+		"-n", m.namespace,
+		podName,
+		portSpec,
+	)
+
+	// Capture stdout to parse the port
+	stdout, err := m.cmd.StdoutPipe()
+	if err != nil {
+		return 0, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	stderr, err := m.cmd.StderrPipe()
+	if err != nil {
+		return 0, fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	if err := m.cmd.Start(); err != nil {
+		return 0, fmt.Errorf("failed to start kubectl port-forward: %w", err)
+	}
+
+	// Read stderr in background for logging
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			cblog.With("component", "portforward").Debug("kubectl stderr", "line", scanner.Text())
+		}
+	}()
+
+	// Parse stdout for port assignment
+	portCh := make(chan int, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			cblog.With("component", "portforward").Debug("kubectl stdout", "line", line)
+
+			matches := portRegex.FindStringSubmatch(line)
+			if len(matches) >= 2 {
+				port, err := strconv.Atoi(matches[1])
+				if err == nil {
+					portCh <- port
+					return
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			errCh <- err
+		} else {
+			errCh <- fmt.Errorf("kubectl port-forward exited without providing port")
+		}
+	}()
+
+	// Wait for port or error with timeout
+	select {
+	case port := <-portCh:
+		cblog.With("component", "portforward").Info("Port-forward established", "localPort", port, "targetPort", m.targetPort)
+		return port, nil
+	case err := <-errCh:
+		_ = m.cmd.Process.Kill()
+		return 0, err
+	case <-time.After(10 * time.Second):
+		_ = m.cmd.Process.Kill()
+		return 0, fmt.Errorf("timeout waiting for port-forward to establish")
+	case <-ctx.Done():
+		_ = m.cmd.Process.Kill()
+		return 0, ctx.Err()
+	}
+}
+
+// monitor watches the port-forward process and handles reconnection
+func (m *Manager) monitor(lastPodName string) {
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		default:
+		}
+
+		// Wait for process to exit
+		if m.cmd != nil {
+			err := m.cmd.Wait()
+			cblog.With("component", "portforward").Warn("Port-forward disconnected", "err", err)
+		}
+
+		m.mu.Lock()
+		if !m.running {
+			m.mu.Unlock()
+			return
+		}
+
+		m.reconnectCount++
+		if m.reconnectCount > maxReconnectAttempts {
+			m.running = false
+			m.mu.Unlock()
+
+			cblog.With("component", "portforward").Error("Max reconnection attempts reached")
+			if m.onDisconnect != nil {
+				m.onDisconnect(fmt.Errorf("port-forward failed after %d reconnection attempts", maxReconnectAttempts))
+			}
+			return
+		}
+		m.mu.Unlock()
+
+		cblog.With("component", "portforward").Info("Attempting to reconnect", "attempt", m.reconnectCount)
+
+		// Wait before reconnecting
+		select {
+		case <-m.stopCh:
+			return
+		case <-time.After(reconnectDelay):
+		}
+
+		// Try to reconnect
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+
+		// Find a ready pod (might be different after restart)
+		podName, err := m.findReadyPod(ctx)
+		if err != nil {
+			cblog.With("component", "portforward").Warn("Failed to find pod for reconnection", "err", err)
+			cancel()
+			continue
+		}
+
+		port, err := m.startPortForward(ctx, podName)
+		cancel()
+
+		if err != nil {
+			cblog.With("component", "portforward").Warn("Failed to reconnect", "err", err)
+			continue
+		}
+
+		m.mu.Lock()
+		m.localPort = port
+		m.reconnectCount = 0 // Reset on successful reconnection
+		m.mu.Unlock()
+
+		cblog.With("component", "portforward").Info("Reconnected successfully", "port", port)
+
+		if m.onReconnect != nil {
+			m.onReconnect(port)
+		}
+	}
+}
+
+// CheckKubectl verifies that kubectl is available and configured
+func CheckKubectl(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "version", "--client", "--output=json")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kubectl not found or not configured: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds support for ArgoCD servers configured with port-forward mode, enabling access to ArgoCD installations that aren't directly exposed.

When ArgoCD CLI config has `server: port-forward`, Argonaut:
- Detects port-forward mode automatically
- Spawns kubectl port-forward to argocd-server pod
- Auto-reconnects if connection drops (up to 5 attempts)
- Cleans up on exit

Configuration:
- Namespace configurable via config.toml [port_forward] section
- Or via ARGONAUT_PORT_FORWARD_NAMESPACE env var
- Defaults to "argocd" namespace

related to #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Port-forward mode for connecting to the server when direct access is unavailable, with automatic local tunneling and reconnection support.
  * New config option to specify the port-forward namespace and CLI detection for port-forward mode.

* **Bug Fixes**
  * Improved shutdown/cleanup and kubectl availability checks with clearer troubleshooting output on failures.

* **Documentation**
  * Added port-forward usage and configuration guidance to the README.

* **Tests**
  * End-to-end and unit tests covering happy path, no-pod errors, and reconnection behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->