### PR TITLE
fix: allow "j" and "k" to be typed in search/filter input

### DIFF
--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -411,10 +411,10 @@ func (m *Model) handleEnhancedSearchModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.state.UI.SearchQuery = ""
 		}
 		return m, nil
-	case "up", "k":
+	case "up":
 		// Navigate results while search is active
 		return m.handleNavigationUp()
-	case "down", "j":
+	case "down":
 		// Navigate results while search is active
 		return m.handleNavigationDown()
 	case "esc":

--- a/e2e/search_input_test.go
+++ b/e2e/search_input_test.go
@@ -1,0 +1,51 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSearchInputAcceptsAllCharacters(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServer()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// Wait for apps view to load
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Fatal("clusters not ready")
+	}
+
+	// Enter search mode
+	if err := tf.OpenSearch(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Type "jk" — these characters should appear in the search input,
+	// not be swallowed by vim-style navigation
+	_ = tf.Send("jk")
+
+	if !tf.WaitForPlain("jk", 3*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("expected 'jk' to appear in search input, but it was intercepted as navigation")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed a bug where typing `j` or `k` in the search/filter input (activated by `/`) would trigger vim-style navigation instead of inserting the character
- Removed redundant `"k"` and `"j"` cases from `handleEnhancedSearchModeKeys()` — arrow keys still work for navigation in search mode
- The centralized nav router already correctly disables vim navigation for search mode; this was a leftover in the search handler

## Test plan
- [x] New E2E test `TestSearchInputAcceptsAllCharacters` verifies `jk` can be typed in the search bar
- [x] All existing E2E tests pass (73/73)
- [x] All unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search input handling by removing vim-style keyboard navigation aliases ("j" for down, "k" for up), restricting navigation to direct arrow keys only and allowing all characters to be typed freely in search mode.

* **Tests**
  * Added comprehensive end-to-end test to verify that search input correctly accepts and displays all characters, including "jk", without unintended keyboard shortcut interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->