### PR TITLE
feat: add :refresh and :refresh! commands for app refresh

### DIFF
--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -664,6 +664,10 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			}
 			mdl, cmd := m.handleSyncModal()
 			return mdl, cmd
+		case "refresh":
+			return m.handleRefreshCommand(arg, false)
+		case "refresh!":
+			return m.handleRefreshCommand(arg, true)
 		case "delete", "del":
 			target := arg
 			if target == "" {

--- a/cmd/app/testdata/snapshots/modal_help.golden
+++ b/cmd/app/testdata/snapshots/modal_help.golden
@@ -10,15 +10,15 @@
  │                                                                                                │ 
  │ APPS VIEW     s  sync •  R  rollback •  r  resources •  d  diff •  Ctrl+D  delete              │ 
  │              :diff [app] • :sync [app] • :rollback [app] • :delete [app]                       │ 
- │              :resources [app] • :sort health|sync asc|desc • :up • :all                        │ 
+ │              :refresh [app] • :refresh! [app] (hard) • :sort health|sync asc|desc              │ 
+ │              :resources [app] • :up • :all                                                     │ 
  │                                                                                                │ 
  │ TREE VIEW    / filter • n/N next/prev match •  d  diff • K open in k9s                         │ 
- │               Space  select •  s  sync •  Ctrl+D  delete • :up return to apps                  │ 
+ │               Space  select •  s  sync •  Ctrl+D  delete • :refresh|:refresh! • :up            │ 
  │                                                                                                │ 
  │ COMMANDS     :q (to exit, google how to exit vim)                                              │ 
  │                                                                                                │ 
  │ Press ?, q or Esc to close                                                                     │ 
- │                                                                                                │ 
  │                                                                                                │ 
  │                                                                                                │ 
  │                                                                                                │ 

--- a/cmd/app/theme_apply.go
+++ b/cmd/app/theme_apply.go
@@ -124,6 +124,11 @@ func applyTheme(p theme.Palette) {
 		Background(p.CursorSelectedBG).
 		Foreground(textOnCursorSelected)
 	// cursorStyle = lipgloss.NewStyle().Background(p.CursorBG)
+
+	// Refresh flash uses a success/green-ish highlight
+	refreshFlashStyle = lipgloss.NewStyle().
+		Background(p.Success).
+		Foreground(textOnSelected)
 }
 
 // applyThemeToModel applies the current theme to model components that need it

--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -250,6 +250,9 @@ var (
 	// Cursor sitting on a selected row should stand out
 	cursorOnSelectedStyle = lipgloss.NewStyle().
 				Background(cyanBright)
+	// Flash highlight for refresh feedback
+	refreshFlashStyle = lipgloss.NewStyle().
+			Background(syncedColor)
 
 	// Status bar style (matches MainLayout status line)
 	statusStyle = lipgloss.NewStyle().

--- a/cmd/app/view_lists.go
+++ b/cmd/app/view_lists.go
@@ -275,8 +275,13 @@ func (m *Model) renderAppRow(app model.App, isCursor bool) string {
 		row = clipAnsiToWidth(row, fullRowWidth)
 	}
 
+	// Check if this app should flash (refresh feedback)
+	isFlashing := m.state.UI.RefreshFlashApps != nil && m.state.UI.RefreshFlashApps[app.Name]
+
 	// Apply highlight: use a distinct style when cursor overlaps a selected row
-	if isCursor && isSelected {
+	if isFlashing {
+		row = refreshFlashStyle.Render(row)
+	} else if isCursor && isSelected {
 		row = cursorOnSelectedStyle.Render(row)
 	} else if active { // cursor or selected
 		row = selectedStyle.Render(row)

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -50,14 +50,16 @@ func (m *Model) renderHelpModal() string {
 		"\n",
 		mono(":diff"), " [app] ", bullet(), " ", mono(":sync"), " [app] ", bullet(), " ", mono(":rollback"), " [app] ", bullet(), " ", mono(":delete"), " [app]",
 		"\n",
-		mono(":resources"), " [app] ", bullet(), " ", mono(":sort"), " health|sync asc|desc ", bullet(), " ", mono(":up"), " ", bullet(), " ", mono(":all"),
+		mono(":refresh"), " [app] ", bullet(), " ", mono(":refresh!"), " [app] (hard) ", bullet(), " ", mono(":sort"), " health|sync asc|desc",
+		"\n",
+		mono(":resources"), " [app] ", bullet(), " ", mono(":up"), " ", bullet(), " ", mono(":all"),
 	}, "")
 
 	// TREE VIEW - hotkeys specific to tree/resources view
 	treeView := strings.Join([]string{
 		mono("/"), " filter ", bullet(), " ", mono("n"), "/", mono("N"), " next/prev match ", bullet(), " ", keycap("d"), " diff ", bullet(), " ", mono("K"), " open in k9s",
 		"\n",
-		keycap("Space"), " select ", bullet(), " ", keycap("s"), " sync ", bullet(), " ", keycap("Ctrl+D"), " delete ", bullet(), " ", mono(":up"), " return to apps",
+		keycap("Space"), " select ", bullet(), " ", keycap("s"), " sync ", bullet(), " ", keycap("Ctrl+D"), " delete ", bullet(), " ", mono(":refresh"), "|", mono(":refresh!"), " ", bullet(), " ", mono(":up"),
 	}, "")
 
 	var helpSections []string

--- a/e2e/refresh_test.go
+++ b/e2e/refresh_test.go
@@ -1,0 +1,216 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---- Refresh capturing mock server ----
+
+type RefreshCall struct {
+	Name string
+	Hard bool // true if refresh=hard, false if refresh=true
+}
+
+type RefreshRecorder struct {
+	mu    sync.Mutex
+	Calls []RefreshCall
+}
+
+func (rr *RefreshRecorder) add(call RefreshCall) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	rr.Calls = append(rr.Calls, call)
+}
+
+func (rr *RefreshRecorder) len() int {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	return len(rr.Calls)
+}
+
+// MockArgoServerRefresh returns an auth-checking server and a recorder for refresh calls
+func MockArgoServerRefresh(validToken string) (*httptest.Server, *RefreshRecorder, error) {
+	rec := &RefreshRecorder{}
+	mux := http.NewServeMux()
+	requireAuth := func(w http.ResponseWriter, r *http.Request) bool {
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+validToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			return false
+		}
+		return true
+	}
+	mux.HandleFunc("/api/v1/session/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		_, _ = w.Write([]byte(`{"version":"e2e"}`))
+	})
+	mux.HandleFunc("/api/v1/applications", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[
+            {"metadata":{"name":"demo","namespace":"argocd"},"spec":{"project":"demo","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Healthy"}}},
+            {"metadata":{"name":"demo2","namespace":"argocd"},"spec":{"project":"demo","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Healthy"}}}
+        ]}`))
+	})
+	mux.HandleFunc("/api/v1/applications/demo/resource-tree", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		_, _ = w.Write([]byte(`{"nodes":[]}`))
+	})
+	mux.HandleFunc("/api/v1/applications/demo2/resource-tree", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		_, _ = w.Write([]byte(`{"nodes":[]}`))
+	})
+
+	// Handler for individual application GET with refresh query param
+	mux.HandleFunc("/api/v1/applications/", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+
+		// Extract app name from path: /api/v1/applications/<name>
+		p := r.URL.Path
+		segs := strings.Split(strings.TrimPrefix(p, "/api/v1/applications/"), "/")
+		if len(segs) == 0 || segs[0] == "" {
+			http.NotFound(w, r)
+			return
+		}
+		name := segs[0]
+
+		// Check for refresh query param
+		refreshParam := r.URL.Query().Get("refresh")
+		if refreshParam != "" {
+			hard := refreshParam == "hard"
+			rec.add(RefreshCall{Name: name, Hard: hard})
+		}
+
+		// Return app JSON
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"metadata":{"name":"` + name + `","namespace":"argocd"},"spec":{"project":"demo","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Healthy"}}}`))
+	})
+
+	// SSE stream endpoint (required for app to start properly)
+	mux.HandleFunc("/api/v1/stream/applications", func(w http.ResponseWriter, r *http.Request) {
+		if !requireAuth(w, r) {
+			return
+		}
+		fl, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "application/json")
+		// Send one event and return (don't block)
+		_, _ = w.Write([]byte(`data: {"result":{"type":"MODIFIED","application":{"metadata":{"name":"demo","namespace":"argocd"},"spec":{"project":"demo","destination":{"name":"cluster-a","namespace":"default"}},"status":{"sync":{"status":"OutOfSync"},"health":{"status":"Healthy"}}}}}` + "\n"))
+		if fl != nil {
+			fl.Flush()
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv, rec, nil
+}
+
+// TestRefreshCommand tests both :refresh and :refresh! commands
+func TestRefreshCommand(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, rec, err := MockArgoServerRefresh("valid-token")
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigWithToken(cfgPath, srv.URL, "valid-token"); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Navigate to apps view
+	if !tf.WaitForPlain("cluster-a", 3*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("ns default")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo", 3*time.Second) {
+		t.Fatal("projects not ready")
+	}
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+	if !tf.WaitForPlain("demo2", 3*time.Second) {
+		t.Fatal("apps not ready")
+	}
+
+	// Test 1: Normal refresh with :refresh command
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("refresh")
+	_ = tf.Enter()
+
+	// Wait for refresh call
+	if !waitUntil(t, func() bool { return rec.len() >= 1 }, 2*time.Second) {
+		t.Fatalf("expected at least 1 refresh call, got %d\n%s", rec.len(), tf.SnapshotPlain())
+	}
+
+	call := rec.Calls[0]
+	if call.Name != "demo" {
+		t.Fatalf("expected refresh for 'demo', got %q", call.Name)
+	}
+	if call.Hard {
+		t.Fatal("expected normal refresh (hard=false), got hard refresh")
+	}
+
+	// Test 2: Hard refresh with :refresh! command
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("refresh!")
+	_ = tf.Enter()
+
+	// Wait for second refresh call
+	if !waitUntil(t, func() bool { return rec.len() >= 2 }, 2*time.Second) {
+		t.Fatalf("expected at least 2 refresh calls, got %d\n%s", rec.len(), tf.SnapshotPlain())
+	}
+
+	call2 := rec.Calls[1]
+	if call2.Name != "demo" {
+		t.Fatalf("expected hard refresh for 'demo', got %q", call2.Name)
+	}
+	if !call2.Hard {
+		t.Fatal("expected hard refresh (hard=true), got normal refresh")
+	}
+}

--- a/pkg/autocomplete/autocomplete.go
+++ b/pkg/autocomplete/autocomplete.go
@@ -162,6 +162,20 @@ func NewAutocompleteEngine() *AutocompleteEngine {
 			TakesArg:    false,
 			ArgType:     "",
 		},
+		{
+			Command:     "refresh",
+			Aliases:     []string{"refresh", "ref"},
+			Description: "Refresh application (compare with git)",
+			TakesArg:    true,
+			ArgType:     "app",
+		},
+		{
+			Command:     "refresh!",
+			Aliases:     []string{"refresh!"},
+			Description: "Hard refresh application (invalidate cache)",
+			TakesArg:    true,
+			ArgType:     "app",
+		},
 	}
 
 	// Build alias map

--- a/pkg/model/messages.go
+++ b/pkg/model/messages.go
@@ -352,6 +352,24 @@ type MultiDeleteCompletedMsg struct {
 	Success  bool
 }
 
+// RefreshCompletedMsg indicates a single app refresh has completed
+type RefreshCompletedMsg struct {
+	AppName string
+	Success bool
+	Hard    bool // Indicates if it was a hard refresh
+	Error   error
+}
+
+// MultiRefreshCompletedMsg indicates multiple app refresh has completed
+type MultiRefreshCompletedMsg struct {
+	AppCount int
+	Success  bool
+	Hard     bool
+}
+
+// ClearRefreshFlashMsg clears the refresh flash highlight after timeout
+type ClearRefreshFlashMsg struct{}
+
 // Rollback Messages - for rollback functionality
 
 // RollbackHistoryLoadedMsg is sent when rollback history is loaded

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -98,21 +98,23 @@ func (s *SelectionState) ToggleSelectedApp(app string) {
 
 // UIState holds UI-related state
 type UIState struct {
-	SearchQuery         string      `json:"searchQuery"`
-	ActiveFilter        string      `json:"activeFilter"`
-	Command             string      `json:"command"`
-	IsVersionOutdated   bool        `json:"isVersionOutdated"`
-	LatestVersion       *string     `json:"latestVersion,omitempty"`
-	UpdateInfo          *UpdateInfo `json:"updateInfo,omitempty"`
-	CommandInputKey     int         `json:"commandInputKey"`
-	TreeAppName         *string     `json:"treeAppName,omitempty"`
-	ThemeSelectedIndex  int         `json:"themeSelectedIndex"`
-	ThemeScrollOffset   int         `json:"themeScrollOffset"`
-	ThemeOriginalName   string      `json:"themeOriginalName,omitempty"`
-	CommandInvalid      bool        `json:"commandInvalid"`
-	Sort                SortConfig  `json:"sort"`
-	ShowWhatsNew        bool        `json:"showWhatsNew"`
-	WhatsNewShownAt     *time.Time  `json:"whatsNewShownAt,omitempty"`
+	SearchQuery         string          `json:"searchQuery"`
+	ActiveFilter        string          `json:"activeFilter"`
+	Command             string          `json:"command"`
+	IsVersionOutdated   bool            `json:"isVersionOutdated"`
+	LatestVersion       *string         `json:"latestVersion,omitempty"`
+	UpdateInfo          *UpdateInfo     `json:"updateInfo,omitempty"`
+	CommandInputKey     int             `json:"commandInputKey"`
+	TreeAppName         *string         `json:"treeAppName,omitempty"`
+	ThemeSelectedIndex  int             `json:"themeSelectedIndex"`
+	ThemeScrollOffset   int             `json:"themeScrollOffset"`
+	ThemeOriginalName   string          `json:"themeOriginalName,omitempty"`
+	CommandInvalid      bool            `json:"commandInvalid"`
+	Sort                SortConfig      `json:"sort"`
+	ShowWhatsNew        bool            `json:"showWhatsNew"`
+	WhatsNewShownAt     *time.Time      `json:"whatsNewShownAt,omitempty"`
+	RefreshFlashApps    map[string]bool `json:"-"` // Apps to highlight after refresh (transient)
+	RefreshFlashTree    bool            `json:"-"` // Flash tree view after refresh (transient)
 }
 
 // ModalState holds modal-related state


### PR DESCRIPTION
Add commands to refresh ArgoCD applications:
- :refresh (alias: ref) - normal refresh, compares with git
- :refresh! - hard refresh, invalidates manifest cache

Features:
- Works in apps view (single app, multi-select, or with argument)
- Works in tree view (refreshes the parent app)
- Immediate execution without confirmation modal
- Visual feedback: flashes refreshed rows green for 1 second

API: Uses GET /api/v1/applications/{name}?refresh=true|hard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added :refresh and :refresh! commands (single-app and multi-app modes) with optional hard refresh.
  * Visual flash feedback in apps and tree views shows which apps were refreshed.

* **Documentation**
  * Help text updated to include refresh and hard-refresh commands in Apps and Tree views.

* **Tests**
  * Added end-to-end tests that exercise refresh (normal and hard) against a mocked API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->