### PR TITLE
Fix vendor hash update script escaping

### DIFF
--- a/.github/workflows/update-nix-vendorhash.yml
+++ b/.github/workflows/update-nix-vendorhash.yml
@@ -1,0 +1,70 @@
+name: Update Nix vendorHash
+
+on:
+  pull_request:
+    paths:
+      - go.mod
+      - go.sum
+      - flake.nix
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-vendorhash:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Update vendorHash
+        id: update
+        run: ./scripts/update-vendorhash.sh
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit updated vendorHash to PR branch
+        if: steps.diff.outputs.changed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          git config user.name "argonaut-bot"
+          git config user.email "argonaut-bot@users.noreply.github.com"
+          git commit -am "chore: update Nix vendor hash"
+          git push
+
+      - name: Create pull request with updated vendorHash
+        if: steps.diff.outputs.changed == 'true' && github.event_name == 'workflow_dispatch'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: update Nix vendor hash"
+          branch: bot/update-nix-vendor-hash
+          delete-branch: true
+          title: "chore: update Nix vendor hash"
+          body: |
+            Update the Nix vendorHash to match current Go dependencies.
+
+      - name: Fail if vendorHash update is required
+        if: steps.diff.outputs.changed == 'true' && !(github.event_name == 'workflow_dispatch') && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          echo "::error::Nix vendorHash is outdated. Run ./scripts/update-vendorhash.sh and push the result." >&2
+          exit 1
+
+      - name: Vendor hash already up to date
+        if: steps.diff.outputs.changed == 'false'
+        run: echo "Nix vendorHash already up to date."

--- a/scripts/update-vendorhash.sh
+++ b/scripts/update-vendorhash.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="flake.nix"
+
+if [[ ! -f "$FILE" ]]; then
+  echo "Cannot find $FILE. Run this script from the repository root." >&2
+  exit 1
+fi
+
+# 1) Force a mismatch so Nix tells us the correct hash
+perl -0777 -i -pe 's/vendorHash\s*=\s*".*?";/vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";/' "$FILE"
+
+# 2) Build and capture the expected hash from stderr
+out="$( (nix build .#default -L 2>&1 || true) )"
+
+# Nix typically prints: got:    sha256-...
+new_hash="$(printf "%s" "$out" | sed -n 's/.*got:\s*\(sha256-[A-Za-z0-9+/=]\+\).*/\1/p' | tail -n1)"
+
+if [[ -z "${new_hash}" ]]; then
+  echo "Could not extract vendorHash. Build output was:" >&2
+  echo "$out" >&2
+  exit 1
+fi
+
+# Escape slashes for Perl's substitution delimiter
+escaped_hash=${new_hash//\//\\/}
+
+# 3) Write the correct hash back
+perl -0777 -i -pe "s/vendorHash\\s*=\\s*\".*?\";/vendorHash = \"${escaped_hash}\";/" "$FILE"
+
+echo "Updated vendorHash to: ${new_hash}"


### PR DESCRIPTION
## Summary
- escape vendorHash values before Perl substitution to handle slashes safely

## Testing
- bash -n scripts/update-vendorhash.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dd8e021c48325b58a544092c06372)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated GitHub Actions workflow to streamline Nix dependency updates, reducing manual maintenance overhead in the development process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->