### PR TITLE
fix: deduplicate Application line in tree view and prevent swallowed keypress after k9s (#206)

### DIFF
--- a/cmd/app/k9s_test.go
+++ b/cmd/app/k9s_test.go
@@ -178,9 +178,6 @@ func TestBuildStatusBarSequence(t *testing.T) {
 				"\x1b[2K",         // Clear line
 				"Argonaut",        // App name
 				"k9s",             // k9s identifier
-				"Pod",             // Kind
-				"default",         // Namespace
-				"minikube",        // Context
 				":q to return",    // Help text
 				"\x1b8",           // Restore cursor
 			},
@@ -206,8 +203,9 @@ func TestBuildStatusBarSequence(t *testing.T) {
 			namespace: "",
 			context:   "prod",
 			wantContains: []string{
-				"Node",
-				"prod",
+				"Argonaut",
+				"k9s",
+				":q to return",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #206.

- **Doubled Application line**: ArgoCD's resource tree stream sometimes includes the Application CR itself as a node. This created a duplicate under the synthetic root. Now filtered out in `UpsertAppTree()`, with children promoted to roots. Safe for app-of-apps (different-named Application nodes are preserved).
- **Swallowed keypress**: After k9s exits, the stdin forwarding goroutine raced with Bubble Tea for stdin. Now uses `unix.Select` to multiplex stdin with a cancellation pipe — closing the pipe after k9s exits unblocks the goroutine immediately. Previous approaches failed on macOS: `os.File.Close()` doesn't unblock reads on dup'd terminal fds, `SetReadDeadline` doesn't work (fd not in Go's poller), and `SetNonblock` corrupts the shared file description.
- **Status bar**: Simplified text to `Argonaut » k9s` to fit narrow terminals. Fixed padding width calculation to use rune count instead of byte count (`»` is multi-byte UTF-8).

## Test plan

- [x] `TestUpsertAppTree_DuplicateApplicationNodeFiltered` — same-name Application CR filtered (red-green verified)
- [x] `TestUpsertAppTree_DifferentApplicationNodePreserved` — app-of-apps child preserved
- [x] All existing tree view and cmd/app tests pass (including updated `TestBuildStatusBarSequence`)
- [x] Manual: open tree view → k9s → close k9s → no blank screen, first keypress works, no doubled Application line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate Application nodes appearing in the resource tree view
  * Improved UTF-8 character handling in status bar display for correct text alignment

* **Changes**
  * Status bar now displays simplified information, removing Kind, Namespace, Name, and Context fields
  * Enhanced application shutdown behavior for cleaner terminal exit handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->