### PR TITLE
feat: add resource-level sync from tree view

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -1178,10 +1178,20 @@ func (m *Model) syncSelectedResources(targets []model.ResourceSyncTarget, prune,
 			cblog.With("component", "resource-sync").Debug("Syncing resources for app",
 				"app", appName, "resourceCount", len(resources))
 
+			// Look up app namespace from state (required for namespaced ArgoCD installations)
+			var appNamespace string
+			for _, app := range m.state.Apps {
+				if app.Name == appName && app.AppNamespace != nil {
+					appNamespace = *app.AppNamespace
+					break
+				}
+			}
+
 			opts := &api.SyncOptions{
-				Prune:     prune,
-				Force:     force,
-				Resources: resources,
+				Prune:        prune,
+				Force:        force,
+				Resources:    resources,
+				AppNamespace: appNamespace,
 			}
 
 			err := appService.SyncApplication(ctx, appName, opts)

--- a/cmd/app/testdata/snapshots/modal_help.golden
+++ b/cmd/app/testdata/snapshots/modal_help.golden
@@ -13,7 +13,7 @@
  │              :resources [app] • :sort health|sync asc|desc • :up • :all                        │ 
  │                                                                                                │ 
  │ TREE VIEW    / filter • n/N next/prev match •  d  diff • K open in k9s                         │ 
- │               Space  select •  Ctrl+D  delete • :up return to apps                             │ 
+ │               Space  select •  s  sync •  Ctrl+D  delete • :up return to apps                  │ 
  │                                                                                                │ 
  │ COMMANDS     :q (to exit, google how to exit vim)                                              │ 
  │                                                                                                │ 

--- a/cmd/app/view_layout.go
+++ b/cmd/app/view_layout.go
@@ -135,9 +135,11 @@ func (m *Model) renderMainLayout() string {
 	// This makes the tree view only highlight selected items (not cursor) with scoped highlights
 	if m.treeView != nil && m.state.Navigation.View == model.ViewTree {
 		willDesaturate := m.state.Mode == model.ModeConfirmResourceDelete ||
+			m.state.Mode == model.ModeConfirmResourceSync ||
 			m.state.Mode == model.ModeConfirmAppDelete ||
 			m.state.Mode == model.ModeConfirmSync ||
-			m.state.Modals.ConfirmSyncLoading
+			m.state.Modals.ConfirmSyncLoading ||
+			m.state.Modals.ResourceSyncLoading
 		m.treeView.SetDesaturateMode(willDesaturate)
 	}
 
@@ -287,6 +289,22 @@ func (m *Model) renderMainLayout() string {
 			modal = m.renderResourceDeleteLoadingModal()
 		} else {
 			modal = m.renderResourceDeleteConfirmModal()
+		}
+		grayBase := desaturateANSI(baseView)
+		baseLayer := lipgloss.NewLayer(grayBase)
+		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
+		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
+		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
+		canvas := lipgloss.NewCanvas(baseLayer, modalLayer)
+		return canvas.Render()
+	}
+	// Resource Sync modal (confirmation or loading state)
+	if m.state.Mode == model.ModeConfirmResourceSync {
+		modal := ""
+		if m.state.Modals.ResourceSyncLoading {
+			modal = m.renderResourceSyncLoadingModal()
+		} else {
+			modal = m.renderResourceSyncConfirmModal()
 		}
 		grayBase := desaturateANSI(baseView)
 		baseLayer := lipgloss.NewLayer(grayBase)

--- a/e2e/resource_sync_test.go
+++ b/e2e/resource_sync_test.go
@@ -1,0 +1,501 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ResourceSyncCall captures a resource sync API call
+type ResourceSyncCall struct {
+	AppName   string
+	Body      string
+	Resources []map[string]interface{} // Parsed resources array from body
+}
+
+// ResourceSyncRecorder records resource sync API calls
+type ResourceSyncRecorder struct {
+	mu    sync.Mutex
+	Calls []ResourceSyncCall
+}
+
+func (r *ResourceSyncRecorder) add(call ResourceSyncCall) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Calls = append(r.Calls, call)
+}
+
+func (r *ResourceSyncRecorder) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.Calls)
+}
+
+func (r *ResourceSyncRecorder) getCall(i int) ResourceSyncCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if i < len(r.Calls) {
+		return r.Calls[i]
+	}
+	return ResourceSyncCall{}
+}
+
+// MockArgoServerForResourceSync creates a mock server for testing resource-level sync
+func MockArgoServerForResourceSync(validToken string) (*httptest.Server, *ResourceSyncRecorder, error) {
+	rec := &ResourceSyncRecorder{}
+	mux := http.NewServeMux()
+
+	requireAuth := func(w http.ResponseWriter, r *http.Request) bool {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+validToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			return false
+		}
+		return true
+	}
+
+	mux.HandleFunc("/api/v1/session/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		_, _ = w.Write([]byte(`{"version":"e2e"}`))
+	})
+
+	mux.HandleFunc("/api/v1/applications", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// One app for testing resource sync
+		_, _ = w.Write([]byte(`{"items":[
+			{"metadata":{"name":"demo","namespace":"argocd"},"spec":{"project":"demo","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Healthy"},"resources":[
+				{"group":"apps","version":"v1","kind":"Deployment","namespace":"default","name":"nginx-deployment","status":"OutOfSync","health":{"status":"Healthy"}},
+				{"group":"","version":"v1","kind":"Service","namespace":"default","name":"nginx-service","status":"Synced","health":{"status":"Healthy"}}
+			]}}
+		]}`))
+	})
+
+	// Resource tree with actual resources
+	mux.HandleFunc("/api/v1/applications/demo/resource-tree", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Tree with a Deployment and Service
+		_, _ = w.Write([]byte(`{
+			"nodes": [
+				{
+					"group": "apps",
+					"version": "v1",
+					"kind": "Deployment",
+					"namespace": "default",
+					"name": "nginx-deployment",
+					"uid": "uid-deployment-1",
+					"health": {"status": "Healthy"},
+					"resourceRef": {"group": "apps", "version": "v1", "kind": "Deployment", "namespace": "default", "name": "nginx-deployment", "uid": "uid-deployment-1"}
+				},
+				{
+					"group": "",
+					"version": "v1",
+					"kind": "Service",
+					"namespace": "default",
+					"name": "nginx-service",
+					"uid": "uid-service-1",
+					"health": {"status": "Healthy"},
+					"resourceRef": {"group": "", "version": "v1", "kind": "Service", "namespace": "default", "name": "nginx-service", "uid": "uid-service-1"}
+				}
+			]
+		}`))
+	})
+
+	// Diffs
+	mux.HandleFunc("/api/v1/applications/demo/managed-resources", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+
+	// Sync endpoint - capture all sync calls
+	mux.HandleFunc("/api/v1/applications/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		if !requireAuth(w, r) {
+			return
+		}
+		// Expect path like /api/v1/applications/<name>/sync
+		p := r.URL.Path
+		if !strings.HasSuffix(p, "/sync") {
+			http.NotFound(w, r)
+			return
+		}
+		segs := strings.Split(p, "/")
+		if len(segs) < 6 {
+			http.NotFound(w, r)
+			return
+		}
+		appName := segs[4]
+		body, _ := io.ReadAll(r.Body)
+
+		// Parse body to extract resources
+		var bodyMap map[string]interface{}
+		var resources []map[string]interface{}
+		if err := json.Unmarshal(body, &bodyMap); err == nil {
+			if res, ok := bodyMap["resources"].([]interface{}); ok {
+				for _, r := range res {
+					if rm, ok := r.(map[string]interface{}); ok {
+						resources = append(resources, rm)
+					}
+				}
+			}
+		}
+
+		rec.add(ResourceSyncCall{
+			AppName:   appName,
+			Body:      string(body),
+			Resources: resources,
+		})
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv, rec, nil
+}
+
+// TestResourceSync_SingleResource tests syncing a single resource from tree view
+func TestResourceSync_SingleResource(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, rec, err := MockArgoServerForResourceSync("valid-token")
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate to apps via commands
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	// Enter tree view by pressing 'r'
+	_ = tf.Send("r")
+	if !tf.WaitForPlain("Deployment", 3*time.Second) {
+		t.Fatalf("tree view not loaded\n%s", tf.SnapshotPlain())
+	}
+
+	// Navigate down to first resource (Deployment)
+	_ = tf.Send("j") // Move to first resource (down from app node)
+
+	// Trigger resource sync with 's'
+	_ = tf.Send("s")
+
+	// Wait for the sync confirmation modal
+	if !tf.WaitForPlain("Sync", 2*time.Second) {
+		t.Fatalf("sync modal not shown\n%s", tf.SnapshotPlain())
+	}
+
+	// Confirm sync with 'y'
+	_ = tf.Send("y")
+
+	// Wait for sync call
+	if !waitUntil(t, func() bool { return rec.len() >= 1 }, 3*time.Second) {
+		t.Fatalf("expected at least 1 sync call, got %d\n%s", rec.len(), tf.SnapshotPlain())
+	}
+
+	call := rec.getCall(0)
+	if call.AppName != "demo" {
+		t.Fatalf("expected sync for 'demo', got %q", call.AppName)
+	}
+
+	// Verify resources array is in the body
+	if len(call.Resources) != 1 {
+		t.Fatalf("expected 1 resource in sync request, got %d. Body: %s", len(call.Resources), call.Body)
+	}
+
+	// Verify the resource details
+	res := call.Resources[0]
+	if res["kind"] != "Deployment" {
+		t.Fatalf("expected kind=Deployment, got %v", res["kind"])
+	}
+	if res["name"] != "nginx-deployment" {
+		t.Fatalf("expected name=nginx-deployment, got %v", res["name"])
+	}
+}
+
+// TestResourceSync_Cancel tests cancelling a resource sync
+func TestResourceSync_Cancel(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, rec, err := MockArgoServerForResourceSync("valid-token")
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate to apps and then tree view
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	// Enter tree view
+	_ = tf.Send("r")
+	if !tf.WaitForPlain("Deployment", 3*time.Second) {
+		t.Fatalf("tree view not loaded\n%s", tf.SnapshotPlain())
+	}
+
+	// Navigate to resource
+	_ = tf.Send("j")
+
+	// Trigger resource sync
+	_ = tf.Send("s")
+
+	// Wait for modal
+	if !tf.WaitForPlain("Sync", 2*time.Second) {
+		t.Fatalf("sync modal not shown\n%s", tf.SnapshotPlain())
+	}
+
+	// Cancel with escape
+	_ = tf.Send("\x1b") // Escape
+
+	// Wait a bit and verify no sync calls were made
+	time.Sleep(500 * time.Millisecond)
+	if rec.len() != 0 {
+		t.Fatalf("expected 0 sync calls after cancel, got %d", rec.len())
+	}
+}
+
+// TestResourceSync_WithPrune tests syncing with prune option enabled
+func TestResourceSync_WithPrune(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, rec, err := MockArgoServerForResourceSync("valid-token")
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate to tree view
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	_ = tf.Send("r")
+	if !tf.WaitForPlain("Deployment", 3*time.Second) {
+		t.Fatalf("tree view not loaded\n%s", tf.SnapshotPlain())
+	}
+
+	_ = tf.Send("j")
+	_ = tf.Send("s")
+
+	if !tf.WaitForPlain("Sync", 2*time.Second) {
+		t.Fatalf("sync modal not shown\n%s", tf.SnapshotPlain())
+	}
+
+	// Toggle prune option with 'p'
+	_ = tf.Send("p")
+
+	// Confirm sync
+	_ = tf.Send("y")
+
+	if !waitUntil(t, func() bool { return rec.len() >= 1 }, 3*time.Second) {
+		t.Fatalf("expected sync call, got %d\n%s", rec.len(), tf.SnapshotPlain())
+	}
+
+	call := rec.getCall(0)
+
+	// Parse body and verify prune=true
+	var body map[string]interface{}
+	if err := json.Unmarshal([]byte(call.Body), &body); err != nil {
+		t.Fatalf("invalid body json: %v", err)
+	}
+	if prune, ok := body["prune"].(bool); !ok || !prune {
+		t.Fatalf("expected prune=true in body, got %v. Body: %s", body["prune"], call.Body)
+	}
+}
+
+// TestResourceSync_AppNodeFullSync tests that pressing 's' on app root triggers full app sync
+func TestResourceSync_AppNodeFullSync(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, rec, err := MockArgoServerForResourceSync("valid-token")
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate to tree view
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	_ = tf.Send("r")
+	if !tf.WaitForPlain("Deployment", 3*time.Second) {
+		t.Fatalf("tree view not loaded\n%s", tf.SnapshotPlain())
+	}
+
+	// Stay on app node (don't navigate down) and trigger sync
+	_ = tf.Send("s")
+
+	// Wait for the app-level sync modal (not resource sync modal)
+	if !tf.WaitForPlain("Sync demo", 2*time.Second) {
+		t.Fatalf("app sync modal not shown\n%s", tf.SnapshotPlain())
+	}
+
+	// Confirm sync
+	_ = tf.Send("\r")
+
+	if !waitUntil(t, func() bool { return rec.len() >= 1 }, 3*time.Second) {
+		t.Fatalf("expected sync call, got %d\n%s", rec.len(), tf.SnapshotPlain())
+	}
+
+	call := rec.getCall(0)
+
+	// Verify this is a full app sync (no resources array)
+	var body map[string]interface{}
+	if err := json.Unmarshal([]byte(call.Body), &body); err != nil {
+		t.Fatalf("invalid body json: %v", err)
+	}
+	if _, hasResources := body["resources"]; hasResources {
+		t.Fatalf("expected full app sync without resources array, but got resources: %s", call.Body)
+	}
+}

--- a/e2e/resource_sync_test.go
+++ b/e2e/resource_sync_test.go
@@ -499,3 +499,199 @@ func TestResourceSync_AppNodeFullSync(t *testing.T) {
 		t.Fatalf("expected full app sync without resources array, but got resources: %s", call.Body)
 	}
 }
+
+// MockArgoServerForResourceSyncError creates a mock server that returns sync errors
+// with ArgoCD's runtimeError format
+func MockArgoServerForResourceSyncError(validToken string, errorCode int, errorMessage string) (*httptest.Server, error) {
+	mux := http.NewServeMux()
+
+	requireAuth := func(w http.ResponseWriter, r *http.Request) bool {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+validToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			return false
+		}
+		return true
+	}
+
+	mux.HandleFunc("/api/v1/session/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		_, _ = w.Write([]byte(`{"version":"e2e"}`))
+	})
+
+	mux.HandleFunc("/api/v1/applications", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[
+			{"metadata":{"name":"demo","namespace":"argocd"},"spec":{"project":"demo","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Healthy"},"resources":[
+				{"group":"apps","version":"v1","kind":"Deployment","namespace":"default","name":"nginx-deployment","status":"OutOfSync","health":{"status":"Healthy"}}
+			]}}
+		]}`))
+	})
+
+	mux.HandleFunc("/api/v1/applications/demo/resource-tree", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"nodes": [
+				{
+					"group": "apps",
+					"version": "v1",
+					"kind": "Deployment",
+					"namespace": "default",
+					"name": "nginx-deployment",
+					"uid": "uid-deployment-1",
+					"health": {"status": "Healthy"},
+					"resourceRef": {"group": "apps", "version": "v1", "kind": "Deployment", "namespace": "default", "name": "nginx-deployment", "uid": "uid-deployment-1"}
+				}
+			]
+		}`))
+	})
+
+	mux.HandleFunc("/api/v1/applications/demo/managed-resources", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	})
+
+	// Sync endpoint - returns error with ArgoCD runtimeError format
+	mux.HandleFunc("/api/v1/applications/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		if !requireAuth(w, r) {
+			return
+		}
+		p := r.URL.Path
+		if !strings.HasSuffix(p, "/sync") {
+			http.NotFound(w, r)
+			return
+		}
+		// Return ArgoCD runtimeError format
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(errorCode)
+		errResp := map[string]interface{}{
+			"code":    errorCode,
+			"error":   "sync_failed",
+			"message": errorMessage,
+		}
+		resp, _ := json.Marshal(errResp)
+		_, _ = w.Write(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv, nil
+}
+
+// TestResourceSync_ErrorDisplayed tests that sync errors are displayed to the user
+func TestResourceSync_ErrorDisplayed(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	// Mock server returns a 403 Forbidden with a descriptive ArgoCD error message
+	errorMessage := "permission denied: applications, sync, demo/demo, sub: proj:demo:admin, iat: 2024-01-01"
+	srv, err := MockArgoServerForResourceSyncError("valid-token", 403, errorMessage)
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate to tree view
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	// Enter tree view
+	_ = tf.Send("r")
+	if !tf.WaitForPlain("Deployment", 3*time.Second) {
+		t.Fatalf("tree view not loaded\n%s", tf.SnapshotPlain())
+	}
+
+	// Navigate to resource
+	_ = tf.Send("j")
+
+	// Trigger resource sync
+	_ = tf.Send("s")
+
+	// Wait for modal
+	if !tf.WaitForPlain("Sync", 2*time.Second) {
+		t.Fatalf("sync modal not shown\n%s", tf.SnapshotPlain())
+	}
+
+	// Confirm sync
+	_ = tf.Send("y")
+
+	// Wait for error message to appear in the UI
+	// The error message should contain key parts of the ArgoCD error
+	if !tf.WaitForPlain("permission denied", 3*time.Second) {
+		snapshot := tf.SnapshotPlain()
+		// Check if any error is displayed
+		if !strings.Contains(snapshot, "Error") {
+			t.Fatalf("expected error to be displayed, but no error visible\n%s", snapshot)
+		}
+		t.Fatalf("expected 'permission denied' in error message\n%s", snapshot)
+	}
+
+	// Verify the error modal shows the ArgoCD error message (not a generic message)
+	snapshot := tf.SnapshotPlain()
+	if !strings.Contains(snapshot, "applications, sync") {
+		t.Fatalf("expected full ArgoCD error details in modal\n%s", snapshot)
+	}
+
+	// User can dismiss the error modal
+	_ = tf.Send("\x1b") // Escape
+
+	// Wait for modal to close - verify we're back to tree view mode
+	time.Sleep(300 * time.Millisecond)
+
+	// The key test assertion: ArgoCD's runtimeError message was parsed and displayed
+	// This confirms the error handling chain works end-to-end
+	t.Log("Successfully verified: ArgoCD error message was parsed and displayed to user")
+}

--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -253,6 +253,20 @@ func (s *ApplicationService) SyncApplication(ctx context.Context, appName string
 		"appNamespace": opts.AppNamespace,
 	}
 
+	// Add resources array if provided (for selective resource sync)
+	if len(opts.Resources) > 0 {
+		reqBody["resources"] = opts.Resources
+	}
+
+	// Add force option via strategy if enabled
+	if opts.Force {
+		reqBody["strategy"] = map[string]interface{}{
+			"apply": map[string]interface{}{
+				"force": true,
+			},
+		}
+	}
+
 	path := fmt.Sprintf("/api/v1/applications/%s/sync", url.PathEscape(appName))
 	if opts.AppNamespace != "" {
 		path += "?appNamespace=" + url.QueryEscape(opts.AppNamespace)
@@ -332,10 +346,20 @@ func (s *ApplicationService) WatchApplications(ctx context.Context, eventChan ch
 }
 
 // SyncOptions represents options for syncing an application
+// SyncResourceTarget represents a specific resource to sync
+type SyncResourceTarget struct {
+	Group     string `json:"group"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
 type SyncOptions struct {
-	Prune        bool   `json:"prune,omitempty"`
-	DryRun       bool   `json:"dryRun,omitempty"`
-	AppNamespace string `json:"appNamespace,omitempty"`
+	Prune        bool                 `json:"prune,omitempty"`
+	DryRun       bool                 `json:"dryRun,omitempty"`
+	Force        bool                 `json:"force,omitempty"`
+	AppNamespace string               `json:"appNamespace,omitempty"`
+	Resources    []SyncResourceTarget `json:"resources,omitempty"`
 }
 
 // ConvertToApp converts an ArgoApplication to our model.App

--- a/pkg/model/messages.go
+++ b/pkg/model/messages.go
@@ -211,6 +211,17 @@ type ResourceDeleteErrorMsg struct {
 	Error string
 }
 
+// ResourceSyncSuccessMsg represents successful resource sync
+type ResourceSyncSuccessMsg struct {
+	Count    int
+	AppNames []string // Names of apps whose resources were synced (for refresh)
+}
+
+// ResourceSyncErrorMsg represents a resource sync error
+type ResourceSyncErrorMsg struct {
+	Error string
+}
+
 // AuthErrorMsg is sent when authentication is required
 type AuthErrorMsg struct {
 	Error error

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -150,6 +150,14 @@ type ModalState struct {
 	ResourceDeleteCascade           bool                   `json:"resourceDeleteCascade"`           // Default true
 	ResourceDeletePropagationPolicy string                 `json:"resourceDeletePropagationPolicy"` // Default "foreground"
 	ResourceDeleteForce             bool                   `json:"resourceDeleteForce"`             // Force deletion
+	// Resource sync confirmation modal state
+	ResourceSyncAppName         *string              `json:"resourceSyncAppName,omitempty"`
+	ResourceSyncTargets         []ResourceSyncTarget `json:"resourceSyncTargets,omitempty"`
+	ResourceSyncConfirmSelected int                  `json:"resourceSyncConfirmSelected"` // 0 = Sync, 1 = Cancel
+	ResourceSyncLoading         bool                 `json:"resourceSyncLoading"`
+	ResourceSyncError           *string              `json:"resourceSyncError,omitempty"`
+	ResourceSyncPrune           bool                 `json:"resourceSyncPrune"` // Prune option
+	ResourceSyncForce           bool                 `json:"resourceSyncForce"` // Force option
 	// Changelog loading modal state
 	ChangelogLoading bool `json:"changelogLoading"`
 	// K9s error modal state

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -41,8 +41,9 @@ const (
 	ModeUpgradeError    Mode = "upgrade-error"
 	ModeUpgradeSuccess  Mode = "upgrade-success"
 	ModeNoDiff           Mode = "no-diff"
-	ModeK9sContextSelect Mode = "k9s-context-select"
-	ModeK9sError         Mode = "k9s-error"
+	ModeK9sContextSelect    Mode = "k9s-context-select"
+	ModeK9sError            Mode = "k9s-error"
+	ModeConfirmResourceSync Mode = "confirm-resource-sync"
 )
 
 // App represents an ArgoCD application
@@ -242,4 +243,13 @@ type ResourceDeleteTarget struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
 	Version   string `json:"version"`
+}
+
+// ResourceSyncTarget represents a resource to be synced
+type ResourceSyncTarget struct {
+	AppName   string `json:"appName"`
+	Group     string `json:"group"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
 }


### PR DESCRIPTION
Add the ability to sync individual resources or multi-selections from the tree view using the 's' key. This mirrors the existing Ctrl+D deletion pattern.

Features:
- Press 's' in tree view to sync selected resource(s)
- Multi-select resources with Space, then sync all at once
- Options: prune (p), force (f)
- Missing resources are allowed (syncing recreates them from git)
- On Application root node, 's' triggers full app sync

Implementation:
- Extended SyncOptions with Resources array and Force field
- Added ModeConfirmResourceSync mode and modal state
- Added sync confirmation modal with cyan theme
- Added E2E tests for resource sync scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource sync from tree view (shortcut: s) for single resources or whole apps
  * Confirmation modal with prune and force toggles; progress/loading modal during sync
  * UI refreshes affected app resource trees after successful sync

* **User-facing Improvements**
  * Clearer parsing and display of ArgoCD sync error messages for better feedback

* **Tests**
  * Comprehensive end-to-end tests covering sync flows, options, cancellations, and error cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->