### PR TITLE
refactor: use parameter structs for functions with 3+ args

### DIFF
--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -822,7 +822,14 @@ func (m *Model) executeAppDeletion() (tea.Model, tea.Cmd) {
 		return m, m.deleteSelectedApplications(m.state.Modals.DeleteCascade, m.state.Modals.DeletePropagationPolicy)
 	} else {
 		// Single app deletion
-		return m, m.deleteSingleApplication(appName, m.state.Modals.DeleteAppNamespace, m.state.Modals.DeleteCascade, m.state.Modals.DeletePropagationPolicy)
+		return m, m.deleteSingleApplication(AppDeleteParams{
+			AppName:   appName,
+			Namespace: m.state.Modals.DeleteAppNamespace,
+			Options: DeleteOptions{
+				Cascade:           m.state.Modals.DeleteCascade,
+				PropagationPolicy: m.state.Modals.DeletePropagationPolicy,
+			},
+		})
 	}
 }
 
@@ -961,9 +968,11 @@ func (m *Model) executeResourceDeletion() (tea.Model, tea.Cmd) {
 
 	return m, m.deleteSelectedResources(
 		m.state.Modals.ResourceDeleteTargets,
-		m.state.Modals.ResourceDeleteCascade,
-		m.state.Modals.ResourceDeletePropagationPolicy,
-		m.state.Modals.ResourceDeleteForce,
+		DeleteOptions{
+			Cascade:           m.state.Modals.ResourceDeleteCascade,
+			PropagationPolicy: m.state.Modals.ResourceDeletePropagationPolicy,
+			Force:             m.state.Modals.ResourceDeleteForce,
+		},
 	)
 }
 
@@ -1642,7 +1651,13 @@ func (m *Model) handleResourceDiff() (*Model, tea.Cmd) {
 	}
 	m.state.Diff.Loading = true
 
-	return m, m.startResourceDiffSession(appName, group, kind, namespace, name)
+	return m, m.startResourceDiffSession(ResourceIdentifier{
+		AppName:   appName,
+		Group:     group,
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+	})
 }
 
 // handleOpenK9s opens k9s for the currently selected resource in tree view

--- a/cmd/app/resource_types.go
+++ b/cmd/app/resource_types.go
@@ -1,0 +1,32 @@
+package main
+
+// ResourceIdentifier contains the parameters to identify a Kubernetes resource
+type ResourceIdentifier struct {
+	AppName   string // ArgoCD application name
+	Group     string // Kubernetes API group (e.g., "apps", "")
+	Kind      string // Kubernetes resource kind (e.g., "Deployment")
+	Namespace string // Resource namespace
+	Name      string // Resource name
+}
+
+// TLSConfig contains TLS certificate configuration
+type TLSConfig struct {
+	CACertFile     string // Path to CA certificate file
+	CACertDir      string // Path to CA certificate directory
+	ClientCertFile string // Path to client certificate file
+	ClientKeyFile  string // Path to client key file
+}
+
+// DeleteOptions contains options for deleting resources
+type DeleteOptions struct {
+	Cascade           bool   // Whether to cascade delete dependent resources
+	PropagationPolicy string // Deletion propagation policy
+	Force             bool   // Force deletion (for resource deletion)
+}
+
+// AppDeleteParams contains parameters for deleting an application
+type AppDeleteParams struct {
+	AppName   string  // Application name
+	Namespace *string // Application namespace (optional)
+	Options   DeleteOptions
+}


### PR DESCRIPTION
## Summary

Introduces parameter structs for functions with 3+ arguments to improve readability and maintainability. This establishes a convention for the codebase going forward.

### New Types (in `resource_types.go`)

- **ResourceIdentifier**: Groups K8s resource identity (appName, group, kind, namespace, name)
- **TLSConfig**: Groups TLS certificate configuration  
- **DeleteOptions**: Groups delete operation options (cascade, propagationPolicy, force)
- **AppDeleteParams**: Combines app identity with delete options

### Updated Functions

| Function | Before | After |
|----------|--------|-------|
| `startResourceDiffSession` | 5 string params | `ResourceIdentifier` |
| `setupTLSTrust` | 4 string params | `TLSConfig` |
| `deleteApplicationHelper` | 6 params | `AppDeleteParams` |
| `deleteSingleApplication` | 4 params | `AppDeleteParams` |
| `deleteSelectedResources` | 4 params | `DeleteOptions` |

## Test plan

- [x] All unit tests pass
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal function signatures and parameter handling for improved code organization.
  * Restructured resource identification and deletion workflows for consistency.
  * Enhanced error message generation and handling mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->