### PR TITLE
feat: add context switching and context picker view

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -110,6 +110,7 @@ func (m *Model) startWatchingApplicationsWithConfig(projects []string, generatio
 	capturedProjects := append([]string(nil), projects...)
 	capturedGeneration := generation
 	capturedReplaceOldWatch := replaceOldWatch
+	epoch := m.switchEpoch
 
 	return func() tea.Msg {
 		cblog.With("component", "api_integration").Info("startWatchingApplications: executing watch setup",
@@ -137,14 +138,14 @@ func (m *Model) startWatchingApplicationsWithConfig(projects []string, generatio
 			var argErr *apperrors.ArgonautError
 			if stdErrors.As(err, &argErr) {
 				if hasHTTPStatusCtx(argErr, 401, 403) || argErr.IsCategory(apperrors.ErrorAuth) || argErr.IsCode("UNAUTHORIZED") || argErr.IsCode("AUTHENTICATION_FAILED") {
-					return model.AuthErrorMsg{Error: err}
+					return model.AuthErrorMsg{Error: err, SwitchEpoch: epoch}
 				}
-				return model.StructuredErrorMsg{Error: argErr}
+				return model.StructuredErrorMsg{Error: argErr, SwitchEpoch: epoch}
 			}
 			if isAuthenticationError(err.Error()) {
-				return model.AuthErrorMsg{Error: err}
+				return model.AuthErrorMsg{Error: err, SwitchEpoch: epoch}
 			}
-			return model.ApiErrorMsg{Message: "Failed to start watch: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Failed to start watch: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		// Return message with the event channel so Update can set it properly
@@ -203,7 +204,8 @@ func (r eventResult) toBatchOperation() (model.AppBatchOperation, bool) {
 // classifyWatchEvent converts a service event into an eventResult for batching.
 // Batchable events (app-updated, app-deleted) are returned via update/deleteName fields.
 // Non-batchable events (auth-error, api-error, etc.) are returned via immediate field.
-func classifyWatchEvent(ev services.ArgoApiEvent) eventResult {
+// epoch is included in all immediate messages so they pass epoch gating when re-dispatched.
+func classifyWatchEvent(ev services.ArgoApiEvent, epoch int) eventResult {
 	switch ev.Type {
 	case "app-updated":
 		if ev.App != nil {
@@ -219,7 +221,7 @@ func classifyWatchEvent(ev services.ArgoApiEvent) eventResult {
 		}
 	case "apps-loaded":
 		if ev.Apps != nil {
-			return eventResult{immediate: model.AppsLoadedMsg{Apps: ev.Apps}}
+			return eventResult{immediate: model.AppsLoadedMsg{Apps: ev.Apps, SwitchEpoch: epoch}}
 		}
 	case "status-change":
 		if ev.Status != "" {
@@ -227,21 +229,21 @@ func classifyWatchEvent(ev services.ArgoApiEvent) eventResult {
 		}
 	case "auth-error":
 		if ev.Error != nil {
-			return eventResult{immediate: model.AuthErrorMsg{Error: ev.Error}}
+			return eventResult{immediate: model.AuthErrorMsg{Error: ev.Error, SwitchEpoch: epoch}}
 		}
 	case "api-error":
 		if ev.Error != nil {
 			var argErr *apperrors.ArgonautError
 			if stdErrors.As(ev.Error, &argErr) {
 				if hasHTTPStatusCtx(argErr, 401, 403) || argErr.IsCategory(apperrors.ErrorAuth) || argErr.IsCode("UNAUTHORIZED") || argErr.IsCode("AUTHENTICATION_FAILED") {
-					return eventResult{immediate: model.AuthErrorMsg{Error: ev.Error}}
+					return eventResult{immediate: model.AuthErrorMsg{Error: ev.Error, SwitchEpoch: epoch}}
 				}
-				return eventResult{immediate: model.StructuredErrorMsg{Error: argErr}}
+				return eventResult{immediate: model.StructuredErrorMsg{Error: argErr, SwitchEpoch: epoch}}
 			}
 			if isAuthenticationError(ev.Error.Error()) {
-				return eventResult{immediate: model.AuthErrorMsg{Error: ev.Error}}
+				return eventResult{immediate: model.AuthErrorMsg{Error: ev.Error, SwitchEpoch: epoch}}
 			}
-			return eventResult{immediate: model.ApiErrorMsg{Message: ev.Error.Error()}}
+			return eventResult{immediate: model.ApiErrorMsg{Message: ev.Error.Error(), SwitchEpoch: epoch}}
 		}
 	}
 	return eventResult{}
@@ -284,7 +286,7 @@ func (m *Model) consumeWatchEvents() tea.Cmd {
 			return nil
 		}
 
-		result := classifyWatchEvent(ev)
+		result := classifyWatchEvent(ev, epoch)
 
 		// If first event is non-batchable, wrap it in a batch so the
 		// AppsBatchUpdateMsg handler continues the watch consumer chain.
@@ -322,7 +324,7 @@ func (m *Model) consumeWatchEvents() tea.Cmd {
 				if !ok {
 					break loop
 				}
-				result := classifyWatchEvent(ev)
+				result := classifyWatchEvent(ev, epoch)
 				if result.immediate != nil {
 					immediate = result.immediate
 					break loop
@@ -418,9 +420,10 @@ func stringSlicesEqual(a, b []string) bool {
 
 // startDiffSession loads diffs and opens the diff pager
 func (m *Model) startDiffSession(appName string) tea.Cmd {
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		if m.state.Server == nil {
-			return model.ApiErrorMsg{Message: "No server configured"}
+			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 45*time.Second)
@@ -429,7 +432,7 @@ func (m *Model) startDiffSession(appName string) tea.Cmd {
 		apiService := services.NewArgoApiService(m.state.Server)
 		diffs, err := apiService.GetResourceDiffs(ctx, m.state.Server, appName)
 		if err != nil {
-			return model.ApiErrorMsg{Message: "Failed to load diffs: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Failed to load diffs: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		normalizedDocs := make([]string, 0)
@@ -480,7 +483,7 @@ func (m *Model) startDiffSession(appName string) tea.Cmd {
 		cmd := exec.Command("git", "--no-pager", "diff", "--no-index", "--no-color", "--", leftFile, rightFile)
 		out, err := cmd.CombinedOutput()
 		if err != nil && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() != 1 {
-			return model.ApiErrorMsg{Message: "Diff failed: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Diff failed: " + err.Error(), SwitchEpoch: epoch}
 		}
 		cleaned := stripDiffHeader(string(out))
 		if strings.TrimSpace(cleaned) == "" {
@@ -515,9 +518,10 @@ func (m *Model) startDiffSession(appName string) tea.Cmd {
 
 // startResourceDiffSession loads the diff for a specific resource and opens the diff pager
 func (m *Model) startResourceDiffSession(res ResourceIdentifier) tea.Cmd {
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		if m.state.Server == nil {
-			return model.ApiErrorMsg{Message: "No server configured"}
+			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 45*time.Second)
@@ -526,7 +530,7 @@ func (m *Model) startResourceDiffSession(res ResourceIdentifier) tea.Cmd {
 		apiService := services.NewArgoApiService(m.state.Server)
 		diffs, err := apiService.GetResourceDiffs(ctx, m.state.Server, res.AppName)
 		if err != nil {
-			return model.ApiErrorMsg{Message: "Failed to load diffs: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Failed to load diffs: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		// Find the matching resource diff
@@ -572,7 +576,7 @@ func (m *Model) startResourceDiffSession(res ResourceIdentifier) tea.Cmd {
 		cmd := exec.Command("git", "--no-pager", "diff", "--no-index", "--no-color", "--", leftFile, rightFile)
 		out, err := cmd.CombinedOutput()
 		if err != nil && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() != 1 {
-			return model.ApiErrorMsg{Message: "Diff failed: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Diff failed: " + err.Error(), SwitchEpoch: epoch}
 		}
 		cleaned := stripDiffHeader(string(out))
 		if strings.TrimSpace(cleaned) == "" {
@@ -645,6 +649,7 @@ func cleanManifestToYAML(jsonOrYaml string) string {
 
 // startLoadingResourceTree loads the resource tree for the given app
 func (m *Model) startLoadingResourceTree(app model.App) tea.Cmd {
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		if m.state.Server == nil {
 			return model.ApiErrorMsg{Message: "No server configured"}
@@ -659,12 +664,12 @@ func (m *Model) startLoadingResourceTree(app model.App) tea.Cmd {
 		}
 		tree, err := argo.GetResourceTree(ctx, m.state.Server, app.Name, appNamespace)
 		if err != nil {
-			return model.ApiErrorMsg{Message: err.Error()}
+			return model.ApiErrorMsg{Message: err.Error(), SwitchEpoch: epoch}
 		}
 		// Marshal to JSON to avoid import cycle in model messages
 		data, merr := json.Marshal(tree)
 		if merr != nil {
-			return model.ApiErrorMsg{Message: merr.Error()}
+			return model.ApiErrorMsg{Message: merr.Error(), SwitchEpoch: epoch}
 		}
 
 		// Also fetch app details to get status.resources for sync status
@@ -680,6 +685,7 @@ func (m *Model) startLoadingResourceTree(app model.App) tea.Cmd {
 			Sync:          app.Sync,
 			TreeJSON:      data,
 			ResourcesJSON: resourcesData,
+			SwitchEpoch:   epoch,
 		}
 	}
 }
@@ -756,6 +762,7 @@ func (m *Model) syncSelectedApplications(prune bool) tea.Cmd {
 		}
 	}
 
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		apiService := services.NewEnhancedArgoApiService(m.state.Server)
 
@@ -767,9 +774,10 @@ func (m *Model) syncSelectedApplications(prune bool) tea.Cmd {
 				// Convert to structured error and return via TUI error handling
 				if argErr, ok := err.(*apperrors.ArgonautError); ok {
 					return model.StructuredErrorMsg{
-						Error:   argErr,
-						Context: map[string]interface{}{"operation": "multi-sync", "appName": appName},
-						Retry:   argErr.Recoverable,
+						Error:       argErr,
+						Context:     map[string]interface{}{"operation": "multi-sync", "appName": appName},
+						Retry:       argErr.Recoverable,
+						SwitchEpoch: epoch,
 					}
 				}
 				// Fallback for non-structured errors
@@ -779,13 +787,14 @@ func (m *Model) syncSelectedApplications(prune bool) tea.Cmd {
 						WithSeverity(apperrors.SeverityHigh).
 						AsRecoverable().
 						WithUserAction("Check your connection to ArgoCD and try again"),
-					Context: map[string]interface{}{"operation": "multi-sync", "appName": appName},
-					Retry:   true,
+					Context:     map[string]interface{}{"operation": "multi-sync", "appName": appName},
+					Retry:       true,
+					SwitchEpoch: epoch,
 				}
 			}
 		}
 
-		return model.MultiSyncCompletedMsg{AppCount: len(selectedApps), Success: true}
+		return model.MultiSyncCompletedMsg{AppCount: len(selectedApps), Success: true, SwitchEpoch: epoch}
 	}
 }
 
@@ -800,6 +809,7 @@ func (m *Model) deleteApplication(req model.AppDeleteRequestMsg) tea.Cmd {
 		}
 	}
 
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
 		defer cancel()
@@ -840,7 +850,7 @@ func (m *Model) deleteApplication(req model.AppDeleteRequestMsg) tea.Cmd {
 		}
 
 		cblog.With("component", "app-delete").Info("Delete completed", "app", req.AppName)
-		return model.AppDeleteSuccessMsg{AppName: req.AppName}
+		return model.AppDeleteSuccessMsg{AppName: req.AppName, SwitchEpoch: epoch}
 	}
 }
 
@@ -852,6 +862,7 @@ func (m *Model) syncSingleApplication(appName string, prune bool) tea.Cmd {
 		}
 	}
 
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
 		defer cancel()
@@ -865,9 +876,10 @@ func (m *Model) syncSingleApplication(appName string, prune bool) tea.Cmd {
 			// Convert to structured error and return via TUI error handling
 			if argErr, ok := err.(*apperrors.ArgonautError); ok {
 				return model.StructuredErrorMsg{
-					Error:   argErr,
-					Context: map[string]interface{}{"operation": "sync", "appName": appName},
-					Retry:   argErr.Recoverable,
+					Error:       argErr,
+					Context:     map[string]interface{}{"operation": "sync", "appName": appName},
+					Retry:       argErr.Recoverable,
+					SwitchEpoch: epoch,
 				}
 			}
 			// Fallback for non-structured errors
@@ -877,13 +889,14 @@ func (m *Model) syncSingleApplication(appName string, prune bool) tea.Cmd {
 					WithSeverity(apperrors.SeverityHigh).
 					AsRecoverable().
 					WithUserAction("Check your connection to ArgoCD and try again"),
-				Context: map[string]interface{}{"operation": "sync", "appName": appName},
-				Retry:   true,
+				Context:     map[string]interface{}{"operation": "sync", "appName": appName},
+				Retry:       true,
+				SwitchEpoch: epoch,
 			}
 		}
 
 		cblog.With("component", "api").Info("Sync completed", "app", appName)
-		return model.SyncCompletedMsg{AppName: appName, Success: true}
+		return model.SyncCompletedMsg{AppName: appName, Success: true, SwitchEpoch: epoch}
 	}
 }
 
@@ -895,6 +908,7 @@ func (m *Model) refreshSingleApplication(appName string, appNamespace *string, h
 		}
 	}
 
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
 		defer cancel()
@@ -917,9 +931,10 @@ func (m *Model) refreshSingleApplication(appName string, appNamespace *string, h
 			cblog.With("component", "api").Error("Refresh failed", "app", appName, "err", err)
 			if argErr, ok := err.(*apperrors.ArgonautError); ok {
 				return model.StructuredErrorMsg{
-					Error:   argErr,
-					Context: map[string]interface{}{"operation": "refresh", "appName": appName, "hard": hard},
-					Retry:   argErr.Recoverable,
+					Error:       argErr,
+					Context:     map[string]interface{}{"operation": "refresh", "appName": appName, "hard": hard},
+					Retry:       argErr.Recoverable,
+					SwitchEpoch: epoch,
 				}
 			}
 			errorMsg := fmt.Sprintf("Failed to refresh %s: %v", appName, err)
@@ -928,8 +943,9 @@ func (m *Model) refreshSingleApplication(appName string, appNamespace *string, h
 					WithSeverity(apperrors.SeverityMedium).
 					AsRecoverable().
 					WithUserAction("Check your connection to ArgoCD and try again"),
-				Context: map[string]interface{}{"operation": "refresh", "appName": appName, "hard": hard},
-				Retry:   true,
+				Context:     map[string]interface{}{"operation": "refresh", "appName": appName, "hard": hard},
+				Retry:       true,
+				SwitchEpoch: epoch,
 			}
 		}
 
@@ -1036,9 +1052,10 @@ func hasHTTPStatusCtx(err *apperrors.ArgonautError, statuses ...int) bool {
 
 // startRollbackSession loads deployment history for rollback
 func (m *Model) startRollbackSession(appName string) tea.Cmd {
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		if m.state.Server == nil {
-			return model.ApiErrorMsg{Message: "No server configured"}
+			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 30*time.Second)
@@ -1052,9 +1069,9 @@ func (m *Model) startRollbackSession(appName string) tea.Cmd {
 			errMsg := err.Error()
 			cblog.With("component", "rollback").Error("Rollback session failed", "app", appName, "err", err)
 			if isAuthenticationError(errMsg) {
-				return model.AuthErrorMsg{Error: err}
+				return model.AuthErrorMsg{Error: err, SwitchEpoch: epoch}
 			}
-			return model.ApiErrorMsg{Message: "Failed to load application: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Failed to load application: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		cblog.With("component", "rollback").Info("Loaded application history", "app", appName, "count", len(app.Status.History))
@@ -1109,9 +1126,10 @@ func (m *Model) loadRevisionMetadata(appName string, rowIndex int, revision stri
 
 // executeRollback performs the actual rollback operation
 func (m *Model) executeRollback(request model.RollbackRequest) tea.Cmd {
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		if m.state.Server == nil {
-			return model.ApiErrorMsg{Message: "No server configured"}
+			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 60*time.Second)
@@ -1123,9 +1141,9 @@ func (m *Model) executeRollback(request model.RollbackRequest) tea.Cmd {
 		if err != nil {
 			errMsg := err.Error()
 			if isAuthenticationError(errMsg) {
-				return model.AuthErrorMsg{Error: err}
+				return model.AuthErrorMsg{Error: err, SwitchEpoch: epoch}
 			}
-			return model.ApiErrorMsg{Message: "Failed to rollback application: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Failed to rollback application: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		// Determine if we should watch after rollback
@@ -1144,9 +1162,10 @@ func (m *Model) executeRollback(request model.RollbackRequest) tea.Cmd {
 
 // startRollbackDiffSession shows diff between current and selected revision
 func (m *Model) startRollbackDiffSession(appName string, revision string) tea.Cmd {
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		if m.state.Server == nil {
-			return model.ApiErrorMsg{Message: "No server configured"}
+			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 45*time.Second)
@@ -1157,7 +1176,7 @@ func (m *Model) startRollbackDiffSession(appName string, revision string) tea.Cm
 		// Get diff between current and target revision
 		diffs, err := apiService.GetResourceDiffs(ctx, m.state.Server, appName)
 		if err != nil {
-			return model.ApiErrorMsg{Message: "Failed to load diffs: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Failed to load diffs: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		// Process diffs (same logic as regular diff)
@@ -1188,7 +1207,7 @@ func (m *Model) startRollbackDiffSession(appName string, revision string) tea.Cm
 		cmd := exec.Command("git", "--no-pager", "diff", "--no-index", "--color=always", "--", leftFile, rightFile)
 		out, err := cmd.CombinedOutput()
 		if err != nil && cmd.ProcessState != nil && cmd.ProcessState.ExitCode() != 1 {
-			return model.ApiErrorMsg{Message: "Diff failed: " + err.Error()}
+			return model.ApiErrorMsg{Message: "Diff failed: " + err.Error(), SwitchEpoch: epoch}
 		}
 
 		cleaned := stripDiffHeader(string(out))
@@ -1321,6 +1340,7 @@ func (m *Model) deleteSingleApplication(params AppDeleteParams) tea.Cmd {
 		}
 	}
 
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
 		defer cancel()
@@ -1334,7 +1354,7 @@ func (m *Model) deleteSingleApplication(params AppDeleteParams) tea.Cmd {
 			}
 		}
 
-		return model.AppDeleteSuccessMsg{AppName: params.AppName}
+		return model.AppDeleteSuccessMsg{AppName: params.AppName, SwitchEpoch: epoch}
 	}
 }
 
@@ -1485,6 +1505,7 @@ func (m *Model) syncSelectedResources(targets []model.ResourceSyncTarget, prune,
 		appNames = append(appNames, name)
 	}
 
+	epoch := m.switchEpoch // capture at call time
 	return func() tea.Msg {
 		cblog.With("component", "resource-sync").Info("Starting resource sync",
 			"count", len(targets), "apps", len(appResources), "prune", prune, "force", force)
@@ -1539,6 +1560,6 @@ func (m *Model) syncSelectedResources(targets []model.ResourceSyncTarget, prune,
 		}
 
 		cblog.With("component", "resource-sync").Info("Resource sync completed successfully", "count", successCount)
-		return model.ResourceSyncSuccessMsg{Count: successCount, AppNames: appNames}
+		return model.ResourceSyncSuccessMsg{Count: successCount, AppNames: appNames, SwitchEpoch: epoch}
 	}
 }

--- a/cmd/app/batch_watch_test.go
+++ b/cmd/app/batch_watch_test.go
@@ -12,7 +12,7 @@ import (
 func TestClassifyWatchEvent_AppUpdated(t *testing.T) {
 	app := &model.App{Name: "test-app", Health: "Healthy", Sync: "Synced"}
 	ev := services.ArgoApiEvent{Type: "app-updated", App: app}
-	result := classifyWatchEvent(ev)
+	result := classifyWatchEvent(ev, 0)
 
 	if result.update == nil {
 		t.Fatal("expected update to be non-nil")
@@ -30,7 +30,7 @@ func TestClassifyWatchEvent_AppUpdated(t *testing.T) {
 
 func TestClassifyWatchEvent_AppDeleted(t *testing.T) {
 	ev := services.ArgoApiEvent{Type: "app-deleted", AppName: "removed-app"}
-	result := classifyWatchEvent(ev)
+	result := classifyWatchEvent(ev, 0)
 
 	if result.deleteName != "removed-app" {
 		t.Errorf("expected deleteName 'removed-app', got %q", result.deleteName)
@@ -45,7 +45,7 @@ func TestClassifyWatchEvent_AppDeleted(t *testing.T) {
 
 func TestClassifyWatchEvent_AuthError(t *testing.T) {
 	ev := services.ArgoApiEvent{Type: "auth-error", Error: fmt.Errorf("unauthorized")}
-	result := classifyWatchEvent(ev)
+	result := classifyWatchEvent(ev, 0)
 
 	if result.immediate == nil {
 		t.Fatal("expected immediate to be non-nil for auth-error")
@@ -60,7 +60,7 @@ func TestClassifyWatchEvent_AuthError(t *testing.T) {
 
 func TestClassifyWatchEvent_StatusChange(t *testing.T) {
 	ev := services.ArgoApiEvent{Type: "status-change", Status: "Connected"}
-	result := classifyWatchEvent(ev)
+	result := classifyWatchEvent(ev, 0)
 
 	if result.immediate == nil {
 		t.Fatal("expected immediate to be non-nil for status-change")

--- a/cmd/app/context_switch.go
+++ b/cmd/app/context_switch.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	cblog "github.com/charmbracelet/log"
+	"github.com/darksworm/argonaut/pkg/config"
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+// performContextSwitch re-reads the ArgoCD config and resolves the named context.
+// Returns a ContextSwitchResultMsg with the new server config or an error.
+func (m *Model) performContextSwitch(contextName string) tea.Cmd {
+	configPath := m.argoConfigPath
+	currentCtx := m.currentContextName
+	return func() tea.Msg {
+		// Same-context no-op
+		if contextName == currentCtx {
+			return model.StatusChangeMsg{Status: "Already on context: " + contextName}
+		}
+
+		// Re-read config from disk (tokens may have changed)
+		cfg, err := config.ReadCLIConfigFromPath(configPath)
+		if err != nil {
+			return model.ContextSwitchResultMsg{Error: err}
+		}
+
+		// Check for unsupported modes
+		if isPF, pfErr := cfg.IsContextPortForward(contextName); pfErr == nil && isPF {
+			return model.ContextSwitchResultMsg{
+				Error: fmt.Errorf("context %q uses port-forward mode, which is not supported for live switching", contextName),
+			}
+		}
+		if isCore, coreErr := cfg.IsContextCore(contextName); coreErr == nil && isCore {
+			return model.ContextSwitchResultMsg{
+				Error: fmt.Errorf("context %q uses core mode, which is not supported for live switching", contextName),
+			}
+		}
+
+		// Resolve context to Server
+		server, err := cfg.ToServerConfigForContext(contextName)
+		if err != nil {
+			return model.ContextSwitchResultMsg{Error: err}
+		}
+
+		return model.ContextSwitchResultMsg{
+			Server:       server,
+			ContextName:  contextName,
+			ContextNames: cfg.GetContextNames(),
+		}
+	}
+}
+
+// handleContextSwitchResult processes the result of a context switch.
+// It tears down the old model, creates a fresh one via NewModel(), and
+// transfers only the narrow set of fields that must survive across contexts.
+func (m *Model) handleContextSwitchResult(msg model.ContextSwitchResultMsg) (tea.Model, tea.Cmd) {
+	if msg.Error != nil {
+		m.statusService.Error("Context switch failed: " + msg.Error.Error())
+		return m, nil
+	}
+
+	cblog.With("component", "context-switch").Info("Switching context",
+		"from", m.currentContextName,
+		"to", msg.ContextName,
+		"server", msg.Server.BaseURL)
+
+	// 1. Cleanup old goroutines — ORDER MATTERS:
+	//    a. Stop forwarding goroutine FIRST
+	m.cleanupAppWatcher()
+	//    b. Stop tree watchers
+	_ = m.cleanupTreeWatchers()
+	//    c. Cancel HTTP SSE stream SECOND (after forwarder is stopped)
+	if m.watchCleanup != nil {
+		m.watchCleanup()
+	}
+
+	// 2. Create fresh model with same config (re-applies preferences)
+	newM := NewModel(m.config)
+
+	// 3. Re-run Init() side effects that BubbleTea won't call on model swap
+	newM.applyThemeToModel()
+
+	// 4. Transfer ONLY what must survive (narrowly defined, test-locked)
+	newM.program = m.program                   // BubbleTea program pointer
+	newM.state.Terminal = m.state.Terminal      // Current terminal size
+	newM.ready = true                          // Already have terminal size
+	newM.argoConfigPath = m.argoConfigPath     // For future switches
+	newM.currentContextName = msg.ContextName  // New context name
+	newM.state.Server = msg.Server             // New server config
+	newM.state.ContextNames = msg.ContextNames // From result (no 2nd config read)
+	newM.switchEpoch = m.switchEpoch + 1       // Increment epoch
+
+	// 5. Start fresh load cycle
+	return newM, tea.Batch(
+		newM.spinner.Tick,
+		func() tea.Msg { return model.SetInitialLoadingMsg{Loading: true} },
+		newM.validateAuthentication(),
+	)
+}

--- a/cmd/app/context_switch_test.go
+++ b/cmd/app/context_switch_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+// TestStaleAppsLoadedMsgDiscarded verifies that AppsLoadedMsg from a previous
+// epoch is silently discarded.
+func TestStaleAppsLoadedMsgDiscarded(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.switchEpoch = 5
+	m.ready = true
+
+	msg := model.AppsLoadedMsg{
+		Apps:        []model.App{{Name: "stale-app"}},
+		SwitchEpoch: 3, // old epoch
+	}
+
+	result, cmd := m.Update(msg)
+	newM := result.(*Model)
+
+	if len(newM.state.Apps) != 0 {
+		t.Errorf("expected 0 apps (stale msg discarded), got %d", len(newM.state.Apps))
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd for discarded message")
+	}
+}
+
+// TestCurrentAppsLoadedMsgApplied verifies that AppsLoadedMsg from the current
+// epoch is applied normally.
+func TestCurrentAppsLoadedMsgApplied(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.switchEpoch = 5
+	m.ready = true
+
+	msg := model.AppsLoadedMsg{
+		Apps:        []model.App{{Name: "current-app"}},
+		SwitchEpoch: 5, // current epoch
+	}
+
+	result, _ := m.Update(msg)
+	newM := result.(*Model)
+
+	if len(newM.state.Apps) != 1 || newM.state.Apps[0].Name != "current-app" {
+		t.Errorf("expected 1 app 'current-app', got %v", newM.state.Apps)
+	}
+}
+
+// TestStaleAppsBatchUpdateMsgDiscarded verifies that AppsBatchUpdateMsg from
+// a previous epoch is fully discarded (no updates, no immediate re-dispatch).
+func TestStaleAppsBatchUpdateMsgDiscarded(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.switchEpoch = 5
+	m.ready = true
+	m.state.Apps = []model.App{{Name: "existing"}}
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+
+	msg := model.AppsBatchUpdateMsg{
+		Updates: []model.AppUpdatedMsg{
+			{App: model.App{Name: "stale-update"}},
+		},
+		Deletes:     []string{"existing"},
+		SwitchEpoch: 3, // old epoch
+		Generation:  0,
+	}
+
+	result, cmd := m.Update(msg)
+	newM := result.(*Model)
+
+	// Apps should be unchanged
+	if len(newM.state.Apps) != 1 || newM.state.Apps[0].Name != "existing" {
+		t.Errorf("expected apps unchanged, got %v", newM.state.Apps)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd for discarded batch")
+	}
+}
+
+// TestStaleAuthValidationResultMsgDiscarded verifies that AuthValidationResultMsg
+// from a previous epoch is discarded.
+func TestStaleAuthValidationResultMsgDiscarded(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.switchEpoch = 5
+	m.state.Mode = model.ModeNormal
+	m.ready = true
+
+	msg := model.AuthValidationResultMsg{
+		Mode:        model.ModeAuthRequired,
+		SwitchEpoch: 3, // old epoch
+	}
+
+	result, cmd := m.Update(msg)
+	newM := result.(*Model)
+
+	if newM.state.Mode != model.ModeNormal {
+		t.Errorf("expected mode to remain ModeNormal, got %v", newM.state.Mode)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd for discarded auth validation")
+	}
+}
+
+// TestStaleResourceTreeLoadedMsgDiscarded verifies that ResourceTreeLoadedMsg
+// from a previous epoch is discarded.
+func TestStaleResourceTreeLoadedMsgDiscarded(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.switchEpoch = 5
+	m.ready = true
+
+	msg := model.ResourceTreeLoadedMsg{
+		AppName:     "stale-app",
+		TreeJSON:    []byte(`{"nodes":[]}`),
+		SwitchEpoch: 3, // old epoch
+	}
+
+	_, cmd := m.Update(msg)
+	if cmd != nil {
+		t.Error("expected nil cmd for discarded tree loaded msg")
+	}
+}
+
+// TestStaleAuthErrorMsgDiscarded verifies that AuthErrorMsg from a previous
+// epoch is discarded.
+func TestStaleAuthErrorMsgDiscarded(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.switchEpoch = 5
+	m.state.Mode = model.ModeNormal
+	m.ready = true
+
+	msg := model.AuthErrorMsg{
+		Error:       nil,
+		SwitchEpoch: 3, // old epoch
+	}
+
+	result, cmd := m.Update(msg)
+	newM := result.(*Model)
+
+	if newM.state.Mode != model.ModeNormal {
+		t.Errorf("expected mode to remain ModeNormal, got %v", newM.state.Mode)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd for discarded auth error")
+	}
+}
+
+// TestContextSwitchPreservedFields verifies that only expected fields survive
+// a context switch (the preserved-fields contract).
+func TestContextSwitchPreservedFields(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://old.example.com", Token: "old-token"}
+	m.state.Terminal = model.TerminalState{Rows: 50, Cols: 120}
+	m.ready = true
+	m.argoConfigPath = "/path/to/config"
+	m.currentContextName = "old-context"
+	m.switchEpoch = 3
+
+	newServer := &model.Server{BaseURL: "https://new.example.com", Token: "new-token"}
+	contextNames := []string{"context-a", "context-b"}
+
+	result, _ := m.handleContextSwitchResult(model.ContextSwitchResultMsg{
+		Server:       newServer,
+		ContextName:  "new-context",
+		ContextNames: contextNames,
+	})
+	newM := result.(*Model)
+
+	// Verify preserved fields
+	if newM.state.Terminal.Rows != 50 || newM.state.Terminal.Cols != 120 {
+		t.Errorf("terminal size not preserved: %+v", newM.state.Terminal)
+	}
+	if !newM.ready {
+		t.Error("ready flag not preserved")
+	}
+	if newM.argoConfigPath != "/path/to/config" {
+		t.Errorf("argoConfigPath not preserved: %q", newM.argoConfigPath)
+	}
+	if newM.currentContextName != "new-context" {
+		t.Errorf("currentContextName not set: %q", newM.currentContextName)
+	}
+	if newM.state.Server != newServer {
+		t.Error("server not set to new server")
+	}
+	if len(newM.state.ContextNames) != 2 {
+		t.Errorf("context names not set: %v", newM.state.ContextNames)
+	}
+	if newM.switchEpoch != 4 {
+		t.Errorf("switchEpoch not incremented: %d", newM.switchEpoch)
+	}
+
+	// Verify old state is NOT carried over
+	if len(newM.state.Apps) != 0 {
+		t.Errorf("old apps should not be carried: %d apps", len(newM.state.Apps))
+	}
+	if newM.watchChan != nil {
+		t.Error("watchChan should be nil on fresh model")
+	}
+	if newM.watchCleanup != nil {
+		t.Error("watchCleanup should be nil on fresh model")
+	}
+	if newM.lastResourceVersion != "" {
+		t.Errorf("lastResourceVersion should be empty: %q", newM.lastResourceVersion)
+	}
+}
+
+// TestContextSwitchSameContextNoOp verifies that switching to the same context
+// produces a status message without teardown.
+func TestContextSwitchSameContextNoOp(t *testing.T) {
+	m := NewModel(nil)
+	m.state.Server = &model.Server{BaseURL: "https://test.example.com", Token: "tok"}
+	m.currentContextName = "my-context"
+	m.argoConfigPath = "/tmp/nonexistent" // won't be read for same-context
+
+	cmd := m.performContextSwitch("my-context")
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+
+	msg := cmd()
+	if statusMsg, ok := msg.(model.StatusChangeMsg); ok {
+		if statusMsg.Status != "Already on context: my-context" {
+			t.Errorf("unexpected status: %q", statusMsg.Status)
+		}
+	} else {
+		t.Errorf("expected StatusChangeMsg, got %T", msg)
+	}
+}

--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -270,6 +270,10 @@ func (m *Model) validateCommand(input string) bool {
 				return false
 			}
 			return true
+		case "context":
+			// Context names are validated at execution time (re-reads config from disk)
+			// so any non-empty arg is syntactically valid here
+			return true
 		}
 	}
 
@@ -1080,6 +1084,15 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			// Fetch and display changelog
 			m.state.Modals.ChangelogLoading = true
 			return m, m.fetchChangelog()
+		case "context", "contexts", "argocd", "ctx":
+			m.state.UI.TreeAppName = nil
+			m.treeLoading = false
+			m.state.Navigation.SelectedIdx = 0
+			if arg != "" {
+				return m, m.performContextSwitch(arg)
+			}
+			m = m.safeChangeView(model.ViewContexts)
+			return m, nil
 		default:
 			// Unknown: set status for feedback
 			return m, func() tea.Msg { return model.StatusChangeMsg{Status: "Unknown command: " + raw} }

--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -120,6 +120,16 @@ func (m *Model) handleToggleSelection() (tea.Model, tea.Cmd) {
 
 // handleDrillDown implements drill-down navigation (enter key)
 func (m *Model) handleDrillDown() (tea.Model, tea.Cmd) {
+	// In contexts view, enter triggers a context switch
+	if m.state.Navigation.View == model.ViewContexts {
+		visibleItems := m.getVisibleItemsForCurrentView()
+		if len(visibleItems) > 0 && m.state.Navigation.SelectedIdx < len(visibleItems) {
+			ctxName := fmt.Sprintf("%v", visibleItems[m.state.Navigation.SelectedIdx])
+			return m, m.performContextSwitch(ctxName)
+		}
+		return m, nil
+	}
+
 	// In apps view, enter opens the resources/tree view for the selected app
 	if m.state.Navigation.View == model.ViewApps {
 		return m.handleOpenResourcesForSelection()
@@ -383,6 +393,9 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 		m.state.UI.Command = ""
 
 		switch curr {
+		case model.ViewContexts:
+			m = m.safeChangeView(model.ViewClusters)
+			m.state.Navigation.SelectedIdx = 0
 		case model.ViewTree:
 			// Return to apps view from tree/resources view
 			if m.treeView != nil {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -267,6 +267,19 @@ func main() {
 	// Load Argo CD CLI configuration (matches TypeScript app-orchestrator.ts)
 	cblog.With("component", "app").Info("Loading Argo CD config…")
 
+	// Determine and store the effective ArgoCD config path
+	effectiveConfigPath := cfgPathFlag
+	if effectiveConfigPath == "" {
+		effectiveConfigPath = config.GetConfigPath()
+	}
+	m.argoConfigPath = effectiveConfigPath
+
+	// Read the CLI config to populate context names
+	if cliCfg, cfgErr := config.ReadCLIConfigFromPath(effectiveConfigPath); cfgErr == nil {
+		m.state.ContextNames = cliCfg.GetContextNames()
+		m.currentContextName = cliCfg.CurrentContext
+	}
+
 	// Port-forward manager (if used)
 	var pfManager *portforward.Manager
 

--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -504,6 +504,10 @@ func (m *Model) getVisibleItems() []interface{} {
 		for _, app := range appsCopy {
 			base = append(base, app)
 		}
+	case model.ViewContexts:
+		for _, name := range m.state.ContextNames {
+			base = append(base, name)
+		}
 	default:
 		// No-op
 	}

--- a/cmd/app/view_banner.go
+++ b/cmd/app/view_banner.go
@@ -79,7 +79,9 @@ func (m *Model) renderCompactBanner() string {
 	total := max(0, m.state.Terminal.Cols-2)
 
 	host := "—"
-	if m.state.Server != nil {
+	if m.currentContextName != "" {
+		host = m.currentContextName
+	} else if m.state.Server != nil {
 		host = hostFromURL(m.state.Server.BaseURL)
 	}
 	cls := scopeToText(m.state.Selections.ScopeClusters)
@@ -181,7 +183,14 @@ func (m *Model) renderContextBlock(isNarrow bool) string {
 	projectScope := scopeToText(m.state.Selections.ScopeProjects)
 
 	var lines []string
-	lines = append(lines, fmt.Sprintf("%s %s", label.Render("Context:"), cyan.Render(serverHost)))
+	if m.currentContextName != "" {
+		lines = append(lines, fmt.Sprintf("%s %s", label.Render("Context:"), cyan.Render(m.currentContextName)))
+		if !isNarrow {
+			lines = append(lines, fmt.Sprintf("%s  %s", label.Render("Server:"), cyan.Render(serverHost)))
+		}
+	} else {
+		lines = append(lines, fmt.Sprintf("%s %s", label.Render("Context:"), cyan.Render(serverHost)))
+	}
 	if clusterScope != "—" {
 		lines = append(lines, fmt.Sprintf("%s %s", label.Render("Cluster:"), clusterScope))
 	}

--- a/cmd/app/view_layout.go
+++ b/cmd/app/view_layout.go
@@ -325,7 +325,7 @@ func (m *Model) renderMainLayout() string {
 		canvas := lipgloss.NewCanvas(baseLayer, modalLayer)
 		return canvas.Render()
 	}
-	if m.state.Mode == model.ModeLoading {
+	if m.state.Mode == model.ModeLoading && m.state.Navigation.View != model.ViewContexts {
 		modal := m.renderInitialLoadingModal()
 		grayBase := desaturateANSI(baseView)
 		baseLayer := lipgloss.NewLayer(grayBase)
@@ -346,7 +346,7 @@ func (m *Model) renderMainLayout() string {
 	// Check if we have no apps loaded (apps are the main data source)
 	hasNoData := len(m.state.Apps) == 0
 
-	if hasNoData && m.state.Mode == model.ModeNormal {
+	if hasNoData && m.state.Mode == model.ModeNormal && m.state.Navigation.View != model.ViewContexts {
 		modal := m.renderNoServerModal()
 		grayBase := desaturateANSI(baseView)
 		baseLayer := lipgloss.NewLayer(grayBase)

--- a/cmd/app/view_lists.go
+++ b/cmd/app/view_lists.go
@@ -70,7 +70,7 @@ func (m *Model) renderListView(availableRows int) string {
 			}
 			tableView = b.String()
 
-		case model.ViewClusters, model.ViewNamespaces, model.ViewProjects, model.ViewApplicationSets:
+		case model.ViewClusters, model.ViewNamespaces, model.ViewProjects, model.ViewApplicationSets, model.ViewContexts:
 			// Custom-render single-column lists with full-row highlight
 			total := len(visibleItems)
 			visibleRows := max(0, tableHeight-1)

--- a/e2e/context_switch_test.go
+++ b/e2e/context_switch_test.go
@@ -1,0 +1,367 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// WriteArgoConfigMultiContext writes an ArgoCD CLI config with two named contexts
+// pointing to two different servers.
+func WriteArgoConfigMultiContext(path, serverAURL, serverBURL string) error {
+	var y bytes.Buffer
+	y.WriteString("contexts:\n")
+	y.WriteString("  - name: serverA\n    server: " + serverAURL + "\n    user: userA\n")
+	y.WriteString("  - name: serverB\n    server: " + serverBURL + "\n    user: userB\n")
+	y.WriteString("servers:\n")
+	y.WriteString("  - server: " + serverAURL + "\n    insecure: true\n")
+	y.WriteString("  - server: " + serverBURL + "\n    insecure: true\n")
+	y.WriteString("users:\n")
+	y.WriteString("  - name: userA\n    auth-token: token-a\n")
+	y.WriteString("  - name: userB\n    auth-token: token-b\n")
+	y.WriteString("current-context: serverA\n")
+	return os.WriteFile(path, y.Bytes(), 0o644)
+}
+
+// MockArgoServerContextA creates a mock server with apps ["alpha-app", "bravo-app"].
+// The SSE stream sends MODIFIED events for both apps in multiple rounds before returning.
+func MockArgoServerContextA() (*httptest.Server, *StreamRecorder, error) {
+	rec := &StreamRecorder{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/session/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	appsJSON := `[
+		{"metadata":{"name":"alpha-app","namespace":"argocd"},"spec":{"project":"projA","destination":{"name":"cluster-a","namespace":"ns-a"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}},
+		{"metadata":{"name":"bravo-app","namespace":"argocd"},"spec":{"project":"projA","destination":{"name":"cluster-a","namespace":"ns-a"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}}
+	]`
+
+	mux.HandleFunc("/api/v1/applications", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(wrapListResponse(appsJSON, "100")))
+	})
+
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"version":"e2e"}`))
+	})
+
+	mux.HandleFunc("/api/v1/applications/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/resource-tree") {
+			_, _ = w.Write([]byte(`{"nodes":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	type appInfo struct {
+		name    string
+		project string
+	}
+	apps := []appInfo{
+		{"alpha-app", "projA"},
+		{"bravo-app", "projA"},
+	}
+
+	mux.HandleFunc("/api/v1/stream/applications", func(w http.ResponseWriter, r *http.Request) {
+		rec.add(StreamRequest{
+			Projects:        r.URL.Query()["projects"],
+			ResourceVersion: r.URL.Query().Get("resourceVersion"),
+		})
+
+		fl, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		// Send multiple rounds of events to simulate a busy server.
+		// Per memory notes: send events and return, never block on r.Context().Done().
+		for round := 0; round < 6; round++ {
+			for _, app := range apps {
+				if shouldSendEvent(r, app.project) {
+					event := fmt.Sprintf(`{"result":{"type":"MODIFIED","application":{"metadata":{"name":"%s","namespace":"argocd"},"spec":{"project":"%s","destination":{"name":"cluster-a","namespace":"ns-a"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}}}}`, app.name, app.project)
+					_, _ = w.Write([]byte(sseEvent(event)))
+				}
+			}
+			if fl != nil {
+				fl.Flush()
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv, rec, nil
+}
+
+// MockArgoServerContextB creates a mock server with apps ["charlie-app", "delta-app"].
+func MockArgoServerContextB() (*httptest.Server, *StreamRecorder, error) {
+	rec := &StreamRecorder{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/session/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	appsJSON := `[
+		{"metadata":{"name":"charlie-app","namespace":"argocd"},"spec":{"project":"projB","destination":{"name":"cluster-b","namespace":"ns-b"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}},
+		{"metadata":{"name":"delta-app","namespace":"argocd"},"spec":{"project":"projB","destination":{"name":"cluster-b","namespace":"ns-b"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}}
+	]`
+
+	mux.HandleFunc("/api/v1/applications", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(wrapListResponse(appsJSON, "200")))
+	})
+
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"version":"e2e"}`))
+	})
+
+	mux.HandleFunc("/api/v1/applications/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/resource-tree") {
+			_, _ = w.Write([]byte(`{"nodes":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	type appInfo struct {
+		name    string
+		project string
+	}
+	apps := []appInfo{
+		{"charlie-app", "projB"},
+		{"delta-app", "projB"},
+	}
+
+	mux.HandleFunc("/api/v1/stream/applications", func(w http.ResponseWriter, r *http.Request) {
+		rec.add(StreamRequest{
+			Projects:        r.URL.Query()["projects"],
+			ResourceVersion: r.URL.Query().Get("resourceVersion"),
+		})
+
+		fl, _ := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		for _, app := range apps {
+			if shouldSendEvent(r, app.project) {
+				event := fmt.Sprintf(`{"result":{"type":"MODIFIED","application":{"metadata":{"name":"%s","namespace":"argocd"},"spec":{"project":"%s","destination":{"name":"cluster-b","namespace":"ns-b"}},"status":{"sync":{"status":"Synced"},"health":{"status":"Healthy"}}}}}`, app.name, app.project)
+				_, _ = w.Write([]byte(sseEvent(event)))
+			}
+		}
+		if fl != nil {
+			fl.Flush()
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv, rec, nil
+}
+
+// TestContextSwitchDiscardsOldSSEEvents verifies the core safety property:
+// after switching from Server A to Server B, SSE events from Server A's stream
+// are discarded and never leak into Server B's view.
+func TestContextSwitchDiscardsOldSSEEvents(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	// 1. Create two mock servers with StreamRecorders
+	srvA, recA, err := MockArgoServerContextA()
+	if err != nil {
+		t.Fatalf("mock server A: %v", err)
+	}
+	t.Cleanup(srvA.Close)
+
+	srvB, recB, err := MockArgoServerContextB()
+	if err != nil {
+		t.Fatalf("mock server B: %v", err)
+	}
+	t.Cleanup(srvB.Close)
+
+	// 2. Write multi-context ArgoCD config (current-context: serverA)
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigMultiContext(cfgPath, srvA.URL, srvB.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// 3. Start app with -argocd-config flag
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// 4. Wait for Server A to load (default view is clusters)
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Fatalf("Server A not loaded\n%s", tf.SnapshotPlain())
+	}
+
+	// 5. Navigate to apps view to see individual app names
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+
+	if !tf.WaitForScreen("alpha-app", 3*time.Second) {
+		t.Fatalf("alpha-app not visible\nScreen:\n%s", tf.Screen())
+	}
+	if !tf.WaitForScreen("bravo-app", 3*time.Second) {
+		t.Fatalf("bravo-app not visible\nScreen:\n%s", tf.Screen())
+	}
+
+	// 6. Verify SSE stream connected to Server A
+	if !waitUntil(t, func() bool { return recA.len() > 0 }, 3*time.Second) {
+		t.Fatal("expected at least one SSE stream request to Server A")
+	}
+
+	// 7. Switch context: open command, type "context serverB", press Enter
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("context serverB")
+	_ = tf.Enter()
+
+	// 8. Wait for Server B to load (default view is clusters, so wait for cluster-b)
+	if !tf.WaitForScreen("cluster-b", 8*time.Second) {
+		t.Fatalf("cluster-b not visible after context switch\nScreen:\n%s", tf.Screen())
+	}
+
+	// 9. Navigate to apps view on Server B (context switch resets to default clusters view)
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+
+	if !tf.WaitForScreen("charlie-app", 3*time.Second) {
+		t.Fatalf("charlie-app not visible in apps view\nScreen:\n%s", tf.Screen())
+	}
+
+	// 10. Verify Server A's apps are NOT on screen
+	screen := tf.Screen()
+	if strings.Contains(screen, "alpha-app") {
+		t.Fatalf("alpha-app should NOT be visible after switching to Server B\nScreen:\n%s", screen)
+	}
+	if strings.Contains(screen, "bravo-app") {
+		t.Fatalf("bravo-app should NOT be visible after switching to Server B\nScreen:\n%s", screen)
+	}
+
+	// 11. Let Server A's SSE keep emitting (it sends events every 500ms for 3s total)
+	time.Sleep(2 * time.Second)
+
+	// 12. Final assertion: screen still shows ONLY Server B's apps
+	screen = tf.Screen()
+	if strings.Contains(screen, "alpha-app") {
+		t.Fatalf("alpha-app leaked onto screen after waiting — old SSE events not discarded\nScreen:\n%s", screen)
+	}
+	if strings.Contains(screen, "bravo-app") {
+		t.Fatalf("bravo-app leaked onto screen after waiting — old SSE events not discarded\nScreen:\n%s", screen)
+	}
+	if !strings.Contains(screen, "charlie-app") {
+		t.Fatalf("charlie-app should still be visible\nScreen:\n%s", screen)
+	}
+	if !strings.Contains(screen, "delta-app") {
+		t.Fatalf("delta-app should still be visible\nScreen:\n%s", screen)
+	}
+
+	// 13. Verify SSE stream connected to Server B
+	if !waitUntil(t, func() bool { return recB.len() > 0 }, 3*time.Second) {
+		t.Fatal("expected at least one SSE stream request to Server B")
+	}
+}
+
+// TestViewContextsDismissesLoadingState verifies that when the user switches to
+// an unreachable context (which shows "Connecting to Argo CD...") and then opens
+// the :context picker view, the loading overlay is dismissed and the context list
+// is visible.
+func TestViewContextsDismissesLoadingState(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	// 1. Create server A (reachable)
+	srvA, _, err := MockArgoServerContextA()
+	if err != nil {
+		t.Fatalf("mock server A: %v", err)
+	}
+	t.Cleanup(srvA.Close)
+
+	// Server B is unreachable — port 1 will always refuse connections
+	unreachableURL := "http://127.0.0.1:1"
+
+	// 2. Write multi-context config (current-context: serverA)
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfigMultiContext(cfgPath, srvA.URL, unreachableURL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// 3. Start app with -argocd-config flag
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath}); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	// 4. Wait for Server A to load (default view is clusters)
+	if !tf.WaitForScreen("cluster-a", 5*time.Second) {
+		t.Fatalf("Server A not loaded\n%s", tf.Screen())
+	}
+
+	// 5. Switch to serverB (unreachable): open command, type "context serverB", Enter
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("context serverB")
+	_ = tf.Enter()
+
+	// 6. Wait for "Connecting to Argo CD" spinner to appear
+	if !tf.WaitForScreen("Connecting to Argo CD", 5*time.Second) {
+		t.Fatalf("expected 'Connecting to Argo CD' after switching to unreachable context\n%s", tf.Screen())
+	}
+
+	// 7. Brief pause, then open :context view (no arg = browse contexts)
+	time.Sleep(300 * time.Millisecond)
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatal(err)
+	}
+	_ = tf.Send("context")
+	_ = tf.Enter()
+
+	// 8. Wait for context names to appear in the list
+	if !tf.WaitForScreen("serverA", 3*time.Second) {
+		t.Fatalf("expected 'serverA' in contexts view\n%s", tf.Screen())
+	}
+
+	// 9. Assert the other context is also visible
+	screen := tf.Screen()
+	if !strings.Contains(screen, "serverB") {
+		t.Fatalf("expected 'serverB' in contexts view\nScreen:\n%s", screen)
+	}
+
+	// 10. Assert the loading/connecting overlay is gone
+	if strings.Contains(screen, "Connecting to Argo CD") {
+		t.Fatalf("'Connecting to Argo CD' should be dismissed when contexts view is active\nScreen:\n%s", screen)
+	}
+
+	// 11. Wait a moment and re-check — the loading state should not reappear
+	time.Sleep(1 * time.Second)
+	screen = tf.Screen()
+	if strings.Contains(screen, "Connecting to Argo CD") {
+		t.Fatalf("'Connecting to Argo CD' reappeared after waiting — loading state leaked into contexts view\nScreen:\n%s", screen)
+	}
+	if !strings.Contains(screen, "serverA") {
+		t.Fatalf("contexts view should still show serverA after waiting\nScreen:\n%s", screen)
+	}
+}

--- a/pkg/autocomplete/autocomplete.go
+++ b/pkg/autocomplete/autocomplete.go
@@ -163,6 +163,13 @@ func NewAutocompleteEngine() *AutocompleteEngine {
 			ArgType:     "",
 		},
 		{
+			Command:     "context",
+			Aliases:     []string{"context", "contexts", "argocd", "ctx"},
+			Description: "Switch or browse ArgoCD server contexts",
+			TakesArg:    true,
+			ArgType:     "argocd-context",
+		},
+		{
 			Command:     "refresh",
 			Aliases:     []string{"refresh", "ref"},
 			Description: "Refresh application (compare with git)",
@@ -327,6 +334,8 @@ func (e *AutocompleteEngine) getArgumentSuggestions(command, argPrefix string, s
 		suggestions = e.getThemeSuggestions(argPrefix)
 	case "sort":
 		suggestions = e.getSortSuggestions(argPrefix)
+	case "argocd-context":
+		suggestions = e.getArgocdContextSuggestions(argPrefix, state)
 	}
 
 	// Add command prefix to suggestions
@@ -485,6 +494,21 @@ func (e *AutocompleteEngine) getThemeSuggestions(prefix string) []string {
 	for _, themeName := range themeNames {
 		if strings.HasPrefix(strings.ToLower(themeName), strings.ToLower(prefix)) {
 			suggestions = append(suggestions, themeName)
+		}
+	}
+
+	sort.Strings(suggestions)
+	return suggestions
+}
+
+// getArgocdContextSuggestions returns ArgoCD context name suggestions
+func (e *AutocompleteEngine) getArgocdContextSuggestions(prefix string, state *model.AppState) []string {
+	var suggestions []string
+	prefix = strings.ToLower(prefix)
+
+	for _, name := range state.ContextNames {
+		if strings.HasPrefix(strings.ToLower(name), prefix) {
+			suggestions = append(suggestions, name)
 		}
 	}
 

--- a/pkg/config/cli_config.go
+++ b/pkg/config/cli_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/darksworm/argonaut/pkg/model"
 	"gopkg.in/yaml.v3"
@@ -199,6 +200,109 @@ func (c *ArgoCLIConfig) ToServerConfig() (*model.Server, error) {
 		Insecure:        serverConfig.Insecure,
 		GrpcWebRootPath: serverConfig.GrpcWebRootPath,
 	}, nil
+}
+
+// GetContextNames returns a sorted list of all context names
+func (c *ArgoCLIConfig) GetContextNames() []string {
+	names := make([]string, 0, len(c.Contexts))
+	for _, ctx := range c.Contexts {
+		names = append(names, ctx.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ToServerConfigForContext converts a named context to a Server model
+func (c *ArgoCLIConfig) ToServerConfigForContext(contextName string) (*model.Server, error) {
+	// Find context
+	var ctx *ArgoContext
+	for i := range c.Contexts {
+		if c.Contexts[i].Name == contextName {
+			ctx = &c.Contexts[i]
+			break
+		}
+	}
+	if ctx == nil {
+		return nil, fmt.Errorf("context %q not found in ArgoCD config", contextName)
+	}
+
+	if ctx.Server == "" {
+		return nil, fmt.Errorf("no server specified for context %q", contextName)
+	}
+
+	// Find server config
+	var serverConfig *ArgoServer
+	for i := range c.Servers {
+		if c.Servers[i].Server == ctx.Server {
+			serverConfig = &c.Servers[i]
+			break
+		}
+	}
+	if serverConfig == nil {
+		return nil, fmt.Errorf("server configuration not found for %s", ctx.Server)
+	}
+
+	// Find user token
+	if ctx.User == "" {
+		return nil, fmt.Errorf("no user specified for context %q", contextName)
+	}
+	var token string
+	for _, user := range c.Users {
+		if user.Name == ctx.User {
+			token = user.AuthToken
+			break
+		}
+	}
+	if token == "" {
+		return nil, fmt.Errorf("no auth token found for user %s in context %q", ctx.User, contextName)
+	}
+
+	baseURL := ensureHTTPS(serverConfig.Server, serverConfig.PlainText)
+
+	return &model.Server{
+		BaseURL:         baseURL,
+		Token:           token,
+		Insecure:        serverConfig.Insecure,
+		GrpcWebRootPath: serverConfig.GrpcWebRootPath,
+	}, nil
+}
+
+// IsContextPortForward returns true if the named context uses port-forward mode
+func (c *ArgoCLIConfig) IsContextPortForward(contextName string) (bool, error) {
+	for _, ctx := range c.Contexts {
+		if ctx.Name == contextName {
+			return ctx.Server == "port-forward", nil
+		}
+	}
+	return false, fmt.Errorf("context %q not found in ArgoCD config", contextName)
+}
+
+// IsContextCore returns true if the named context's server is running in core mode
+func (c *ArgoCLIConfig) IsContextCore(contextName string) (bool, error) {
+	// Find context
+	var serverURL string
+	found := false
+	for _, ctx := range c.Contexts {
+		if ctx.Name == contextName {
+			serverURL = ctx.Server
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false, fmt.Errorf("context %q not found in ArgoCD config", contextName)
+	}
+	if serverURL == "" {
+		return false, nil
+	}
+
+	// Find server config
+	for _, server := range c.Servers {
+		if server.Server == serverURL {
+			return server.Core, nil
+		}
+	}
+	return false, fmt.Errorf("server configuration not found for %s", serverURL)
 }
 
 // ensureHTTPS ensures the URL has the correct protocol

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -180,7 +180,8 @@ type AppState struct {
 	Server     *Server         `json:"server,omitempty"`
 	Apps       []App           `json:"apps"`
 	Index      *AppIndex       `json:"-"` // Pre-computed index, rebuilt on mutation
-	APIVersion string          `json:"apiVersion"`
+	APIVersion   string          `json:"apiVersion"`
+	ContextNames []string        `json:"contextNames,omitempty"`
 	// Note: AbortController equivalent will use context.Context in Go services
 	Diff     *DiffState     `json:"diff,omitempty"`
 	Rollback *RollbackState `json:"rollback,omitempty"`

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -14,6 +14,7 @@ const (
 	ViewApps            View = "apps"
 	ViewTree            View = "tree"
 	ViewApplicationSets View = "applicationsets"
+	ViewContexts        View = "contexts"
 )
 
 // Mode represents the current application mode


### PR DESCRIPTION
## Summary

Closes #214

- Add runtime context switching via `:context <name>` — re-reads ArgoCD config from disk, tears down old SSE streams/watchers, creates a fresh model with SwitchEpoch gating to discard stale async messages
- Add browsable context picker via `:context` (no arg) or `:ctx` — new `ViewContexts` list view with search/filter, Enter to switch, Escape to go back
- Fix loading overlay rendering on top of the context picker when switching to unreachable servers

## Test plan

- [x] Unit tests for context switch logic (8 tests in `cmd/app/context_switch_test.go`)
- [x] Unit tests for config APIs (`pkg/config/cli_config_test.go`)
- [x] E2E test: SSE events from old context discarded after switch (`TestContextSwitchDiscardsOldSSEEvents`)
- [x] E2E test: loading overlay dismissed when opening context picker (`TestViewContextsDismissesLoadingState`)
- [x] `go test ./cmd/app/ ./pkg/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context switching UI and "context" command (with aliases) plus autocomplete; header shows active context and CLI config path is respected.

* **Bug Fixes**
  * Robust context switch flow with clean teardown/reload; epoch-based gating prevents stale cross-context events and refines loading/overlay behavior when browsing contexts.

* **Tests**
  * New unit and end-to-end tests covering context switching, stale-event dismissal, and UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->