### PR TITLE
feat: improve error logging for HTTP request failures

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -281,8 +281,16 @@ func (c *Client) request(ctx context.Context, method, path string, body interfac
 				WithUserAction("Server may be unreachable - check your connection")
 		}
 
+		// Log the actual error at warn level so users can see what went wrong
+		// This will show TLS certificate errors, connection refused, etc.
+		cblog.With("component", "api", "op", "http").Warn("HTTP request failed",
+			"method", method,
+			"url", url,
+			"error", err.Error(),
+		)
+
 		return nil, apperrors.Wrap(err, apperrors.ErrorNetwork, "HTTP_REQUEST_FAILED",
-			"HTTP request failed").
+			fmt.Sprintf("HTTP request failed: %v", err)).
 			WithContext("method", method).
 			WithContext("url", url).
 			AsRecoverable().

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -200,8 +200,15 @@ func (c *Client) Stream(ctx context.Context, path string) (*StreamResponse, erro
 			return nil, timeoutErr.WithContext("url", url)
 		}
 
+		// Log the actual error at warn level so users can see what went wrong
+		cblog.With("component", "api", "op", "http").Warn("HTTP request failed",
+			"method", "GET",
+			"url", url,
+			"error", err.Error(),
+		)
+
 		return nil, apperrors.Wrap(err, apperrors.ErrorNetwork, "STREAM_REQUEST_FAILED",
-			"Stream request failed").
+			fmt.Sprintf("Stream request failed: %v", err)).
 			WithContext("url", url).
 			AsRecoverable().
 			WithUserAction("Check your network connection and ArgoCD server status")


### PR DESCRIPTION
## Summary
- Log raw HTTP errors at WARN level for better visibility
- Include original error message in UI error display
- Helps diagnose TLS certificate issues and connection problems

## Context
A user reported an issue with `insecure: true` not working with their self-signed certificate. While investigating, we discovered that HTTP request errors (including TLS certificate errors) weren't being logged clearly, making it difficult to diagnose issues.

## Changes
- Added WARN-level logging of the actual error when HTTP requests fail
- Modified error wrapping to include the original error message in the UI display
- Now users will see exactly what went wrong (e.g., "x509: certificate signed by unknown authority") instead of just "HTTP request failed"

## Test plan
- [x] Existing e2e tests pass
- [ ] Manual testing: Run with a server that has an untrusted certificate and verify the error is clearly logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error reporting with richer underlying error details and added warn-level logs for failed requests. No changes to public APIs or behavior.
* **Security / Privacy**
  * Sensitive credentials are stripped from logged URLs to avoid exposing embedded credentials in logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->