### PR TITLE
fix: harden pr-prerelease workflow security

### DIFF
--- a/.github/workflows/pr-prerelease.yml
+++ b/.github/workflows/pr-prerelease.yml
@@ -14,11 +14,12 @@ permissions:
 jobs:
   check-release-pr:
     runs-on: ubuntu-latest
-    # Run on release-please PRs OR when someone comments /prerelease on any PR
+    # Run on release-please PRs OR when darksworm comments /prerelease on any PR
     if: |
       (github.event_name == 'pull_request') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       github.event.comment.user.login == 'darksworm' &&
        contains(github.event.comment.body, '/prerelease'))
     outputs:
       is_release_pr: ${{ steps.check.outputs.is_release_pr }}
@@ -55,7 +56,7 @@ jobs:
           COMMENT_PR_SHA: ${{ steps.pr-details.outputs.sha }}
         run: |
           if [[ "$EVENT_NAME" == "issue_comment" ]]; then
-            # Manual trigger via /prerelease comment
+            # Manual trigger via /prerelease comment (already verified actor is darksworm)
             echo "should_build=true" >> $GITHUB_OUTPUT
             echo "is_release_pr=false" >> $GITHUB_OUTPUT
             echo "pr_ref=$COMMENT_PR_REF" >> $GITHUB_OUTPUT
@@ -111,11 +112,14 @@ jobs:
 
       - name: Create snapshot version
         id: version
+        env:
+          IS_RELEASE_PR: ${{ needs.check-release-pr.outputs.is_release_pr }}
+          PR_REF: ${{ needs.check-release-pr.outputs.pr_ref }}
         run: |
           # Extract version from release-please PR title and add -dev suffix
-          if [[ "${{ needs.check-release-pr.outputs.is_release_pr }}" == "true" ]]; then
-            # Extract version from PR title: "chore(main): release X.Y.Z"
-            BASE_VERSION=$(echo "${{ needs.check-release-pr.outputs.pr_ref }}" | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          if [[ "$IS_RELEASE_PR" == "true" ]]; then
+            # Extract version from branch name
+            BASE_VERSION=$(echo "$PR_REF" | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
             if [[ -z "$BASE_VERSION" ]]; then
               VERSION="dev-snapshot-$(git rev-parse --short HEAD)"
             else
@@ -223,17 +227,20 @@ jobs:
 
       - name: Comment on PR with download link
         uses: actions/github-script@v7
+        env:
+          PRE_VERSION: ${{ steps.version.outputs.version }}
+          PR_NUMBER: ${{ needs.check-release-pr.outputs.pr_number }}
         with:
           script: |
             const fs = require('fs');
-            const version = '${{ steps.version.outputs.version }}';
+            const version = process.env.PRE_VERSION;
 
             // List artifacts in pr-artifacts directory
             const artifactFiles = fs.readdirSync('pr-artifacts').filter(f => f !== 'checksums.txt');
             const checksums = fs.readFileSync('pr-artifacts/checksums.txt', 'utf8');
 
             // Generate download links for categorized artifacts
-            const baseUrl = `https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const baseUrl = `https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             // Categorize files
             const linuxBinaries = artifactFiles.filter(f => f.includes('linux') || (f === 'argonaut' && !f.includes('darwin')));
@@ -266,6 +273,7 @@ jobs:
 
             const artifactList = downloadLinks.join('\n');
 
+            const repoFullName = `${context.repo.owner}/${context.repo.repo}`;
             const comment = `## 🚀 Pre-release Build Available
 
             A pre-release build has been created for this PR with version \`${version}\`.
@@ -282,7 +290,7 @@ jobs:
 
             ### 🐳 Docker Image
             \`\`\`bash
-            docker pull ghcr.io/${{ github.repository }}:${version}
+            docker pull ghcr.io/${repoFullName}:${version}
             \`\`\`
 
             ### 🔍 Checksums
@@ -295,7 +303,7 @@ jobs:
             </details>
 
             ### 📋 Alternative Download
-            You can also browse all artifacts from the [Actions tab](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            You can also browse all artifacts from the [Actions tab](https://github.com/${repoFullName}/actions/runs/${context.runId}).
 
             > **Note:** This is a pre-release build for testing purposes only. The version includes \`-dev\` to clearly indicate it's not an official release.
 
@@ -303,10 +311,11 @@ jobs:
             *This comment will be updated on each push to the PR.*`;
 
             // Find existing comment
+            const prNumber = context.issue?.number || Number(process.env.PR_NUMBER);
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: prNumber,
             });
 
             const botComment = comments.data.find(comment =>
@@ -327,7 +336,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 body: comment
               });
             }

--- a/argocd/setup-fixed.sh
+++ b/argocd/setup-fixed.sh
@@ -29,7 +29,8 @@ else
 fi
 
 # Always apply to ensure latest version
-kubectl -n argocd apply -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+# Use --server-side to avoid the 262KB annotation limit on large CRDs (applicationsets.argoproj.io)
+kubectl -n argocd apply --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 # 3) Wait for ArgoCD to be ready
 echo "Waiting for ArgoCD to be ready..."


### PR DESCRIPTION
## Summary
- Restrict `/prerelease` comment trigger to `darksworm` only — previously anyone could trigger builds of arbitrary PR code
- Fix shell script injection via `${{ }}` interpolation in `run:` blocks (branch names could inject commands)
- Fix JS injection via `${{ }}` interpolation in `github-script` (version strings could inject code)
- Replace remaining `${{ }}` template interpolations in JS with safe `context.*` API

## Security issues addressed

| Issue | Severity | Fix |
|---|---|---|
| No actor check on `/prerelease` | Critical | Added `github.event.comment.user.login == 'darksworm'` |
| Shell injection via `pr_ref` in `run:` | High | Moved to `env:` block |
| JS injection via version in `github-script` | Medium | Use `process.env` instead |
| Template injection via `github.repository`/`github.run_id` | Low | Use `context.repo`/`context.runId` |

## Test plan
- [ ] Open a PR and verify release-please auto-build still triggers
- [ ] Comment `/prerelease` as darksworm — should trigger build
- [ ] Verify non-darksworm `/prerelease` comments are ignored (check Actions tab shows no run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced prerelease workflow with improved version extraction and access controls.
  * Improved ArgoCD deployment process using server-side configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->