### PR TITLE
fix: make :sync command work in tree view

### DIFF
--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -658,6 +658,10 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			body := m.readLogContent()
 			return m, m.openTextPager("Logs", body)
 		case "sync":
+			// In tree view, sync the selected resource(s); in apps view, sync the app
+			if m.state.Navigation.View == model.ViewTree {
+				return m.handleResourceSync()
+			}
 			mdl, cmd := m.handleSyncModal()
 			return mdl, cmd
 		case "delete", "del":


### PR DESCRIPTION
The :sync command was only working in apps view. When in tree view, it would show "Navigate to apps view to sync applications" instead of showing the sync confirmation popup like the 's' key does.

Now the :sync command checks the current view and calls the appropriate handler - handleResourceSync() for tree view (same as 's' key) or handleSyncModal() for apps view.

Added regression test TestResourceSync_CommandInTreeView.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The sync command now works directly from the tree view, enabling streamlined resource synchronization without leaving your current view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->