### PR TITLE
feat: k9s opens with resource name filter pre-applied

### DIFF
--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -1698,7 +1698,7 @@ func (m *Model) handleOpenK9s() (tea.Model, tea.Cmd) {
 		if err != nil || len(contexts) == 0 {
 			// No kubeconfig or no contexts - just launch k9s without context
 			cblog.With("component", "k9s").Warn("Could not load kubeconfig contexts", "err", err)
-			return m, m.openK9s(kind, namespace, "")
+			return m, m.openK9s(kind, namespace, "", name)
 		}
 
 		// Always show picker - even with single context, user must confirm
@@ -1706,11 +1706,12 @@ func (m *Model) handleOpenK9s() (tea.Model, tea.Cmd) {
 		m.k9sContextSelected = 0
 		m.k9sPendingKind = kind
 		m.k9sPendingNamespace = namespace
+		m.k9sPendingName = name
 		m.state.Mode = model.ModeK9sContextSelect
 		return m, nil
 	}
 
-	return m, m.openK9s(kind, namespace, context)
+	return m, m.openK9s(kind, namespace, context, name)
 }
 
 // handleK9sContextSelectKeys handles input when selecting a kubeconfig context for k9s
@@ -1725,6 +1726,9 @@ func (m *Model) handleK9sContextSelectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		// Cancel context selection
 		m.state.Mode = model.ModeNormal
 		m.k9sContextOptions = nil
+		m.k9sPendingKind = ""
+		m.k9sPendingNamespace = ""
+		m.k9sPendingName = ""
 		return m, nil
 	case "up", "k":
 		if m.k9sContextSelected > 0 {
@@ -1741,14 +1745,16 @@ func (m *Model) handleK9sContextSelectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		selectedContext := m.k9sContextOptions[m.k9sContextSelected]
 		kind := m.k9sPendingKind
 		namespace := m.k9sPendingNamespace
+		name := m.k9sPendingName
 
 		// Clear state
 		m.k9sContextOptions = nil
 		m.k9sPendingKind = ""
 		m.k9sPendingNamespace = ""
+		m.k9sPendingName = ""
 		m.state.Mode = model.ModeNormal
 
-		return m, m.openK9s(kind, namespace, selectedContext)
+		return m, m.openK9s(kind, namespace, selectedContext, name)
 	}
 
 	return m, nil

--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -1698,7 +1698,11 @@ func (m *Model) handleOpenK9s() (tea.Model, tea.Cmd) {
 		if err != nil || len(contexts) == 0 {
 			// No kubeconfig or no contexts - just launch k9s without context
 			cblog.With("component", "k9s").Warn("Could not load kubeconfig contexts", "err", err)
-			return m, m.openK9s(kind, namespace, "", name)
+			return m, m.openK9s(K9sResourceParams{
+				Kind:      kind,
+				Namespace: namespace,
+				Name:      name,
+			})
 		}
 
 		// Always show picker - even with single context, user must confirm
@@ -1711,7 +1715,12 @@ func (m *Model) handleOpenK9s() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	return m, m.openK9s(kind, namespace, context, name)
+	return m, m.openK9s(K9sResourceParams{
+		Kind:      kind,
+		Namespace: namespace,
+		Context:   context,
+		Name:      name,
+	})
 }
 
 // handleK9sContextSelectKeys handles input when selecting a kubeconfig context for k9s
@@ -1754,7 +1763,12 @@ func (m *Model) handleK9sContextSelectKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.k9sPendingName = ""
 		m.state.Mode = model.ModeNormal
 
-		return m, m.openK9s(kind, namespace, selectedContext, name)
+		return m, m.openK9s(K9sResourceParams{
+			Kind:      kind,
+			Namespace: namespace,
+			Context:   selectedContext,
+			Name:      name,
+		})
 	}
 
 	return m, nil

--- a/cmd/app/k9s_sandbox.go
+++ b/cmd/app/k9s_sandbox.go
@@ -21,7 +21,7 @@ import (
 )
 
 // openK9s runs k9s in a PTY with a status bar at the bottom showing Argonaut context
-func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
+func (m *Model) openK9s(params K9sResourceParams) tea.Cmd {
 	return func() tea.Msg {
 		if m.program != nil {
 			m.program.Send(pauseRenderingMsg{})
@@ -45,25 +45,26 @@ func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 		}
 
 		// Map the kind to k9s resource alias
-		resourceAlias := kind
-		if alias, ok := k9sResourceMap[kind]; ok {
+		resourceAlias := params.Kind
+		if alias, ok := k9sResourceMap[params.Kind]; ok {
 			resourceAlias = alias
 		} else {
-			resourceAlias = strings.ToLower(kind)
+			resourceAlias = strings.ToLower(params.Kind)
 		}
 
 		// Build args - include filter if name is provided
 		var args []string
-		if name != "" {
-			args = []string{"-c", fmt.Sprintf("%s /%s", resourceAlias, name)}
+		if params.Name != "" {
+			args = []string{"-c", fmt.Sprintf("%s /%s", resourceAlias, params.Name)}
 		} else {
 			args = []string{"-c", resourceAlias}
 		}
-		if namespace != "" {
-			args = append(args, "-n", namespace)
+		if params.Namespace != "" {
+			args = append(args, "-n", params.Namespace)
 		}
 
 		// Allow context override via config
+		context := params.Context
 		if cfgCtx := m.config.GetK9sContext(); cfgCtx != "" {
 			context = cfgCtx
 		}
@@ -138,7 +139,7 @@ func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 
 		// Clear screen and draw initial status bar
 		fmt.Print("\x1b[2J\x1b[H")
-		drawStatusBarBottom(rows, cols, kind, namespace, context, name)
+		drawStatusBarBottom(rows, cols, params)
 
 		// Set up input forwarding from stdin to PTY with cancellation
 		// Note: On Unix terminals, blocking reads on stdin cannot be interrupted
@@ -164,7 +165,7 @@ func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 		}()
 
 		// Process k9s output and inject status bar at frame boundaries
-		processK9sOutputWithStatusBar(ptmx, &sizeMu, &currentRows, &currentCols, kind, namespace, context, name)
+		processK9sOutputWithStatusBar(ptmx, &sizeMu, &currentRows, &currentCols, params)
 
 		// Wait for k9s to exit
 		if err := cmd.Wait(); err != nil {
@@ -188,7 +189,7 @@ func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 }
 
 // processK9sOutputWithStatusBar reads k9s output and injects status bar at frame boundaries
-func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols *int, kind, namespace, context, name string) {
+func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols *int, params K9sResourceParams) {
 	buf := make([]byte, 32*1024)
 
 	for {
@@ -202,7 +203,7 @@ func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols
 			sizeMu.Unlock()
 
 			// Look for frame boundaries and inject status bar
-			output := injectStatusBarAtFrameBoundaries(data, r, c, kind, namespace, context, name)
+			output := injectStatusBarAtFrameBoundaries(data, r, c, params)
 
 			os.Stdout.Write(output)
 		}
@@ -213,9 +214,9 @@ func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols
 }
 
 // injectStatusBarAtFrameBoundaries finds frame boundary sequences and injects status bar after them
-func injectStatusBarAtFrameBoundaries(data []byte, rows, cols int, kind, namespace, context, name string) []byte {
+func injectStatusBarAtFrameBoundaries(data []byte, rows, cols int, params K9sResourceParams) []byte {
 	// Build the status bar injection sequence
-	statusBar := buildStatusBarSequence(rows, cols, kind, namespace, context, name)
+	statusBar := buildStatusBarSequence(rows, cols, params)
 
 	// Patterns that indicate frame boundaries:
 	// ESC[2J - clear entire screen (clears our status bar too!)
@@ -264,7 +265,7 @@ func injectStatusBarAtFrameBoundaries(data []byte, rows, cols int, kind, namespa
 }
 
 // buildStatusBarSequence creates the ANSI sequence to draw the status bar on the last row
-func buildStatusBarSequence(rows, cols int, kind, namespace, context, name string) []byte {
+func buildStatusBarSequence(rows, cols int, params K9sResourceParams) []byte {
 	var buf bytes.Buffer
 
 	// Save cursor, move to last row, clear line
@@ -274,18 +275,18 @@ func buildStatusBarSequence(rows, cols int, kind, namespace, context, name strin
 
 	// Build status bar content
 	left := " Argonaut » k9s"
-	if kind != "" {
-		left += fmt.Sprintf(" (%s", kind)
-		if namespace != "" {
-			left += "/" + namespace
+	if params.Kind != "" {
+		left += fmt.Sprintf(" (%s", params.Kind)
+		if params.Namespace != "" {
+			left += "/" + params.Namespace
 		}
-		if name != "" {
-			left += ": " + name
+		if params.Name != "" {
+			left += ": " + params.Name
 		}
 		left += ")"
 	}
-	if context != "" {
-		left += " [" + context + "]"
+	if params.Context != "" {
+		left += " [" + params.Context + "]"
 	}
 	right := ":q to return "
 
@@ -309,8 +310,8 @@ func buildStatusBarSequence(rows, cols int, kind, namespace, context, name strin
 }
 
 // drawStatusBarBottom draws the status bar on the last row of the terminal (for initial draw)
-func drawStatusBarBottom(rows, cols int, kind, namespace, context, name string) {
-	os.Stdout.Write(buildStatusBarSequence(rows, cols, kind, namespace, context, name))
+func drawStatusBarBottom(rows, cols int, params K9sResourceParams) {
+	os.Stdout.Write(buildStatusBarSequence(rows, cols, params))
 }
 
 // getTerminalSize returns the current terminal rows and cols

--- a/cmd/app/k9s_sandbox.go
+++ b/cmd/app/k9s_sandbox.go
@@ -21,7 +21,7 @@ import (
 )
 
 // openK9s runs k9s in a PTY with a status bar at the bottom showing Argonaut context
-func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
+func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 	return func() tea.Msg {
 		if m.program != nil {
 			m.program.Send(pauseRenderingMsg{})
@@ -52,8 +52,13 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 			resourceAlias = strings.ToLower(kind)
 		}
 
-		// Build args
-		args := []string{"-c", resourceAlias}
+		// Build args - include filter if name is provided
+		var args []string
+		if name != "" {
+			args = []string{"-c", fmt.Sprintf("%s /%s", resourceAlias, name)}
+		} else {
+			args = []string{"-c", resourceAlias}
+		}
 		if namespace != "" {
 			args = append(args, "-n", namespace)
 		}
@@ -133,7 +138,7 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 
 		// Clear screen and draw initial status bar
 		fmt.Print("\x1b[2J\x1b[H")
-		drawStatusBarBottom(rows, cols, kind, namespace, context)
+		drawStatusBarBottom(rows, cols, kind, namespace, context, name)
 
 		// Set up input forwarding from stdin to PTY with cancellation
 		// Note: On Unix terminals, blocking reads on stdin cannot be interrupted
@@ -159,7 +164,7 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 		}()
 
 		// Process k9s output and inject status bar at frame boundaries
-		processK9sOutputWithStatusBar(ptmx, &sizeMu, &currentRows, &currentCols, kind, namespace, context)
+		processK9sOutputWithStatusBar(ptmx, &sizeMu, &currentRows, &currentCols, kind, namespace, context, name)
 
 		// Wait for k9s to exit
 		if err := cmd.Wait(); err != nil {
@@ -183,7 +188,7 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 }
 
 // processK9sOutputWithStatusBar reads k9s output and injects status bar at frame boundaries
-func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols *int, kind, namespace, context string) {
+func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols *int, kind, namespace, context, name string) {
 	buf := make([]byte, 32*1024)
 
 	for {
@@ -197,7 +202,7 @@ func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols
 			sizeMu.Unlock()
 
 			// Look for frame boundaries and inject status bar
-			output := injectStatusBarAtFrameBoundaries(data, r, c, kind, namespace, context)
+			output := injectStatusBarAtFrameBoundaries(data, r, c, kind, namespace, context, name)
 
 			os.Stdout.Write(output)
 		}
@@ -208,9 +213,9 @@ func processK9sOutputWithStatusBar(ptmx *os.File, sizeMu *sync.Mutex, rows, cols
 }
 
 // injectStatusBarAtFrameBoundaries finds frame boundary sequences and injects status bar after them
-func injectStatusBarAtFrameBoundaries(data []byte, rows, cols int, kind, namespace, context string) []byte {
+func injectStatusBarAtFrameBoundaries(data []byte, rows, cols int, kind, namespace, context, name string) []byte {
 	// Build the status bar injection sequence
-	statusBar := buildStatusBarSequence(rows, cols, kind, namespace, context)
+	statusBar := buildStatusBarSequence(rows, cols, kind, namespace, context, name)
 
 	// Patterns that indicate frame boundaries:
 	// ESC[2J - clear entire screen (clears our status bar too!)
@@ -259,7 +264,7 @@ func injectStatusBarAtFrameBoundaries(data []byte, rows, cols int, kind, namespa
 }
 
 // buildStatusBarSequence creates the ANSI sequence to draw the status bar on the last row
-func buildStatusBarSequence(rows, cols int, kind, namespace, context string) []byte {
+func buildStatusBarSequence(rows, cols int, kind, namespace, context, name string) []byte {
 	var buf bytes.Buffer
 
 	// Save cursor, move to last row, clear line
@@ -273,6 +278,9 @@ func buildStatusBarSequence(rows, cols int, kind, namespace, context string) []b
 		left += fmt.Sprintf(" (%s", kind)
 		if namespace != "" {
 			left += "/" + namespace
+		}
+		if name != "" {
+			left += ": " + name
 		}
 		left += ")"
 	}
@@ -301,8 +309,8 @@ func buildStatusBarSequence(rows, cols int, kind, namespace, context string) []b
 }
 
 // drawStatusBarBottom draws the status bar on the last row of the terminal (for initial draw)
-func drawStatusBarBottom(rows, cols int, kind, namespace, context string) {
-	os.Stdout.Write(buildStatusBarSequence(rows, cols, kind, namespace, context))
+func drawStatusBarBottom(rows, cols int, kind, namespace, context, name string) {
+	os.Stdout.Write(buildStatusBarSequence(rows, cols, kind, namespace, context, name))
 }
 
 // getTerminalSize returns the current terminal rows and cols

--- a/cmd/app/k9s_sandbox_other.go
+++ b/cmd/app/k9s_sandbox_other.go
@@ -14,7 +14,7 @@ import (
 )
 
 // openK9s on non-Unix systems falls back to running k9s without the status bar sandbox
-func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
+func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 	return func() tea.Msg {
 		if m.program != nil {
 			m.program.Send(pauseRenderingMsg{})
@@ -45,8 +45,13 @@ func (m *Model) openK9s(kind, namespace, context string) tea.Cmd {
 			resourceAlias = strings.ToLower(kind)
 		}
 
-		// Build args
-		args := []string{"-c", resourceAlias}
+		// Build args - include filter if name is provided
+		var args []string
+		if name != "" {
+			args = []string{"-c", fmt.Sprintf("%s /%s", resourceAlias, name)}
+		} else {
+			args = []string{"-c", resourceAlias}
+		}
 		if namespace != "" {
 			args = append(args, "-n", namespace)
 		}

--- a/cmd/app/k9s_sandbox_other.go
+++ b/cmd/app/k9s_sandbox_other.go
@@ -14,7 +14,7 @@ import (
 )
 
 // openK9s on non-Unix systems falls back to running k9s without the status bar sandbox
-func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
+func (m *Model) openK9s(params K9sResourceParams) tea.Cmd {
 	return func() tea.Msg {
 		if m.program != nil {
 			m.program.Send(pauseRenderingMsg{})
@@ -38,25 +38,26 @@ func (m *Model) openK9s(kind, namespace, context, name string) tea.Cmd {
 		}
 
 		// Map the kind to k9s resource alias
-		resourceAlias := kind
-		if alias, ok := k9sResourceMap[kind]; ok {
+		resourceAlias := params.Kind
+		if alias, ok := k9sResourceMap[params.Kind]; ok {
 			resourceAlias = alias
 		} else {
-			resourceAlias = strings.ToLower(kind)
+			resourceAlias = strings.ToLower(params.Kind)
 		}
 
 		// Build args - include filter if name is provided
 		var args []string
-		if name != "" {
-			args = []string{"-c", fmt.Sprintf("%s /%s", resourceAlias, name)}
+		if params.Name != "" {
+			args = []string{"-c", fmt.Sprintf("%s /%s", resourceAlias, params.Name)}
 		} else {
 			args = []string{"-c", resourceAlias}
 		}
-		if namespace != "" {
-			args = append(args, "-n", namespace)
+		if params.Namespace != "" {
+			args = append(args, "-n", params.Namespace)
 		}
 
 		// Allow context override via config
+		context := params.Context
 		if cfgCtx := m.config.GetK9sContext(); cfgCtx != "" {
 			context = cfgCtx
 		}

--- a/cmd/app/k9s_test.go
+++ b/cmd/app/k9s_test.go
@@ -141,7 +141,12 @@ func TestInjectStatusBarAtFrameBoundaries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := injectStatusBarAtFrameBoundaries(tt.input, tt.rows, tt.cols, tt.kind, tt.namespace, tt.context, "")
+			params := K9sResourceParams{
+				Kind:      tt.kind,
+				Namespace: tt.namespace,
+				Context:   tt.context,
+			}
+			output := injectStatusBarAtFrameBoundaries(tt.input, tt.rows, tt.cols, params)
 			tt.check(t, output)
 		})
 	}
@@ -207,7 +212,12 @@ func TestBuildStatusBarSequence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := buildStatusBarSequence(tt.rows, tt.cols, tt.kind, tt.namespace, tt.context, "")
+			params := K9sResourceParams{
+				Kind:      tt.kind,
+				Namespace: tt.namespace,
+				Context:   tt.context,
+			}
+			output := buildStatusBarSequence(tt.rows, tt.cols, params)
 			outputStr := string(output)
 			for _, want := range tt.wantContains {
 				if !strings.Contains(outputStr, want) {

--- a/cmd/app/k9s_test.go
+++ b/cmd/app/k9s_test.go
@@ -141,7 +141,7 @@ func TestInjectStatusBarAtFrameBoundaries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := injectStatusBarAtFrameBoundaries(tt.input, tt.rows, tt.cols, tt.kind, tt.namespace, tt.context)
+			output := injectStatusBarAtFrameBoundaries(tt.input, tt.rows, tt.cols, tt.kind, tt.namespace, tt.context, "")
 			tt.check(t, output)
 		})
 	}
@@ -207,7 +207,7 @@ func TestBuildStatusBarSequence(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := buildStatusBarSequence(tt.rows, tt.cols, tt.kind, tt.namespace, tt.context)
+			output := buildStatusBarSequence(tt.rows, tt.cols, tt.kind, tt.namespace, tt.context, "")
 			outputStr := string(output)
 			for _, want := range tt.wantContains {
 				if !strings.Contains(outputStr, want) {

--- a/cmd/app/k9s_types.go
+++ b/cmd/app/k9s_types.go
@@ -1,0 +1,9 @@
+package main
+
+// K9sResourceParams contains the parameters for opening a resource in k9s
+type K9sResourceParams struct {
+	Kind      string // Kubernetes resource kind (e.g., "Deployment")
+	Namespace string // Resource namespace
+	Context   string // Kubernetes context to use
+	Name      string // Resource name (used as filter in k9s)
+}

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -92,6 +92,7 @@ type Model struct {
 	k9sContextSelected  int      // Selected index in context list
 	k9sPendingKind      string   // Resource kind to open in k9s
 	k9sPendingNamespace string   // Resource namespace to open in k9s
+	k9sPendingName      string   // Resource name to filter in k9s
 
 	// Text selection state for mouse-based copy
 	selection *selection.Selection

--- a/e2e/k9s_test.go
+++ b/e2e/k9s_test.go
@@ -253,9 +253,9 @@ func TestK9s_OpenDeploymentResource(t *testing.T) {
 		t.Fatal("k9s was not invoked")
 	}
 
-	// Should contain -c deploy (resource alias for Deployment)
-	if !strings.Contains(args, "-c deploy") {
-		t.Errorf("expected args to contain '-c deploy', got: %s", args)
+	// Should contain -c 'deploy /demo-deploy' (resource alias + filter for Deployment)
+	if !strings.Contains(args, "-c deploy /demo-deploy") {
+		t.Errorf("expected args to contain '-c deploy /demo-deploy', got: %s", args)
 	}
 
 	// Should contain -n default (namespace)
@@ -351,9 +351,9 @@ func TestK9s_OpenServiceResource(t *testing.T) {
 		t.Fatal("k9s was not invoked")
 	}
 
-	// Should contain -c svc (resource alias for Service)
-	if !strings.Contains(args, "-c svc") {
-		t.Errorf("expected args to contain '-c svc', got: %s", args)
+	// Should contain -c 'svc /demo-svc' (resource alias + filter for Service)
+	if !strings.Contains(args, "-c svc /demo-svc") {
+		t.Errorf("expected args to contain '-c svc /demo-svc', got: %s", args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- When pressing `K` on a resource in tree view, k9s now opens with the resource name pre-applied as a filter
- Makes it easier to jump directly to a specific resource instead of manually filtering
- Uses k9s's built-in filter syntax (`-c 'deploy /name'`) documented in [k9s#789](https://github.com/derailed/k9s/issues/789)

**Before:** `k9s -c deploy -n default` → shows all deployments  
**After:** `k9s -c 'deploy /my-app' -n default` → shows only matching deployments

## Test plan

- [x] All k9s e2e tests pass (9/9)
- [x] Manual test: open tree view, press K on a Deployment, verify k9s opens with filter applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * K9s launcher now preserves and applies a resource name filter during context selection; status bar displays kind, namespace, name and context.
* **Tests**
  * End-to-end and unit tests updated to expect the resource-name filter in K9s invocation and in status rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->