### PR TITLE
fix: Docker mount path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker pull ghcr.io/darksworm/argonaut:latest
 Run with mounted Argo CD config:
 ```bash
 docker run -it --rm \
-  -v ~/.config/argocd:/root/.config/argocd:ro \
+  -v ~/.config/argocd:/home/appuser/.config/argocd:ro \
   ghcr.io/darksworm/argonaut:latest
 ```
 


### PR DESCRIPTION
Still doesn't work for me, after this change:
```
2025/12/08 08:15:12 INFO Argo CD Apps started component=app logFile=/tmp/a9s-1800107197.log
2025/12/08 08:15:12 WARN Could not save last seen version component=app err=failed to create config directory: mkdir /home/appuser/.config/argonaut: permission denied
2025/12/08 08:15:12 INFO Loading Argo CD config… component=app
2025/12/08 08:15:12 ERRO Could not load Argo CD config component=app err=failed to read CLI config: failed to read ArgoCD config from /home/appuser/.config/argocd/config: open /home/appuser/
.config/argocd/config: permission denied
2025/12/08 08:15:12 INFO Please run 'argocd login' to configure and authenticate component=app
2025/12/08 08:15:12 INFO Ready component=status
2025/12/08 08:15:12 INFO Ready component=status
2025/12/08 08:15:12 INFO No server configured - showing auth required component=auth
2025/12/08 08:15:12 INFO SetModeMsg received component=model old_mode=normal new_mode=auth-required
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker volume mount configuration for Argo CD. This change may affect file permissions and runtime path expectations. Configuration path location has been modified inside the container.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->