### PR TITLE
chore: clean up debug logs and add version to startup message

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -388,7 +388,7 @@ func setupLogging() {
 	}
 	cblog.SetDefault(logger)
 
-	cblog.With("component", "app").Info("Argo CD Apps started", "logFile", f.Name())
+	cblog.With("component", "app").Info("Argo CD Apps started", "version", appVersion, "logFile", f.Name())
 }
 
 // loadArgoConfig loads ArgoCD CLI configuration (matches TypeScript app-orchestrator.ts)

--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -271,11 +271,6 @@ const (
 // View implements tea.Model.View - 1:1 mapping from React App.tsx
 func (m *Model) View() tea.View {
 	m.renderCount++
-	cblog.With("component", "view").Debug("View() called",
-		"render_count", m.renderCount,
-		"mode", m.state.Mode,
-		"view", m.state.Navigation.View,
-		"apps_count", len(m.state.Apps))
 
 	var content string
 	// Don't show plain "Starting..." - let renderMainLayout handle the loading modal
@@ -459,14 +454,6 @@ func (m *Model) getVisibleItems() []interface{} {
 	// Derive unique groups and filtered apps from current state, mirroring TS useVisibleItems
 	// 1) Gather filtered apps through selected scopes
 	apps := m.state.Apps
-	cblog.With("component", "view").Debug("getVisibleItems called",
-		"total_apps", len(apps),
-		"first_app", func() string {
-			if len(apps) > 0 {
-				return fmt.Sprintf("%s (health=%s, sync=%s)", apps[0].Name, apps[0].Health, apps[0].Sync)
-			}
-			return "no apps"
-		}())
 
 	// Filter by clusters scope
 	if len(m.state.Selections.ScopeClusters) > 0 {


### PR DESCRIPTION
## Summary
- Removed noisy debug logs that were cluttering the output (`getVisibleItems` and `View()` render calls)
- Added version information to the startup log message for better diagnostics

## Changes
- Removed `DEBU getVisibleItems called` log from `cmd/app/view.go`
- Removed `DEBU View() called` log from `cmd/app/view.go`  
- Added version to startup message: `INFO Argo CD Apps started version=<version>`

The version will show "dev" during development or the actual version when built with proper ldflags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced startup logs to include application version information for improved operational visibility
  * Removed verbose debug logging to reduce log noise and improve performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->