### PR TITLE
fix: removed broken modal background fill

### DIFF
--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -783,7 +783,6 @@ func (m *Model) renderConfirmSyncModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(modalWidth)
 

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -128,7 +128,6 @@ func (m *Model) renderRollbackLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(outOfSyncColor).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 28
 	w := max(minW, lipgloss.Width(content)+4)
@@ -143,7 +142,6 @@ func (m *Model) renderSyncLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 24
 	w := max(minW, lipgloss.Width(content)+4)
@@ -158,7 +156,6 @@ func (m *Model) renderChangelogLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 28
 	w := max(minW, lipgloss.Width(content)+4)
@@ -173,7 +170,6 @@ func (m *Model) renderInitialLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(magentaBright).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 32
 	w := max(minW, lipgloss.Width(content)+4)
@@ -188,7 +184,6 @@ func (m *Model) renderNoServerModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(magentaBright).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 40
 	w := max(minW, lipgloss.Width(content)+4)
@@ -324,7 +319,6 @@ func (m *Model) renderUpgradeConfirmModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(68).
 		AlignHorizontal(lipgloss.Center)
@@ -416,7 +410,6 @@ func (m *Model) renderUpgradeLoadingModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(50).
 		AlignHorizontal(lipgloss.Center)
@@ -445,7 +438,6 @@ func (m *Model) renderUpgradeErrorModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(redColor).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(80).
 		AlignHorizontal(lipgloss.Center)
@@ -466,7 +458,6 @@ func (m *Model) renderUpgradeSuccessModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(syncedColor).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(60).
 		AlignHorizontal(lipgloss.Center)
@@ -565,7 +556,6 @@ func (m *Model) renderAppDeleteConfirmModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(outOfSyncColor).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(modalWidth)
 
@@ -631,7 +621,6 @@ func (m *Model) renderAppDeleteLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(outOfSyncColor).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 32
 	w := max(minW, lipgloss.Width(content)+4)
@@ -690,7 +679,6 @@ func (m *Model) renderResourceDeleteConfirmModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(outOfSyncColor).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(modalWidth)
 
@@ -767,7 +755,6 @@ func (m *Model) renderResourceDeleteLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(outOfSyncColor).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 32
 	w := max(minW, lipgloss.Width(content)+4)
@@ -828,7 +815,6 @@ func (m *Model) renderResourceSyncConfirmModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(syncedColor).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(modalWidth)
 
@@ -890,7 +876,6 @@ func (m *Model) renderResourceSyncLoadingModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(syncedColor).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 32
 	w := max(minW, lipgloss.Width(content)+4)
@@ -906,7 +891,6 @@ func (m *Model) renderNoDiffModal() string {
 	wrapper := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(syncedColor).
-		Background(darkBG).
 		Padding(1, 2)
 	minW := 28
 	w := max(minW, lipgloss.Width(content)+4)
@@ -975,7 +959,6 @@ func (m *Model) renderK9sContextSelectionModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(50).
 		AlignHorizontal(lipgloss.Left)
@@ -994,7 +977,6 @@ func (m *Model) renderK9sErrorModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(redColor).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(60).
 		AlignHorizontal(lipgloss.Center)
@@ -1100,7 +1082,6 @@ func (m *Model) renderThemeSelectionModal() string {
 	modalStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(darkBG).
 		Padding(1, 2).
 		Width(44).
 		AlignHorizontal(lipgloss.Left)


### PR DESCRIPTION
## Summary
- Removes explicit `Background(darkBG)` from all modal styles
- Modals now use terminal's default background, matching the rest of the app

## Context
PR #178 added `Background(darkBG)` to modal styles to make them consistent, but `darkBG` is ANSI color 0 (black) which doesn't match the terminal's actual background color. This caused modals to appear with a different background than the rest of the app.

## Test plan
- [x] Build passes
- [x] All unit tests pass
- [ ] Verify modals display correctly with various terminal themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed explicit dark background styling from modals throughout the application. Modals now inherit default background styling instead of using a fixed dark color scheme. All other modal styling including borders and padding remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->