### PR TITLE
chore: remove unused cblog import from view.go

### DIFF
--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -10,7 +10,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	cblog "github.com/charmbracelet/log"
 	"github.com/darksworm/argonaut/pkg/model"
 	"github.com/darksworm/argonaut/pkg/sort"
 )


### PR DESCRIPTION
## Summary
Removed unused `cblog` import that was left after removing debug logs in PR #195.

## Changes
- Removed unused `cblog "github.com/charmbracelet/log"` import from `cmd/app/view.go`

This fixes the compilation warning about the unused import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused import dependency, reducing code size with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->