### PR TITLE
fix: improve timeout handling and add detailed error logging

### DIFF
--- a/cmd/app/model_init.go
+++ b/cmd/app/model_init.go
@@ -133,7 +133,10 @@ func (m *Model) validateAuthentication() tea.Cmd {
 				strings.Contains(errStr, "no such host") ||
 				strings.Contains(errStr, "network is unreachable") ||
 				strings.Contains(errStr, "timeout") ||
-				strings.Contains(errStr, "dial tcp") {
+				strings.Contains(errStr, "dial tcp") ||
+				strings.Contains(errStr, "tls:") ||
+				strings.Contains(errStr, "x509:") ||
+				strings.Contains(errStr, "certificate") {
 				return model.SetModeMsg{Mode: model.ModeConnectionError}
 			}
 

--- a/e2e/tls_cert_test.go
+++ b/e2e/tls_cert_test.go
@@ -88,7 +88,8 @@ func TestTLSUntrustedCert(t *testing.T) {
 	}
 
 	// Expect connection error (since TLS handshake will fail with untrusted cert)
-	if !tf.WaitForPlain("Connection Error", 6*time.Second) {
+	// Wait longer as TLS handshake timeout is now 10 seconds
+	if !tf.WaitForPlain("Connection Error", 12*time.Second) {
 		t.Log("Snapshot:", tf.SnapshotPlain())
 		t.Fatal("expected 'Connection Error' message when using untrusted certificate")
 	}
@@ -199,7 +200,8 @@ func TestTLSClientCertAuthFails(t *testing.T) {
 	}
 
 	// Should see connection error due to missing client certificate
-	if !tf.WaitForPlain("Connection Error", 6*time.Second) {
+	// Wait longer as TLS handshake timeout is now 10 seconds
+	if !tf.WaitForPlain("Connection Error", 12*time.Second) {
 		t.Log("Snapshot:", tf.SnapshotPlain())
 		t.Fatal("expected 'Connection Error' when client cert is required but not provided")
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -281,7 +281,7 @@ func (c *Client) request(ctx context.Context, method, path string, body interfac
 	cblog.With("component", "api", "op", "http").Debug("Making HTTP request",
 		"method", method,
 		"url", sanitizeURL(url),
-		"timeout", "10s",
+		"timeout", appcontext.DefaultTimeouts.API.String(),
 	)
 
 	resp, err := c.httpClient.Do(req)
@@ -299,7 +299,7 @@ func (c *Client) request(ctx context.Context, method, path string, body interfac
 				"Request timed out - server may be unreachable").
 				WithContext("method", method).
 				WithContext("url", url).
-				WithContext("timeout", "10s").
+				WithContext("timeout", appcontext.DefaultTimeouts.API.String()).
 				WithUserAction("Check your connection to ArgoCD server and try again")
 		}
 

--- a/pkg/context/timeouts.go
+++ b/pkg/context/timeouts.go
@@ -22,11 +22,11 @@ type TimeoutConfig struct {
 // DefaultTimeouts provides sensible defaults for different operation types
 var DefaultTimeouts = TimeoutConfig{
 	Default:  5 * time.Second,  // Most operations should be fast
-	API:      3 * time.Second,  // API calls should be quick
+	API:      10 * time.Second, // API calls - increased to handle slow TLS handshakes
 	Stream:   0,                // No timeout for streams (handled by parent context)
-	Auth:     5 * time.Second,  // Auth should be reasonably fast
+	Auth:     10 * time.Second, // Auth - increased to handle slow TLS handshakes
 	Sync:     10 * time.Second, // Sync operations - max 10 seconds
-	Resource: 3 * time.Second,  // Resource queries should be fast
+	Resource: 10 * time.Second, // Resource queries - increased to handle slow TLS
 	UI:       2 * time.Second,  // UI operations must be very fast
 }
 


### PR DESCRIPTION
## Summary
- Add WARN logging to all timeout/cancellation paths for better error visibility
- Add DEBUG logging before HTTP requests to trace connection attempts
- Increase timeouts to handle slow TLS certificate validation

## Problem
Users were experiencing "Failed to list applications" errors without any details about the underlying cause. The actual TLS/connection errors were being swallowed by early timeout returns that didn't log the specific error.

## Solution
1. **Enhanced Logging**: Added WARN level logs to all early return paths (context deadline exceeded, context canceled, network timeout) so the actual error is visible in logs
2. **Debug Tracing**: Added DEBUG logs before making HTTP requests to show what's being attempted
3. **Increased Timeouts**: 
   - API timeout: 3s → 10s
   - TLS handshake timeout: 3s → 10s  
   - Dial timeout: 2s → 5s
   - Response header timeout: 5s → 10s

These changes give enough time for slow TLS certificate validation to complete while providing detailed error information when connections fail.

## Test plan
- [x] Build and run with a server that has TLS certificate issues
- [x] Verify WARN logs now show the actual TLS error details
- [x] Verify DEBUG logs show HTTP request attempts
- [x] Test that normal connections still work with the increased timeouts
- [ ] Test with various network conditions (slow, fast, intermittent)

Fixes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased various HTTP and TLS-related timeouts to reduce spurious failures during slow handshakes and network delays.

* **Improvements**
  * More detailed diagnostic logging for HTTP/S operations to aid troubleshooting and surface timeout/cancellation conditions.
  * Authentication flow now treats additional TLS/certificate failures as connection errors for clearer error signaling.

* **Tests**
  * End-to-end TLS test timeouts increased to account for longer handshake durations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->