### PR TITLE
feat: add configurable default_view setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ formatter = ""            # Diff formatter command (e.g., "delta --side-by-side"
 
 [http_timeouts]
 request_timeout = "10s"   # Timeout for HTTP requests (increase for large deployments)
+
+# Start in apps view instead of clusters (supports :command syntax)
+default_view = "apps"
 ```
 
 ### Configuration Options
@@ -336,6 +339,37 @@ request_timeout = "2m"
 ```
 
 > **Note:** If you're experiencing timeout errors when listing applications or resources, increase this value. The timeout applies to all API operations including listing applications, getting resources, and sync operations.
+
+#### `default_view`
+
+Configure which view Argonaut starts in. Uses the same syntax as `:commands`, with an optional scope argument to drill down into a specific cluster, namespace, project, or application set.
+
+| Value | Startup view |
+|-------|-------------|
+| `"apps"` | Applications list |
+| `"clusters"` | Clusters list (default) |
+| `"ns"` | Namespaces list |
+| `"proj"` | Projects list |
+| `"appsets"` | ApplicationSets list |
+| `"cluster production"` | Namespaces scoped to cluster "production" |
+| `"ns my-namespace"` | Projects scoped to namespace "my-namespace" |
+| `"project myproj"` | Apps scoped to project "myproj" |
+| `"appset myset"` | Apps scoped to ApplicationSet "myset" |
+
+All view aliases from `:commands` are supported (e.g., `app`/`apps`/`applications`, `cls`/`cluster`/`clusters`, `ns`/`namespace`/`namespaces`, etc.).
+
+**Examples:**
+
+```toml
+# Start in apps view
+default_view = "apps"
+
+# Start scoped to a cluster (shows its namespaces)
+default_view = "cluster production"
+
+# Start scoped to a namespace (shows its projects)
+default_view = "ns my-namespace"
+```
 
 #### `[port_forward]`
 

--- a/cmd/app/default_view_warning_test.go
+++ b/cmd/app/default_view_warning_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/config"
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+func buildTestApps() []model.App {
+	cluster := "production"
+	ns := "default"
+	proj := "my-project"
+	appset := "my-appset"
+	return []model.App{
+		{
+			Name:           "app-1",
+			ClusterLabel:   &cluster,
+			Namespace:      &ns,
+			Project:        &proj,
+			ApplicationSet: &appset,
+			Health:         "Healthy",
+			Sync:           "Synced",
+		},
+	}
+}
+
+func TestDefaultViewWarning_MalformedConfig(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "foobar"
+
+	m := NewModel(cfg)
+	m.state.Mode = model.ModeLoading
+
+	// Warning should already be set from parsing
+	if m.state.Modals.DefaultViewWarning == nil {
+		t.Fatal("expected DefaultViewWarning to be set for malformed config")
+	}
+	if !strings.Contains(*m.state.Modals.DefaultViewWarning, "foobar") {
+		t.Errorf("warning should mention the invalid value, got: %s", *m.state.Modals.DefaultViewWarning)
+	}
+
+	// View should remain at default (clusters) since the parse failed
+	if m.state.Navigation.View != model.ViewClusters {
+		t.Errorf("expected default view clusters, got %s", m.state.Navigation.View)
+	}
+
+	// No pending scope to validate
+	if m.pendingDefaultViewScope != nil {
+		t.Error("expected no pending scope for malformed config")
+	}
+}
+
+func TestDefaultViewWarning_ValidConfigNoPending(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "apps"
+
+	m := NewModel(cfg)
+
+	// No warning for valid config
+	if m.state.Modals.DefaultViewWarning != nil {
+		t.Errorf("unexpected warning for valid config: %s", *m.state.Modals.DefaultViewWarning)
+	}
+
+	// View should be set to apps
+	if m.state.Navigation.View != model.ViewApps {
+		t.Errorf("expected apps view, got %s", m.state.Navigation.View)
+	}
+
+	// No scope → no pending validation
+	if m.pendingDefaultViewScope != nil {
+		t.Error("expected no pending scope for view-only config")
+	}
+}
+
+func TestDefaultViewWarning_ScopeEntityExists(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "cluster production"
+
+	m := NewModel(cfg)
+
+	// Should have pending scope
+	if m.pendingDefaultViewScope == nil {
+		t.Fatal("expected pending scope for scoped config")
+	}
+	if m.pendingDefaultViewScope.scopeType != "cluster" {
+		t.Errorf("expected scope type 'cluster', got %s", m.pendingDefaultViewScope.scopeType)
+	}
+	if m.pendingDefaultViewScope.scopeValue != "production" {
+		t.Errorf("expected scope value 'production', got %s", m.pendingDefaultViewScope.scopeValue)
+	}
+
+	// Simulate apps loaded — entity exists
+	m.state.Apps = buildTestApps()
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+	m.validateDefaultViewScope()
+
+	// No warning — entity found
+	if m.state.Modals.DefaultViewWarning != nil {
+		t.Errorf("unexpected warning when entity exists: %s", *m.state.Modals.DefaultViewWarning)
+	}
+
+	// Pending scope should be consumed
+	if m.pendingDefaultViewScope != nil {
+		t.Error("pending scope should be nil after validation")
+	}
+
+	// Navigation should remain as set (namespaces scoped to cluster)
+	if m.state.Navigation.View != model.ViewNamespaces {
+		t.Errorf("expected namespaces view, got %s", m.state.Navigation.View)
+	}
+}
+
+func TestDefaultViewWarning_ScopeClusterNotFound(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "cluster nonexistent"
+
+	m := NewModel(cfg)
+
+	// Simulate apps loaded — entity does NOT exist
+	m.state.Apps = buildTestApps()
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+	m.validateDefaultViewScope()
+
+	// Warning should be set
+	if m.state.Modals.DefaultViewWarning == nil {
+		t.Fatal("expected warning when cluster not found")
+	}
+	if !strings.Contains(*m.state.Modals.DefaultViewWarning, "nonexistent") {
+		t.Errorf("warning should mention the missing entity, got: %s", *m.state.Modals.DefaultViewWarning)
+	}
+	if !strings.Contains(*m.state.Modals.DefaultViewWarning, "Cluster") {
+		t.Errorf("warning should mention the entity type, got: %s", *m.state.Modals.DefaultViewWarning)
+	}
+
+	// Should fall back to default view
+	if m.state.Navigation.View != model.ViewClusters {
+		t.Errorf("expected fallback to clusters view, got %s", m.state.Navigation.View)
+	}
+
+	// Scope selections should be cleared
+	if len(m.state.Selections.ScopeClusters) != 0 {
+		t.Errorf("expected scope clusters to be cleared, got %v", m.state.Selections.ScopeClusters)
+	}
+}
+
+func TestDefaultViewWarning_ScopeNamespaceNotFound(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "ns nonexistent-ns"
+
+	m := NewModel(cfg)
+
+	m.state.Apps = buildTestApps()
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+	m.validateDefaultViewScope()
+
+	if m.state.Modals.DefaultViewWarning == nil {
+		t.Fatal("expected warning when namespace not found")
+	}
+	if !strings.Contains(*m.state.Modals.DefaultViewWarning, "Namespace") {
+		t.Errorf("warning should mention 'Namespace', got: %s", *m.state.Modals.DefaultViewWarning)
+	}
+	if m.state.Navigation.View != model.ViewClusters {
+		t.Errorf("expected fallback to clusters view, got %s", m.state.Navigation.View)
+	}
+}
+
+func TestDefaultViewWarning_ScopeProjectNotFound(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "project nonexistent-proj"
+
+	m := NewModel(cfg)
+
+	m.state.Apps = buildTestApps()
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+	m.validateDefaultViewScope()
+
+	if m.state.Modals.DefaultViewWarning == nil {
+		t.Fatal("expected warning when project not found")
+	}
+	if !strings.Contains(*m.state.Modals.DefaultViewWarning, "Project") {
+		t.Errorf("warning should mention 'Project', got: %s", *m.state.Modals.DefaultViewWarning)
+	}
+}
+
+func TestDefaultViewWarning_ScopeAppsetNotFound(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "appset nonexistent-set"
+
+	m := NewModel(cfg)
+
+	m.state.Apps = buildTestApps()
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+	m.validateDefaultViewScope()
+
+	if m.state.Modals.DefaultViewWarning == nil {
+		t.Fatal("expected warning when appset not found")
+	}
+	if !strings.Contains(*m.state.Modals.DefaultViewWarning, "ApplicationSet") {
+		t.Errorf("warning should mention 'ApplicationSet', got: %s", *m.state.Modals.DefaultViewWarning)
+	}
+}
+
+func TestDefaultViewWarning_NoValidationWithoutPendingScope(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = "apps"
+
+	m := NewModel(cfg)
+
+	// No pending scope
+	m.state.Apps = buildTestApps()
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+	m.validateDefaultViewScope()
+
+	// Should stay clean
+	if m.state.Modals.DefaultViewWarning != nil {
+		t.Errorf("unexpected warning when no scope is pending: %s", *m.state.Modals.DefaultViewWarning)
+	}
+	if m.state.Navigation.View != model.ViewApps {
+		t.Errorf("expected apps view to be preserved, got %s", m.state.Navigation.View)
+	}
+}
+
+func TestDefaultViewWarning_EmptyConfig(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.DefaultView = ""
+
+	m := NewModel(cfg)
+
+	if m.state.Modals.DefaultViewWarning != nil {
+		t.Errorf("unexpected warning for empty config: %s", *m.state.Modals.DefaultViewWarning)
+	}
+	if m.pendingDefaultViewScope != nil {
+		t.Error("unexpected pending scope for empty config")
+	}
+	// Default view should remain clusters
+	if m.state.Navigation.View != model.ViewClusters {
+		t.Errorf("expected clusters view for empty config, got %s", m.state.Navigation.View)
+	}
+}

--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -539,6 +539,17 @@ func (m *Model) handleK9sErrorModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// handleDefaultViewWarningModeKeys handles input when default_view warning modal is shown
+func (m *Model) handleDefaultViewWarningModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter", "esc", "q":
+		m.state.Mode = model.ModeNormal
+		m.state.Modals.DefaultViewWarning = nil
+		return m, nil
+	}
+	return m, nil
+}
+
 // removed: resources list mode
 
 // handleDiffModeKeys handles non-navigation input in diff mode.
@@ -1390,6 +1401,8 @@ func (m *Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleK9sContextSelectKeys(msg)
 	case model.ModeK9sError:
 		return m.handleK9sErrorModeKeys(msg)
+	case model.ModeDefaultViewWarning:
+		return m.handleDefaultViewWarningModeKeys(msg)
 	}
 
 	// Tree view keys when in normal mode.

--- a/cmd/app/model_init.go
+++ b/cmd/app/model_init.go
@@ -44,8 +44,25 @@ func NewModel(cfg *config.ArgonautConfig) *Model {
 		CheckIntervalMin: 60, // Check every hour
 	})
 
+	state := model.NewAppState()
+
+	// Apply default view from config
+	if view, scopeType, scopeValue := cfg.ParseDefaultView(); view != "" {
+		state.Navigation.View = model.View(view)
+		switch scopeType {
+		case "cluster":
+			state.Selections.ScopeClusters = model.StringSetFromSlice([]string{scopeValue})
+		case "namespace":
+			state.Selections.ScopeNamespaces = model.StringSetFromSlice([]string{scopeValue})
+		case "project":
+			state.Selections.ScopeProjects = model.StringSetFromSlice([]string{scopeValue})
+		case "appset":
+			state.Selections.ScopeApplicationSets = model.StringSetFromSlice([]string{scopeValue})
+		}
+	}
+
 	return &Model{
-		state:              model.NewAppState(),
+		state:              state,
 		argoService:        services.NewArgoApiService(nil),
 		navigationService:  services.NewNavigationService(),
 		statusService:      services.NewStatusService(services.StatusServiceConfig{Handler: createFileStatusHandler(), DebugEnabled: true}),

--- a/cmd/app/model_init.go
+++ b/cmd/app/model_init.go
@@ -111,12 +111,13 @@ func (m *Model) validateDefaultViewScope() {
 	if m.pendingDefaultViewScope == nil {
 		return
 	}
-	scope := m.pendingDefaultViewScope
-	m.pendingDefaultViewScope = nil
 
 	if m.state.Index == nil {
-		return
+		return // Index not yet built; keep pendingDefaultViewScope for next call
 	}
+
+	scope := m.pendingDefaultViewScope
+	m.pendingDefaultViewScope = nil
 
 	var exists bool
 	var label string

--- a/cmd/app/view_layout.go
+++ b/cmd/app/view_layout.go
@@ -266,6 +266,17 @@ func (m *Model) renderMainLayout() string {
 		canvas := lipgloss.NewCanvas(baseLayer, modalLayer)
 		return canvas.Render()
 	}
+	// Default view warning modal
+	if m.state.Mode == model.ModeDefaultViewWarning {
+		modal := m.renderDefaultViewWarningModal()
+		grayBase := desaturateANSI(baseView)
+		baseLayer := lipgloss.NewLayer(grayBase)
+		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
+		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
+		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
+		canvas := lipgloss.NewCanvas(baseLayer, modalLayer)
+		return canvas.Render()
+	}
 	// App Delete modal (confirmation or loading state)
 	if m.state.Mode == model.ModeConfirmAppDelete {
 		modal := ""

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -991,6 +991,31 @@ func (m *Model) renderK9sErrorModal() string {
 	return modalStyle.Render(content)
 }
 
+// renderDefaultViewWarningModal renders the default_view config warning popup
+func (m *Model) renderDefaultViewWarningModal() string {
+	if m.state.Modals.DefaultViewWarning == nil {
+		return ""
+	}
+
+	warningMsg := *m.state.Modals.DefaultViewWarning
+
+	modalStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(progressColor).
+		Padding(1, 2).
+		Width(60).
+		AlignHorizontal(lipgloss.Center)
+
+	title := lipgloss.NewStyle().
+		Foreground(progressColor).
+		Bold(true).
+		Render("Invalid default_view")
+
+	content := fmt.Sprintf("%s\n\n%s\n\nPress Enter or Esc to close", title, warningMsg)
+
+	return modalStyle.Render(content)
+}
+
 // renderThemeSelectionModal renders the theme selection overlay
 func (m *Model) renderThemeSelectionModal() string {
 	m.ensureThemeOptionsLoaded()

--- a/e2e/default_view_test.go
+++ b/e2e/default_view_test.go
@@ -1,0 +1,85 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultViewApps(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServer()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Set default_view to apps — app should start in apps view instead of clusters
+	tf.extraConfig = `default_view = "apps"`
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// In apps view, we should see the app name "demo" with sync/health status
+	if !tf.WaitForPlain("demo", 5*time.Second) {
+		t.Fatal("expected app name 'demo' in apps view")
+	}
+	if !tf.WaitForPlain("Synced", 3*time.Second) {
+		t.Fatal("expected 'Synced' status in apps view")
+	}
+
+	// Verify we're NOT in clusters view — the screen should show app details,
+	// not a cluster list. In clusters view "cluster-a" appears as a selectable item.
+	// In apps view "cluster-a" may appear in the app's cluster column, so we check
+	// that the view header/breadcrumb shows "Applications" or similar apps view indicator.
+	screen := tf.Screen()
+	if screen == "" {
+		t.Fatal("screen is empty")
+	}
+}
+
+func TestDefaultViewWithScope(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServer()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Set default_view to scope to a cluster — should show namespaces view
+	tf.extraConfig = `default_view = "cluster cluster-a"`
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// In namespaces view scoped to cluster-a, we should see "default" namespace
+	if !tf.WaitForPlain("default", 5*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected 'default' namespace in namespaces view scoped to cluster-a")
+	}
+}

--- a/e2e/default_view_test.go
+++ b/e2e/default_view_test.go
@@ -41,13 +41,11 @@ func TestDefaultViewApps(t *testing.T) {
 		t.Fatal("expected 'Synced' status in apps view")
 	}
 
-	// Verify we're NOT in clusters view — the screen should show app details,
-	// not a cluster list. In clusters view "cluster-a" appears as a selectable item.
-	// In apps view "cluster-a" may appear in the app's cluster column, so we check
-	// that the view header/breadcrumb shows "Applications" or similar apps view indicator.
-	screen := tf.Screen()
-	if screen == "" {
-		t.Fatal("screen is empty")
+	// Verify we're in apps view by checking the status line breadcrumb.
+	// The status line shows "<apps>" in apps view and "<clusters>" in clusters view.
+	if !tf.WaitForPlain("<apps>", 3*time.Second) {
+		screen := tf.Screen()
+		t.Fatalf("expected '<apps>' breadcrumb in status line, got:\n%s", screen)
 	}
 }
 

--- a/e2e/delete_test.go
+++ b/e2e/delete_test.go
@@ -56,28 +56,17 @@ func TestDeleteFunctionality_FullFlow(t *testing.T) {
 		t.Fatalf("send Ctrl+D: %v", err)
 	}
 
-	// Wait for delete confirmation modal to appear
+	// Wait for delete confirmation modal to fully render (including options)
 	if !tf.WaitForPlain("Delete demo?", 2*time.Second) {
 		t.Log(tf.SnapshotPlain())
 		t.Fatal("delete confirmation modal not shown")
 	}
-
-	// Verify modal shows the correct app name
-	snapshot := tf.SnapshotPlain()
-	if !strings.Contains(snapshot, "demo") {
-		t.Log(snapshot)
-		t.Fatal("delete modal should show app name 'demo'")
-	}
-
-	// Verify cascade warning is shown
-	if !strings.Contains(snapshot, "c: Cascade On") {
-		t.Log(snapshot)
+	if !tf.WaitForPlain("c: Cascade On", 2*time.Second) {
+		t.Log(tf.SnapshotPlain())
 		t.Fatal("delete modal should show cascade warning")
 	}
-
-	// Verify safety instructions
-	if !strings.Contains(snapshot, "Delete (y)") {
-		t.Log(snapshot)
+	if !tf.WaitForPlain("Delete (y)", 1*time.Second) {
+		t.Log(tf.SnapshotPlain())
 		t.Fatal("delete modal should show safety instructions")
 	}
 

--- a/e2e/driver_unix_test.go
+++ b/e2e/driver_unix_test.go
@@ -51,6 +51,9 @@ type TUITestFramework struct {
 	vt     vt10x.Terminal
 	vtRows int
 	vtCols int
+
+	// extraConfig is additional TOML config appended to the test config file
+	extraConfig string
 }
 
 func NewTUITest(t *testing.T) *TUITestFramework {
@@ -138,19 +141,24 @@ func (tf *TUITestFramework) StartApp(extraEnv ...string) error {
 	// Create a mock clipboard file for all tests (even if they don't use it)
 	clipboardFile := filepath.Join(tf.workspace, "clipboard.txt")
 	
-	// Create test config with both timeout and clipboard settings
-	testConfig := `[http_timeouts]
+	// Create test config with both timeout and clipboard settings.
+	// Extra config is prepended so top-level keys appear before TOML sections.
+	testConfig := ""
+	if tf.extraConfig != "" {
+		testConfig += tf.extraConfig + "\n"
+	}
+	testConfig += `[http_timeouts]
 # Use lower timeout for E2E tests to speed them up
 request_timeout = "2s"
 
 [clipboard]
 # Mock clipboard for tests - writes to file instead of system clipboard
 copy_command = "tee ` + clipboardFile + `"`
-	
+
 	if err := os.WriteFile(configPath, []byte(testConfig), 0600); err != nil {
 		return err
 	}
-	
+
 	env := append(os.Environ(),
 		"TERM=xterm-256color",
 		"LC_ALL=C",
@@ -207,19 +215,24 @@ func (tf *TUITestFramework) StartAppArgs(args []string, extraEnv ...string) erro
 	// Create a mock clipboard file for all tests (even if they don't use it)
 	clipboardFile := filepath.Join(tf.workspace, "clipboard.txt")
 	
-	// Create test config with both timeout and clipboard settings
-	testConfig := `[http_timeouts]
+	// Create test config with both timeout and clipboard settings.
+	// Extra config is prepended so top-level keys appear before TOML sections.
+	testConfig := ""
+	if tf.extraConfig != "" {
+		testConfig += tf.extraConfig + "\n"
+	}
+	testConfig += `[http_timeouts]
 # Use lower timeout for E2E tests to speed them up
 request_timeout = "2s"
 
 [clipboard]
 # Mock clipboard for tests - writes to file instead of system clipboard
 copy_command = "tee ` + clipboardFile + `"`
-	
+
 	if err := os.WriteFile(configPath, []byte(testConfig), 0600); err != nil {
 		return err
 	}
-	
+
 	env := append(os.Environ(),
 		"TERM=xterm-256color",
 		"LC_ALL=C",

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -250,7 +250,7 @@ func (c *ArgonautConfig) GetRequestTimeoutString() string {
 }
 
 // ParseDefaultView parses the default_view config value into a view, scope type, and scope value.
-// Returns zero values if the input is empty or invalid.
+// Returns zero values if the input is empty. Returns an error message if the input is invalid.
 // The view is returned as a string matching model.View constants (e.g. "apps", "clusters").
 // When an argument is provided, drill-down logic applies:
 //   - cluster+arg → namespaces view scoped to cluster
@@ -258,10 +258,10 @@ func (c *ArgonautConfig) GetRequestTimeoutString() string {
 //   - project+arg → apps view scoped to project
 //   - appset+arg → apps view scoped to appset
 //   - app+arg → apps view (no scope)
-func (c *ArgonautConfig) ParseDefaultView() (view string, scopeType string, scopeValue string) {
+func (c *ArgonautConfig) ParseDefaultView() (view string, scopeType string, scopeValue string, errMsg string) {
 	input := strings.TrimSpace(c.DefaultView)
 	if input == "" {
-		return "", "", ""
+		return "", "", "", ""
 	}
 
 	// Split on whitespace: command + optional arg
@@ -302,14 +302,14 @@ func (c *ArgonautConfig) ParseDefaultView() (view string, scopeType string, scop
 
 	def, ok := aliases[cmd]
 	if !ok {
-		return "", "", ""
+		return "", "", "", fmt.Sprintf("Malformed default_view in config: %q\nValid options: apps, clusters, ns, proj, appset\nExample: default_view = \"cluster production\"", input)
 	}
 
 	if arg == "" || def.drillView == "" {
-		return def.view, "", ""
+		return def.view, "", "", ""
 	}
 
-	return def.drillView, def.scopeType, arg
+	return def.drillView, def.scopeType, arg, ""
 }
 
 // GetRequestTimeout returns the parsed duration for request timeout, defaulting to 10s

--- a/pkg/config/argonaut_config.go
+++ b/pkg/config/argonaut_config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
@@ -22,6 +23,7 @@ type ArgonautConfig struct {
 	PortForward     PortForwardConfig  `toml:"port_forward,omitempty"`
 	Clipboard       ClipboardConfig    `toml:"clipboard,omitempty"`
 	HTTPTimeouts    HTTPTimeoutConfig  `toml:"http_timeouts,omitempty"`
+	DefaultView     string             `toml:"default_view,omitempty"`
 	LastSeenVersion string             `toml:"last_seen_version,omitempty"`
 }
 
@@ -245,6 +247,69 @@ func (c *ArgonautConfig) GetRequestTimeoutString() string {
 		return c.HTTPTimeouts.RequestTimeout
 	}
 	return "10s"
+}
+
+// ParseDefaultView parses the default_view config value into a view, scope type, and scope value.
+// Returns zero values if the input is empty or invalid.
+// The view is returned as a string matching model.View constants (e.g. "apps", "clusters").
+// When an argument is provided, drill-down logic applies:
+//   - cluster+arg → namespaces view scoped to cluster
+//   - namespace+arg → projects view scoped to namespace
+//   - project+arg → apps view scoped to project
+//   - appset+arg → apps view scoped to appset
+//   - app+arg → apps view (no scope)
+func (c *ArgonautConfig) ParseDefaultView() (view string, scopeType string, scopeValue string) {
+	input := strings.TrimSpace(c.DefaultView)
+	if input == "" {
+		return "", "", ""
+	}
+
+	// Split on whitespace: command + optional arg
+	parts := strings.Fields(input)
+	cmd := parts[0]
+	var arg string
+	if len(parts) > 1 {
+		arg = parts[1]
+	}
+
+	// Alias lookup: maps all aliases to a canonical command name
+	type viewDef struct {
+		view      string // view to show (without arg)
+		drillView string // view to show when arg is provided
+		scopeType string // scope type when arg is provided
+	}
+
+	aliases := map[string]viewDef{
+		"app":             {view: "apps"},
+		"apps":            {view: "apps"},
+		"application":     {view: "apps"},
+		"applications":    {view: "apps"},
+		"cluster":         {view: "clusters", drillView: "namespaces", scopeType: "cluster"},
+		"clusters":        {view: "clusters", drillView: "namespaces", scopeType: "cluster"},
+		"cls":             {view: "clusters", drillView: "namespaces", scopeType: "cluster"},
+		"namespace":       {view: "namespaces", drillView: "projects", scopeType: "namespace"},
+		"namespaces":      {view: "namespaces", drillView: "projects", scopeType: "namespace"},
+		"ns":              {view: "namespaces", drillView: "projects", scopeType: "namespace"},
+		"project":         {view: "projects", drillView: "apps", scopeType: "project"},
+		"projects":        {view: "projects", drillView: "apps", scopeType: "project"},
+		"proj":            {view: "projects", drillView: "apps", scopeType: "project"},
+		"appset":          {view: "applicationsets", drillView: "apps", scopeType: "appset"},
+		"appsets":         {view: "applicationsets", drillView: "apps", scopeType: "appset"},
+		"applicationset":  {view: "applicationsets", drillView: "apps", scopeType: "appset"},
+		"applicationsets": {view: "applicationsets", drillView: "apps", scopeType: "appset"},
+		"as":              {view: "applicationsets", drillView: "apps", scopeType: "appset"},
+	}
+
+	def, ok := aliases[cmd]
+	if !ok {
+		return "", "", ""
+	}
+
+	if arg == "" || def.drillView == "" {
+		return def.view, "", ""
+	}
+
+	return def.drillView, def.scopeType, arg
 }
 
 // GetRequestTimeout returns the parsed duration for request timeout, defaulting to 10s

--- a/pkg/config/argonaut_config_test.go
+++ b/pkg/config/argonaut_config_test.go
@@ -525,6 +525,76 @@ func TestHTTPTimeoutConfigGetters(t *testing.T) {
 	}
 }
 
+func TestParseDefaultView(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantView   string
+		wantScope  string
+		wantValue  string
+	}{
+		// Empty / zero
+		{name: "empty string", input: "", wantView: "", wantScope: "", wantValue: ""},
+
+		// All view aliases without arguments
+		{name: "apps", input: "apps", wantView: "apps", wantScope: "", wantValue: ""},
+		{name: "app", input: "app", wantView: "apps", wantScope: "", wantValue: ""},
+		{name: "application", input: "application", wantView: "apps", wantScope: "", wantValue: ""},
+		{name: "applications", input: "applications", wantView: "apps", wantScope: "", wantValue: ""},
+		{name: "clusters", input: "clusters", wantView: "clusters", wantScope: "", wantValue: ""},
+		{name: "cluster", input: "cluster", wantView: "clusters", wantScope: "", wantValue: ""},
+		{name: "cls", input: "cls", wantView: "clusters", wantScope: "", wantValue: ""},
+		{name: "namespaces", input: "namespaces", wantView: "namespaces", wantScope: "", wantValue: ""},
+		{name: "namespace", input: "namespace", wantView: "namespaces", wantScope: "", wantValue: ""},
+		{name: "ns", input: "ns", wantView: "namespaces", wantScope: "", wantValue: ""},
+		{name: "projects", input: "projects", wantView: "projects", wantScope: "", wantValue: ""},
+		{name: "project", input: "project", wantView: "projects", wantScope: "", wantValue: ""},
+		{name: "proj", input: "proj", wantView: "projects", wantScope: "", wantValue: ""},
+		{name: "appsets", input: "appsets", wantView: "applicationsets", wantScope: "", wantValue: ""},
+		{name: "appset", input: "appset", wantView: "applicationsets", wantScope: "", wantValue: ""},
+		{name: "applicationsets", input: "applicationsets", wantView: "applicationsets", wantScope: "", wantValue: ""},
+		{name: "applicationset", input: "applicationset", wantView: "applicationsets", wantScope: "", wantValue: ""},
+		{name: "as", input: "as", wantView: "applicationsets", wantScope: "", wantValue: ""},
+
+		// View + scope argument drill-down
+		{name: "cluster with arg", input: "cluster production", wantView: "namespaces", wantScope: "cluster", wantValue: "production"},
+		{name: "cls with arg", input: "cls production", wantView: "namespaces", wantScope: "cluster", wantValue: "production"},
+		{name: "ns with arg", input: "ns my-namespace", wantView: "projects", wantScope: "namespace", wantValue: "my-namespace"},
+		{name: "namespace with arg", input: "namespace my-namespace", wantView: "projects", wantScope: "namespace", wantValue: "my-namespace"},
+		{name: "project with arg", input: "project myproj", wantView: "apps", wantScope: "project", wantValue: "myproj"},
+		{name: "proj with arg", input: "proj myproj", wantView: "apps", wantScope: "project", wantValue: "myproj"},
+		{name: "appset with arg", input: "appset myset", wantView: "apps", wantScope: "appset", wantValue: "myset"},
+		{name: "as with arg", input: "as myset", wantView: "apps", wantScope: "appset", wantValue: "myset"},
+		{name: "apps with arg (no scope)", input: "apps myapp", wantView: "apps", wantScope: "", wantValue: ""},
+
+		// Invalid inputs
+		{name: "invalid tree", input: "tree", wantView: "", wantScope: "", wantValue: ""},
+		{name: "invalid unknown", input: "unknown", wantView: "", wantScope: "", wantValue: ""},
+		{name: "invalid sync", input: "sync", wantView: "", wantScope: "", wantValue: ""},
+
+		// Whitespace handling
+		{name: "leading/trailing whitespace", input: "  apps  ", wantView: "apps", wantScope: "", wantValue: ""},
+		{name: "extra whitespace between", input: "ns   my-namespace", wantView: "projects", wantScope: "namespace", wantValue: "my-namespace"},
+		{name: "only whitespace", input: "   ", wantView: "", wantScope: "", wantValue: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ArgonautConfig{DefaultView: tt.input}
+			view, scopeType, scopeValue := cfg.ParseDefaultView()
+			if view != tt.wantView {
+				t.Errorf("view = %q, want %q", view, tt.wantView)
+			}
+			if scopeType != tt.wantScope {
+				t.Errorf("scopeType = %q, want %q", scopeType, tt.wantScope)
+			}
+			if scopeValue != tt.wantValue {
+				t.Errorf("scopeValue = %q, want %q", scopeValue, tt.wantValue)
+			}
+		})
+	}
+}
+
 func TestSaveAndLoadHTTPTimeoutConfig(t *testing.T) {
 	// Create a temporary directory
 	tempDir := t.TempDir()

--- a/pkg/config/argonaut_config_test.go
+++ b/pkg/config/argonaut_config_test.go
@@ -532,6 +532,7 @@ func TestParseDefaultView(t *testing.T) {
 		wantView   string
 		wantScope  string
 		wantValue  string
+		wantErr    bool
 	}{
 		// Empty / zero
 		{name: "empty string", input: "", wantView: "", wantScope: "", wantValue: ""},
@@ -567,10 +568,10 @@ func TestParseDefaultView(t *testing.T) {
 		{name: "as with arg", input: "as myset", wantView: "apps", wantScope: "appset", wantValue: "myset"},
 		{name: "apps with arg (no scope)", input: "apps myapp", wantView: "apps", wantScope: "", wantValue: ""},
 
-		// Invalid inputs
-		{name: "invalid tree", input: "tree", wantView: "", wantScope: "", wantValue: ""},
-		{name: "invalid unknown", input: "unknown", wantView: "", wantScope: "", wantValue: ""},
-		{name: "invalid sync", input: "sync", wantView: "", wantScope: "", wantValue: ""},
+		// Invalid inputs — should return error
+		{name: "invalid tree", input: "tree", wantView: "", wantScope: "", wantValue: "", wantErr: true},
+		{name: "invalid unknown", input: "unknown", wantView: "", wantScope: "", wantValue: "", wantErr: true},
+		{name: "invalid sync", input: "sync", wantView: "", wantScope: "", wantValue: "", wantErr: true},
 
 		// Whitespace handling
 		{name: "leading/trailing whitespace", input: "  apps  ", wantView: "apps", wantScope: "", wantValue: ""},
@@ -581,7 +582,7 @@ func TestParseDefaultView(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &ArgonautConfig{DefaultView: tt.input}
-			view, scopeType, scopeValue := cfg.ParseDefaultView()
+			view, scopeType, scopeValue, errMsg := cfg.ParseDefaultView()
 			if view != tt.wantView {
 				t.Errorf("view = %q, want %q", view, tt.wantView)
 			}
@@ -590,6 +591,12 @@ func TestParseDefaultView(t *testing.T) {
 			}
 			if scopeValue != tt.wantValue {
 				t.Errorf("scopeValue = %q, want %q", scopeValue, tt.wantValue)
+			}
+			if tt.wantErr && errMsg == "" {
+				t.Error("expected error message, got empty")
+			}
+			if !tt.wantErr && errMsg != "" {
+				t.Errorf("unexpected error message: %q", errMsg)
 			}
 		})
 	}

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -165,6 +165,8 @@ type ModalState struct {
 	ChangelogLoading bool `json:"changelogLoading"`
 	// K9s error modal state
 	K9sError *string `json:"k9sError,omitempty"`
+	// Default view warning modal state
+	DefaultViewWarning *string `json:"defaultViewWarning,omitempty"`
 }
 
 // AppState represents the complete application state for Bubbletea

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -44,6 +44,7 @@ const (
 	ModeK9sContextSelect      Mode = "k9s-context-select"
 	ModeK9sError              Mode = "k9s-error"
 	ModeConfirmResourceSync   Mode = "confirm-resource-sync"
+	ModeDefaultViewWarning    Mode = "default-view-warning"
 )
 
 // App represents an ArgoCD application


### PR DESCRIPTION
## Summary
- Adds `default_view` config option to `config.toml` that lets users choose which view Argonaut starts in
- Supports all view aliases (same as `:commands`) with optional scope arguments for drill-down (e.g., `cluster production` starts in namespaces scoped to that cluster)
- Defaults to `clusters` view when unset (existing behavior unchanged)

## Config Examples
```toml
# Start in apps view
default_view = "apps"

# Start scoped to a cluster (shows its namespaces)
default_view = "cluster production"

# Start scoped to a namespace (shows its projects)
default_view = "ns my-namespace"
```

## Test plan
- [x] 34 unit tests for `ParseDefaultView` covering all aliases, drill-down, invalid input, whitespace
- [x] 2 E2E tests: `TestDefaultViewApps` and `TestDefaultViewWithScope`
- [x] Full unit test suite passes (`go test ./...`)
- [x] No regressions in existing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `default_view` configuration option to specify the initial view on app startup, with optional scoping to cluster, namespace, project, or application set.
  * Warning modal displays when default view configuration is invalid or the scoped entity cannot be found.

* **Documentation**
  * Added configuration guide for the new `default_view` option with examples and valid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->