### PR TITLE
feat: open Application CR in k9s

### DIFF
--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -1732,19 +1732,22 @@ func (m *Model) handleOpenK9s() (tea.Model, tea.Cmd) {
 // We always show the context picker because we don't know which kubeconfig
 // context maps to the ArgoCD management cluster.
 func (m *Model) openK9sForApplicationCR(appName string) (tea.Model, tea.Cmd) {
-	// Find the app to get its AppNamespace
-	var namespace string
+	// Default to "argocd" — the standard ArgoCD installation namespace.
+	// Override only when the app is found with an explicit AppNamespace.
+	namespace := "argocd"
+	usingDefault := true
 	for i := range m.state.Apps {
 		if m.state.Apps[i].Name == appName {
 			if m.state.Apps[i].AppNamespace != nil {
 				namespace = *m.state.Apps[i].AppNamespace
+				usingDefault = false
 			}
 			break
 		}
 	}
 
 	cblog.With("component", "k9s").Debug("Opening k9s for Application CR",
-		"name", appName, "namespace", namespace)
+		"name", appName, "namespace", namespace, "usingDefault", usingDefault)
 
 	return m.showK9sContextPicker("Application", namespace, appName)
 }

--- a/cmd/app/k9s_test.go
+++ b/cmd/app/k9s_test.go
@@ -259,6 +259,7 @@ func TestK9sResourceMapCoverage(t *testing.T) {
 		"RoleBinding":              "rolebinding",
 		"ClusterRole":              "clusterrole",
 		"ClusterRoleBinding":       "clusterrolebinding",
+		"Application":              "applications.argoproj.io",
 	}
 
 	for kind, expectedAlias := range expectedMappings {

--- a/cmd/app/model_pager.go
+++ b/cmd/app/model_pager.go
@@ -185,6 +185,7 @@ var k9sResourceMap = map[string]string{
 	"RoleBinding":           "rolebinding",
 	"ClusterRole":           "clusterrole",
 	"ClusterRoleBinding":    "clusterrolebinding",
+	"Application":           "applications.argoproj.io",
 }
 
 // k9sDoneMsg signals that k9s has exited

--- a/cmd/app/testdata/snapshots/modal_help.golden
+++ b/cmd/app/testdata/snapshots/modal_help.golden
@@ -8,7 +8,8 @@
  │ VIEWS        :cls|:clusters • :ns|:namespaces • :proj|:projects • :apps                        │ 
  │              :appsets|:applicationsets • :theme • :logs                                        │ 
  │                                                                                                │ 
- │ APPS VIEW     s  sync •  R  rollback •  r  resources •  d  diff •  Ctrl+D  delete              │ 
+ │ APPS VIEW     s  sync •  R  rollback •  r  resources •  d  diff •  K  open in k9s •  Ctrl+D    │ 
+ │ delete                                                                                         │ 
  │              :diff [app] • :sync [app] • :rollback [app] • :delete [app]                       │ 
  │              :refresh [app] • :refresh! [app] (hard) • :sort health|sync asc|desc              │ 
  │              :resources [app] • :up • :all                                                     │ 
@@ -19,7 +20,6 @@
  │ COMMANDS     :q (to exit, google how to exit vim)                                              │ 
  │                                                                                                │ 
  │ Press ?, q or Esc to close                                                                     │ 
- │                                                                                                │ 
  │                                                                                                │ 
  │                                                                                                │ 
  │                                                                                                │ 

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -46,7 +46,7 @@ func (m *Model) renderHelpModal() string {
 
 	// APPS VIEW - hotkeys and commands specific to apps view
 	appsView := strings.Join([]string{
-		keycap("s"), " sync ", bullet(), " ", keycap("R"), " rollback ", bullet(), " ", keycap("r"), " resources ", bullet(), " ", keycap("d"), " diff ", bullet(), " ", keycap("Ctrl+D"), " delete",
+		keycap("s"), " sync ", bullet(), " ", keycap("R"), " rollback ", bullet(), " ", keycap("r"), " resources ", bullet(), " ", keycap("d"), " diff ", bullet(), " ", keycap("K"), " open in k9s ", bullet(), " ", keycap("Ctrl+D"), " delete",
 		"\n",
 		mono(":diff"), " [app] ", bullet(), " ", mono(":sync"), " [app] ", bullet(), " ", mono(":rollback"), " [app] ", bullet(), " ", mono(":delete"), " [app]",
 		"\n",


### PR DESCRIPTION
## Summary
- Press `K` on the Application root node in **tree view** to open the ArgoCD Application CR in k9s
- Press `K` on any app in the **app list view** to do the same
- Always shows the context picker (we can't auto-detect which kubeconfig context maps to the ArgoCD management cluster)
- Uses `applications.argoproj.io` as the k9s resource alias and `AppNamespace` (typically `argocd`) as the namespace

## Test plan
- [x] `go test ./cmd/app/ -run TestK9sResourceMapCoverage` — resource map includes Application
- [x] `go test -tags e2e -run TestK9s_OpenApplicationCR` — tree view: K on Application node → context picker → k9s with correct args
- [x] `go test -tags e2e -run TestK9s_OpenApplicationFromAppsList` — app list: K on app → context picker → k9s with correct args
- [x] `go test ./...` — all unit tests pass
- [x] `go test -tags e2e -v` — all E2E tests pass (62/62)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut K to open Applications in k9s from the Apps view
  * Added an explicit context-picker when launching k9s for Applications so users choose the kubeconfig context

* **Documentation**
  * Updated Apps view help to show the new K shortcut and adjusted keybinding layout

* **Tests**
  * Added tests validating the context-picker interaction and k9s launch behavior for Applications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->