### PR TITLE
fix: harden updater and app-watch lifecycle

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -70,6 +70,7 @@ func (m *Model) startLoadingApplications() tea.Cmd {
 // WatchStartedMsg indicates the watch stream has started
 type watchStartedMsg struct {
 	eventChan <-chan services.ArgoApiEvent
+	cleanup   func()
 }
 
 // startWatchingApplications starts the real-time watch stream
@@ -88,7 +89,7 @@ func (m *Model) startWatchingApplications() tea.Cmd {
 		apiService := services.NewArgoApiService(m.state.Server)
 
 		// Start watching applications
-		eventChan, _, err := apiService.WatchApplications(ctx, m.state.Server)
+		eventChan, cleanup, err := apiService.WatchApplications(ctx, m.state.Server)
 		if err != nil {
 			// Promote auth-related errors to AuthErrorMsg
 			var argErr *apperrors.ArgonautError
@@ -106,7 +107,7 @@ func (m *Model) startWatchingApplications() tea.Cmd {
 
 		// Return message with the event channel so Update can set it properly
 		cblog.With("component", "watch").Info("Watch started successfully, returning watchStartedMsg")
-		return watchStartedMsg{eventChan: eventChan}
+		return watchStartedMsg{eventChan: eventChan, cleanup: cleanup}
 	}
 }
 

--- a/cmd/app/model_watchers.go
+++ b/cmd/app/model_watchers.go
@@ -2,6 +2,15 @@ package main
 
 import "github.com/darksworm/argonaut/pkg/model"
 
+// cleanupAppWatcher stops the active applications watcher if present.
+func (m *Model) cleanupAppWatcher() *Model {
+	if m.appWatchCleanup != nil {
+		m.appWatchCleanup()
+		m.appWatchCleanup = nil
+	}
+	return m
+}
+
 // cleanupTreeWatchers stops all active tree watchers and clears the list.
 func (m *Model) cleanupTreeWatchers() *Model {
 	if len(m.treeWatchCleanups) > 0 {

--- a/cmd/app/model_watchers_test.go
+++ b/cmd/app/model_watchers_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+	"github.com/darksworm/argonaut/pkg/services"
+)
+
+func TestSetServerMsg_CleansUpExistingAppWatcher(t *testing.T) {
+	m := NewModel(nil)
+
+	cleanupCalls := 0
+	m.appWatchCleanup = func() { cleanupCalls++ }
+
+	server := &model.Server{BaseURL: "https://argo.example.com"}
+	newModel, _ := m.Update(model.SetServerMsg{Server: server})
+	m = newModel.(*Model)
+
+	if cleanupCalls != 1 {
+		t.Fatalf("expected existing watcher cleanup to be called once, got %d", cleanupCalls)
+	}
+	if m.appWatchCleanup != nil {
+		t.Fatal("expected appWatchCleanup to be cleared until new watch starts")
+	}
+	if m.state.Server != server {
+		t.Fatal("expected server to be updated")
+	}
+}
+
+func TestWatchStartedMsg_ReplacesCleanupAndForwardsEvents(t *testing.T) {
+	m := NewModel(nil)
+
+	oldCleanupCalls := 0
+	m.appWatchCleanup = func() { oldCleanupCalls++ }
+
+	newCleanupCalls := 0
+	eventChan := make(chan services.ArgoApiEvent, 1)
+	eventChan <- services.ArgoApiEvent{Type: "status-change", Status: "watching"}
+	close(eventChan)
+
+	newModel, cmd := m.Update(watchStartedMsg{
+		eventChan: eventChan,
+		cleanup:   func() { newCleanupCalls++ },
+	})
+	m = newModel.(*Model)
+
+	if oldCleanupCalls != 1 {
+		t.Fatalf("expected previous watcher cleanup to be called once, got %d", oldCleanupCalls)
+	}
+
+	if cmd == nil {
+		t.Fatal("expected consumeWatchEvent command from watchStartedMsg")
+	}
+	msg := cmd()
+	statusMsg, ok := msg.(model.StatusChangeMsg)
+	if !ok {
+		t.Fatalf("expected StatusChangeMsg, got %T", msg)
+	}
+	if statusMsg.Status != "watching" {
+		t.Fatalf("expected forwarded status 'watching', got %q", statusMsg.Status)
+	}
+
+	m.cleanupAppWatcher()
+	if newCleanupCalls != 1 {
+		t.Fatalf("expected new watcher cleanup to be called once, got %d", newCleanupCalls)
+	}
+}
+
+func TestApiErrorMsg_CleansUpAppWatcher(t *testing.T) {
+	m := NewModel(nil)
+
+	cleanupCalls := 0
+	m.appWatchCleanup = func() { cleanupCalls++ }
+
+	newModel, _ := m.Update(model.ApiErrorMsg{Message: "boom"})
+	m = newModel.(*Model)
+
+	if cleanupCalls != 1 {
+		t.Fatalf("expected app watcher cleanup on API error, got %d", cleanupCalls)
+	}
+	if m.appWatchCleanup != nil {
+		t.Fatal("expected appWatchCleanup to be cleared after API error")
+	}
+}
+
+func TestAuthErrorMsg_CleansUpAppWatcher(t *testing.T) {
+	m := NewModel(nil)
+
+	cleanupCalls := 0
+	m.appWatchCleanup = func() { cleanupCalls++ }
+
+	newModel, _ := m.Update(model.AuthErrorMsg{Error: errors.New("auth required")})
+	m = newModel.(*Model)
+
+	if cleanupCalls != 1 {
+		t.Fatalf("expected app watcher cleanup on auth error, got %d", cleanupCalls)
+	}
+	if m.appWatchCleanup != nil {
+		t.Fatal("expected appWatchCleanup to be cleared after auth error")
+	}
+}

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -20,30 +20,30 @@ const (
 type Mode string
 
 const (
-	ModeNormal          Mode = "normal"
-	ModeLoading         Mode = "loading"
-	ModeSearch          Mode = "search"
-	ModeCommand         Mode = "command"
-	ModeTheme           Mode = "theme"
-	ModeHelp            Mode = "help"
-	ModeConfirmSync     Mode = "confirm-sync"
-	ModeRollback        Mode = "rollback"
+	ModeNormal                Mode = "normal"
+	ModeLoading               Mode = "loading"
+	ModeSearch                Mode = "search"
+	ModeCommand               Mode = "command"
+	ModeTheme                 Mode = "theme"
+	ModeHelp                  Mode = "help"
+	ModeConfirmSync           Mode = "confirm-sync"
+	ModeRollback              Mode = "rollback"
 	ModeConfirmAppDelete      Mode = "confirm-app-delete"
 	ModeConfirmResourceDelete Mode = "confirm-resource-delete"
 	ModeExternal              Mode = "external"
-	ModeDiff            Mode = "diff"
-	ModeAuthRequired    Mode = "auth-required"
-	ModeRulerLine       Mode = "rulerline"
-	ModeError           Mode = "error"
-	ModeConnectionError Mode = "connection-error"
-	ModeCoreDetected    Mode = "core-detected"
-	ModeUpgrade         Mode = "upgrade"
-	ModeUpgradeError    Mode = "upgrade-error"
-	ModeUpgradeSuccess  Mode = "upgrade-success"
-	ModeNoDiff           Mode = "no-diff"
-	ModeK9sContextSelect    Mode = "k9s-context-select"
-	ModeK9sError            Mode = "k9s-error"
-	ModeConfirmResourceSync Mode = "confirm-resource-sync"
+	ModeDiff                  Mode = "diff"
+	ModeAuthRequired          Mode = "auth-required"
+	ModeRulerLine             Mode = "rulerline"
+	ModeError                 Mode = "error"
+	ModeConnectionError       Mode = "connection-error"
+	ModeCoreDetected          Mode = "core-detected"
+	ModeUpgrade               Mode = "upgrade"
+	ModeUpgradeError          Mode = "upgrade-error"
+	ModeUpgradeSuccess        Mode = "upgrade-success"
+	ModeNoDiff                Mode = "no-diff"
+	ModeK9sContextSelect      Mode = "k9s-context-select"
+	ModeK9sError              Mode = "k9s-error"
+	ModeConfirmResourceSync   Mode = "confirm-resource-sync"
 )
 
 // App represents an ArgoCD application
@@ -224,15 +224,17 @@ const (
 
 // UpdateInfo contains information about available updates
 type UpdateInfo struct {
-	Available        bool          `json:"available"`
-	CurrentVersion   string        `json:"current_version"`
-	LatestVersion    string        `json:"latest_version"`
-	PublishedAt      time.Time     `json:"published_at"`
-	InstallMethod    InstallMethod `json:"install_method"`
-	DownloadURL      string        `json:"download_url,omitempty"`
-	LastChecked      time.Time     `json:"last_checked"`
-	CheckIntervalMin int           `json:"check_interval_min"`
-	NotificationShownAt *time.Time `json:"notification_shown_at,omitempty"`
+	Available           bool          `json:"available"`
+	CurrentVersion      string        `json:"current_version"`
+	LatestVersion       string        `json:"latest_version"`
+	PublishedAt         time.Time     `json:"published_at"`
+	InstallMethod       InstallMethod `json:"install_method"`
+	DownloadURL         string        `json:"download_url,omitempty"`
+	ChecksumURL         string        `json:"checksum_url,omitempty"`
+	ChecksumSHA256      string        `json:"checksum_sha256,omitempty"`
+	LastChecked         time.Time     `json:"last_checked"`
+	CheckIntervalMin    int           `json:"check_interval_min"`
+	NotificationShownAt *time.Time    `json:"notification_shown_at,omitempty"`
 }
 
 // ResourceDeleteTarget represents a resource to be deleted

--- a/pkg/services/update.go
+++ b/pkg/services/update.go
@@ -2,11 +2,16 @@ package services
 
 import (
 	"archive/tar"
+	"bufio"
+	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -145,6 +150,14 @@ func (u *UpdateServiceImpl) CheckForUpdates(currentVersion string) (*model.Updat
 		updateInfo.DownloadURL = downloadURL
 		if downloadURL != "" {
 			logger.Debug("Found download URL", "url", downloadURL)
+			checksumURL, checksumSHA256, checksumErr := u.fetchAssetChecksum(&release, downloadURL)
+			if checksumErr != nil {
+				logger.Warn("Failed to load release checksum", "err", checksumErr)
+			} else if checksumSHA256 != "" {
+				updateInfo.ChecksumURL = checksumURL
+				updateInfo.ChecksumSHA256 = checksumSHA256
+				logger.Debug("Loaded release checksum", "checksum_url", checksumURL)
+			}
 		} else {
 			logger.Warn("No download URL found for platform", "os", runtime.GOOS, "arch", runtime.GOARCH)
 		}
@@ -180,15 +193,15 @@ func (u *UpdateServiceImpl) DetectInstallMethod() model.InstallMethod {
 
 	// Check for Homebrew installation (macOS/Linux)
 	if strings.Contains(execPath, "/opt/homebrew/") ||
-	   strings.Contains(execPath, "/usr/local/Cellar/") ||
-	   strings.Contains(execPath, "/home/linuxbrew/") {
+		strings.Contains(execPath, "/usr/local/Cellar/") ||
+		strings.Contains(execPath, "/home/linuxbrew/") {
 		logger.Debug("Detected Homebrew installation")
 		return model.InstallMethodBrew
 	}
 
 	// Check for AUR installation (Arch Linux)
 	if strings.Contains(execPath, "/usr/bin/") &&
-	   runtime.GOOS == "linux" {
+		runtime.GOOS == "linux" {
 		// Additional check for pacman database
 		if _, err := os.Stat("/var/lib/pacman/local"); err == nil {
 			// Check if argonaut is in pacman database
@@ -206,8 +219,14 @@ func (u *UpdateServiceImpl) DetectInstallMethod() model.InstallMethod {
 
 // DownloadAndReplace implements UpdateService.DownloadAndReplace
 func (u *UpdateServiceImpl) DownloadAndReplace(updateInfo *model.UpdateInfo) error {
+	if updateInfo == nil {
+		return fmt.Errorf("update info is required")
+	}
 	if updateInfo.DownloadURL == "" {
 		return fmt.Errorf("no download URL available")
+	}
+	if updateInfo.ChecksumSHA256 == "" {
+		return fmt.Errorf("refusing update without SHA-256 checksum metadata")
 	}
 
 	logger := cblog.With("component", "update")
@@ -227,6 +246,14 @@ func (u *UpdateServiceImpl) DownloadAndReplace(updateInfo *model.UpdateInfo) err
 		return fmt.Errorf("download failed with status %d", resp.StatusCode)
 	}
 
+	downloadData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read update payload: %w", err)
+	}
+	if err := verifySHA256(downloadData, updateInfo.ChecksumSHA256); err != nil {
+		return fmt.Errorf("checksum verification failed: %w", err)
+	}
+
 	// Get current executable path
 	execPath, err := os.Executable()
 	if err != nil {
@@ -238,10 +265,10 @@ func (u *UpdateServiceImpl) DownloadAndReplace(updateInfo *model.UpdateInfo) err
 
 	if isArchive {
 		// Handle archive extraction
-		return u.downloadAndExtractArchive(resp.Body, execPath, updateInfo.DownloadURL)
+		return u.downloadAndExtractArchive(bytes.NewReader(downloadData), execPath, updateInfo.DownloadURL)
 	} else {
 		// Handle direct binary download (legacy path)
-		return u.downloadDirectBinary(resp.Body, execPath)
+		return u.downloadDirectBinary(bytes.NewReader(downloadData), execPath)
 	}
 }
 
@@ -499,8 +526,10 @@ func (u *UpdateServiceImpl) extractTarGz(reader io.Reader, destDir string) error
 			return fmt.Errorf("failed to read tar header: %w", err)
 		}
 
-		// Create the full path
-		destPath := filepath.Join(destDir, header.Name)
+		destPath, err := secureExtractPath(destDir, header.Name)
+		if err != nil {
+			return err
+		}
 
 		// Ensure the destination directory exists
 		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
@@ -510,7 +539,7 @@ func (u *UpdateServiceImpl) extractTarGz(reader io.Reader, destDir string) error
 		switch header.Typeflag {
 		case tar.TypeReg:
 			// Regular file
-			file, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY, os.FileMode(header.Mode))
+			file, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
 			if err != nil {
 				return fmt.Errorf("failed to create file %s: %w", destPath, err)
 			}
@@ -525,10 +554,145 @@ func (u *UpdateServiceImpl) extractTarGz(reader io.Reader, destDir string) error
 			if err := os.MkdirAll(destPath, os.FileMode(header.Mode)); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", destPath, err)
 			}
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("unsupported archive entry type for %s", header.Name)
 		}
 	}
 
 	return nil
+}
+
+func verifySHA256(data []byte, expected string) error {
+	expected = strings.ToLower(strings.TrimSpace(expected))
+	if expected == "" {
+		return fmt.Errorf("missing expected checksum")
+	}
+	sum := sha256.Sum256(data)
+	actual := hex.EncodeToString(sum[:])
+	if actual != expected {
+		return fmt.Errorf("expected %s, got %s", expected, actual)
+	}
+	return nil
+}
+
+func secureExtractPath(destDir, entryName string) (string, error) {
+	clean := filepath.Clean(entryName)
+	if clean == "." || clean == "" {
+		return "", fmt.Errorf("invalid archive entry: %q", entryName)
+	}
+	if filepath.IsAbs(clean) {
+		return "", fmt.Errorf("archive entry uses absolute path: %q", entryName)
+	}
+
+	destPath := filepath.Join(destDir, clean)
+	rel, err := filepath.Rel(destDir, destPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to validate archive path %q: %w", entryName, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry escapes destination: %q", entryName)
+	}
+	return destPath, nil
+}
+
+func (u *UpdateServiceImpl) fetchAssetChecksum(release *GitHubRelease, downloadURL string) (string, string, error) {
+	checksumURL := findChecksumAssetURL(release)
+	if checksumURL == "" {
+		return "", "", fmt.Errorf("no checksum asset found in release")
+	}
+	assetName, err := assetNameFromURL(downloadURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	req, err := http.NewRequest("GET", checksumURL, nil)
+	if err != nil {
+		return checksumURL, "", fmt.Errorf("failed to create checksum request: %w", err)
+	}
+	req.Header.Set("User-Agent", "argonaut-update-checker")
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return checksumURL, "", fmt.Errorf("failed to fetch checksum asset: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return checksumURL, "", fmt.Errorf("checksum asset download failed with status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return checksumURL, "", fmt.Errorf("failed to read checksum asset: %w", err)
+	}
+	sum := parseChecksumForAsset(string(body), assetName)
+	if sum == "" {
+		return checksumURL, "", fmt.Errorf("checksum for asset %q not found", assetName)
+	}
+	return checksumURL, sum, nil
+}
+
+func findChecksumAssetURL(release *GitHubRelease) string {
+	for _, asset := range release.Assets {
+		name := strings.ToLower(asset.Name)
+		if strings.Contains(name, "sha256") || strings.Contains(name, "checksums") {
+			return asset.BrowserDownloadURL
+		}
+	}
+	return ""
+}
+
+func assetNameFromURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse download URL: %w", err)
+	}
+	name := filepath.Base(u.Path)
+	if name == "." || name == "/" || name == "" {
+		return "", fmt.Errorf("could not infer asset name from download URL")
+	}
+	return name, nil
+}
+
+func parseChecksumForAsset(contents, assetName string) string {
+	scanner := bufio.NewScanner(strings.NewReader(contents))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			candidate := strings.TrimPrefix(parts[1], "*")
+			if candidate == assetName && isHexSHA256(parts[0]) {
+				return strings.ToLower(parts[0])
+			}
+		}
+
+		if strings.HasPrefix(line, "SHA256(") {
+			// Format: SHA256(filename)= <hash>
+			closeIdx := strings.Index(line, ")=")
+			if closeIdx > len("SHA256(") {
+				name := strings.TrimSpace(line[len("SHA256("):closeIdx])
+				hash := strings.TrimSpace(line[closeIdx+2:])
+				if name == assetName && isHexSHA256(hash) {
+					return strings.ToLower(hash)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func isHexSHA256(v string) bool {
+	if len(v) != 64 {
+		return false
+	}
+	for _, c := range v {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // findBinaryInDir recursively searches for a binary file with the given name

--- a/pkg/services/update.go
+++ b/pkg/services/update.go
@@ -537,7 +537,7 @@ func (u *UpdateServiceImpl) extractTarGz(reader io.Reader, destDir string) error
 		}
 
 		switch header.Typeflag {
-		case tar.TypeReg:
+		case tar.TypeReg, tar.TypeRegA:
 			// Regular file
 			file, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
 			if err != nil {
@@ -556,6 +556,8 @@ func (u *UpdateServiceImpl) extractTarGz(reader io.Reader, destDir string) error
 			}
 		case tar.TypeSymlink, tar.TypeLink:
 			return fmt.Errorf("unsupported archive entry type for %s", header.Name)
+		default:
+			return fmt.Errorf("unsupported tar entry type %q for %s (size=%d)", header.Typeflag, header.Name, header.Size)
 		}
 	}
 

--- a/pkg/services/update_test.go
+++ b/pkg/services/update_test.go
@@ -1,0 +1,116 @@
+package services
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+type tarEntry struct {
+	name     string
+	body     string
+	typeflag byte
+}
+
+func buildTarGz(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.name,
+			Mode:     0o644,
+			Size:     int64(len(e.body)),
+			Typeflag: e.typeflag,
+		}
+		if e.typeflag == 0 {
+			hdr.Typeflag = tar.TypeReg
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write tar body: %v", err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractTarGzRejectsPathTraversal(t *testing.T) {
+	svc := &UpdateServiceImpl{}
+	destDir := t.TempDir()
+	archive := buildTarGz(t, []tarEntry{
+		{name: "../evil.txt", body: "owned"},
+	})
+
+	err := svc.extractTarGz(bytes.NewReader(archive), destDir)
+	if err == nil {
+		t.Fatal("expected path traversal archive to be rejected")
+	}
+	if _, statErr := os.Stat(filepath.Join(destDir, "..", "evil.txt")); statErr == nil {
+		t.Fatal("unexpected file created outside extraction directory")
+	}
+}
+
+func TestExtractTarGzRejectsSymlink(t *testing.T) {
+	svc := &UpdateServiceImpl{}
+	destDir := t.TempDir()
+	archive := buildTarGz(t, []tarEntry{
+		{name: "link", typeflag: tar.TypeSymlink},
+	})
+
+	err := svc.extractTarGz(bytes.NewReader(archive), destDir)
+	if err == nil {
+		t.Fatal("expected symlink archive entry to be rejected")
+	}
+}
+
+func TestParseChecksumForAsset(t *testing.T) {
+	content := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  argonaut-v1.0.0-linux-amd64.tar.gz\n"
+	got := parseChecksumForAsset(content, "argonaut-v1.0.0-linux-amd64.tar.gz")
+	want := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	data := []byte("abc")
+	// sha256("abc")
+	const good = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if err := verifySHA256(data, good); err != nil {
+		t.Fatalf("expected checksum to verify: %v", err)
+	}
+	if err := verifySHA256(data, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); err == nil {
+		t.Fatal("expected checksum mismatch")
+	}
+}
+
+func TestDownloadAndReplaceRejectsMissingChecksum(t *testing.T) {
+	svc := &UpdateServiceImpl{}
+	err := svc.DownloadAndReplace(nil)
+	if err == nil {
+		t.Fatal("expected nil updateInfo to fail")
+	}
+
+	err = svc.DownloadAndReplace(&model.UpdateInfo{
+		DownloadURL: "https://example.com/argonaut.tar.gz",
+	})
+	if err == nil {
+		t.Fatal("expected missing checksum to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- fix app watch lifecycle management by carrying and calling cleanup callbacks
- avoid channel cross-talk by forwarding through captured watch channels
- harden updater with SHA-256 checksum enforcement before install
- secure tar extraction against path traversal and symlink/hardlink entries
- add tests for tar extraction safety and checksum helpers

## Validation
- go test ./pkg/services ./cmd/app
- go test ./pkg/services/appdelete ./pkg/api ./pkg/context
- go test ./...
- go test -race ./cmd/app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced update verification with SHA-256 checksum validation.
  * Strengthened archive extraction to prevent path traversal and reject symlinks.

* **New Features**
  * Update metadata now includes checksum URLs and SHA-256 values when available.

* **Bug Fixes**
  * Improved application watcher cleanup to prevent resource leaks during state transitions.

* **Tests**
  * Added comprehensive tests for update verification, archive extraction safety, and watcher cleanup.

* **Chores**
  * Update check API now surfaces errors alongside update metadata (signature change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->