### PR TITLE
fix(header): show ns and project when navigating from app view

### DIFF
--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -819,8 +819,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 					m.treeNav.Reset() // Reset scroll position
 					m.state.SaveNavigationState()
 					m.state.Navigation.View = model.ViewTree
-					m.state.UI.TreeAppName = nil
-					m.state.UI.TreeAppNamespace = nil
+					m.clearTreeApp()
 					m.treeLoading = true
 					var cmds []tea.Cmd
 					for _, n := range names {
@@ -882,8 +881,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			// Clean up any existing tree watchers before starting new one
 			m.cleanupTreeWatchers()
 			m.state.Navigation.View = model.ViewTree
-			m.state.UI.TreeAppName = &target
-			m.state.UI.TreeAppNamespace = selectedApp.AppNamespace
+			m.setTreeApp(*selectedApp)
 			m.treeLoading = true
 			return m, tea.Batch(m.startLoadingResourceTree(*selectedApp), m.startWatchingResourceTree(*selectedApp), m.consumeTreeEvent())
 		case "all":
@@ -933,8 +931,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			return m, m.startDiffSession(target, targetNamespace)
 		case "cluster", "clusters", "cls":
 			// Exit deep views and clear lower-level scopes
-			m.state.UI.TreeAppName = nil
-			m.state.UI.TreeAppNamespace = nil
+			m.clearTreeApp()
 			m.treeLoading = false
 			m.state.Selections.SelectedApps = model.NewStringSet()
 			m.state.Navigation.SelectedIdx = 0 // Reset navigation for view change
@@ -968,8 +965,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			}
 			return m, nil
 		case "namespace", "namespaces", "ns":
-			m.state.UI.TreeAppName = nil
-			m.state.UI.TreeAppNamespace = nil
+			m.clearTreeApp()
 			m.treeLoading = false
 			m.state.Navigation.SelectedIdx = 0 // Reset navigation for view change
 			m = m.safeChangeView(model.ViewNamespaces)
@@ -1000,8 +996,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			}
 			return m, nil
 		case "project", "projects", "proj":
-			m.state.UI.TreeAppName = nil
-			m.state.UI.TreeAppNamespace = nil
+			m.clearTreeApp()
 			m.treeLoading = false
 			m.state.Navigation.SelectedIdx = 0 // Reset navigation for view change
 			m = m.safeChangeView(model.ViewProjects)
@@ -1050,8 +1045,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			}
 			return m, nil
 		case "appset", "appsets", "applicationset", "applicationsets", "as":
-			m.state.UI.TreeAppName = nil
-			m.state.UI.TreeAppNamespace = nil
+			m.clearTreeApp()
 			m.treeLoading = false
 			m.state.Navigation.SelectedIdx = 0
 			m.state.Selections.SelectedApps = model.NewStringSet()
@@ -1101,7 +1095,7 @@ func (m *Model) handleEnhancedCommandModeKeys(msg tea.KeyMsg) (tea.Model, tea.Cm
 			m.state.Modals.ChangelogLoading = true
 			return m, m.fetchChangelog()
 		case "context", "contexts", "argocd", "ctx":
-			m.state.UI.TreeAppName = nil
+			m.clearTreeApp()
 			m.treeLoading = false
 			m.state.Navigation.SelectedIdx = 0
 			if arg != "" {

--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -408,12 +408,12 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 			// If we drilled into this tree from a parent tree (app-of-apps), pop the stack and go back.
 			if n := len(m.state.SavedNavigation); n > 0 {
 				top := m.state.SavedNavigation[n-1]
-				if top.View == model.ViewTree && top.TreeAppName != nil {
+				if top.View == model.ViewTree && top.TreeApp != nil {
 					m.state.SavedNavigation = m.state.SavedNavigation[:n-1]
-					parentAppName := *top.TreeAppName
+					parentAppName := top.TreeApp.Name
 					parentAppNamespace := ""
-					if top.TreeAppNamespace != nil {
-						parentAppNamespace = *top.TreeAppNamespace
+					if top.TreeApp.AppNamespace != nil {
+						parentAppNamespace = *top.TreeApp.AppNamespace
 					}
 					parentApp := m.findAppByNameAndNamespace(parentAppName, parentAppNamespace)
 					if parentApp != nil {
@@ -423,8 +423,7 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 						m.treeView.SetSize(m.contentInnerWidth(), m.state.Terminal.Rows)
 						m.treeNav.Reset()
 						m.state.Navigation.View = model.ViewTree
-						m.state.UI.TreeAppName = &parentApp.Name
-						m.state.UI.TreeAppNamespace = parentApp.AppNamespace
+						m.setTreeApp(*parentApp)
 						m.treeLoading = true
 						return m, tea.Batch(m.startLoadingResourceTree(*parentApp), m.startWatchingResourceTree(*parentApp), m.consumeTreeEvent())
 					}
@@ -432,8 +431,7 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 			}
 			// Return to apps view from tree/resources view
 			m = m.safeChangeView(model.ViewApps)
-			m.state.UI.TreeAppName = nil
-			m.state.UI.TreeAppNamespace = nil
+			m.clearTreeApp()
 			m.state.Navigation.SelectedIdx = 0
 		case model.ViewApps:
 			// Check if scoped by ApplicationSet (separate hierarchy)
@@ -1060,7 +1058,9 @@ func (m *Model) handleResourceSync() (tea.Model, tea.Cmd) {
 		appName := m.treeView.GetAppName()
 		if appName != "" {
 			m.state.Modals.ConfirmTarget = &appName
-			m.state.Modals.ConfirmTargetNamespace = m.state.UI.TreeAppNamespace
+			if m.state.UI.TreeApp != nil {
+				m.state.Modals.ConfirmTargetNamespace = m.state.UI.TreeApp.AppNamespace
+			}
 			m.state.Modals.ConfirmSyncSelected = 0 // default to Yes
 			m.state.Mode = model.ModeConfirmSync
 			return m, nil
@@ -1644,9 +1644,8 @@ func (m *Model) handleOpenResourcesForSelection() (tea.Model, tea.Cmd) {
 		m.treeNav.Reset() // Reset scroll position
 		m.state.SaveNavigationState()
 		m.state.Navigation.View = model.ViewTree
-		// Clear single-app tracker
-		m.state.UI.TreeAppName = nil
-		m.state.UI.TreeAppNamespace = nil
+		// Clear single-app tracker (multi-app tree has no single owner)
+		m.clearTreeApp()
 		m.treeLoading = true
 		var cmds []tea.Cmd
 		for _, name := range selected {
@@ -1688,8 +1687,7 @@ func (m *Model) handleOpenResourcesForSelection() (tea.Model, tea.Cmd) {
 	m.treeNav.Reset() // Reset scroll position
 	m.state.SaveNavigationState()
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = &app.Name
-	m.state.UI.TreeAppNamespace = app.AppNamespace
+	m.setTreeApp(app)
 	m.treeLoading = true
 	return m, tea.Batch(m.startLoadingResourceTree(app), m.startWatchingResourceTree(app), m.consumeTreeEvent())
 }
@@ -1713,8 +1711,7 @@ func (m *Model) handleNavigateToChildApp(appName string, appNamespace string) (t
 	m.treeView.SetSize(m.contentInnerWidth(), m.state.Terminal.Rows)
 	m.treeNav.Reset()
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = &app.Name
-	m.state.UI.TreeAppNamespace = app.AppNamespace
+	m.setTreeApp(*app)
 	m.treeLoading = true
 	return m, tea.Batch(m.startLoadingResourceTree(*app), m.startWatchingResourceTree(*app), m.consumeTreeEvent())
 }
@@ -1740,7 +1737,10 @@ func (m *Model) findAppByNameAndNamespace(name string, namespace string) *model.
 }
 
 func (m *Model) currentTreeAppNamespace() *string {
-	return m.state.UI.TreeAppNamespace
+	if m.state.UI.TreeApp == nil {
+		return nil
+	}
+	return m.state.UI.TreeApp.AppNamespace
 }
 
 // handleResourceDiff shows the diff for the currently selected resource in tree view
@@ -1762,7 +1762,7 @@ func (m *Model) handleResourceDiff() (*Model, tea.Cmd) {
 				m.state.Diff = &model.DiffState{}
 			}
 			m.state.Diff.Loading = true
-			return m, m.startDiffSession(name, m.state.UI.TreeAppNamespace)
+			return m, m.startDiffSession(name, m.currentTreeAppNamespace())
 		}
 		// Child Application CR (app-of-apps): show diff of the Application CR itself
 		// as a resource within the parent app
@@ -1778,7 +1778,7 @@ func (m *Model) handleResourceDiff() (*Model, tea.Cmd) {
 		m.state.Diff.Loading = true
 		return m, m.startResourceDiffSession(ResourceIdentifier{
 			AppName:      parentApp,
-			AppNamespace: m.state.UI.TreeAppNamespace,
+			AppNamespace: m.currentTreeAppNamespace(),
 			Group:        group,
 			Kind:         kind,
 			Namespace:    namespace,
@@ -1788,8 +1788,8 @@ func (m *Model) handleResourceDiff() (*Model, tea.Cmd) {
 
 	// Get the app name for resource-level diff
 	appName := ""
-	if m.state.UI.TreeAppName != nil {
-		appName = *m.state.UI.TreeAppName
+	if m.state.UI.TreeApp != nil {
+		appName = m.state.UI.TreeApp.Name
 	} else if m.treeView != nil {
 		appName = m.treeView.GetAppName()
 	}
@@ -1803,9 +1803,13 @@ func (m *Model) handleResourceDiff() (*Model, tea.Cmd) {
 	}
 	m.state.Diff.Loading = true
 
+	var treeAppNS *string
+	if m.state.UI.TreeApp != nil {
+		treeAppNS = m.state.UI.TreeApp.AppNamespace
+	}
 	return m, m.startResourceDiffSession(ResourceIdentifier{
 		AppName:      appName,
-		AppNamespace: m.state.UI.TreeAppNamespace,
+		AppNamespace: treeAppNS,
 		Group:        group,
 		Kind:         kind,
 		Namespace:    namespace,
@@ -1837,9 +1841,9 @@ func (m *Model) handleOpenK9s() (tea.Model, tea.Cmd) {
 	// Try to find the context from the current app's cluster info
 	var context string
 	var contextFound bool
-	if m.state.UI.TreeAppName != nil {
+	if m.state.UI.TreeApp != nil {
 		for i := range m.state.Apps {
-			if m.state.Apps[i].Name == *m.state.UI.TreeAppName {
+			if m.state.Apps[i].Name == m.state.UI.TreeApp.Name {
 				app := m.state.Apps[i]
 				if app.ClusterID != nil {
 					clusterID := *app.ClusterID

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -835,8 +835,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					appObj = *found
 				}
 				m.state.Navigation.View = model.ViewTree
-				m.state.UI.TreeAppName = &msg.AppName
-				m.state.UI.TreeAppNamespace = appObj.AppNamespace
+				m.setTreeApp(appObj)
 				return m, tea.Batch(m.startLoadingResourceTree(appObj), m.startWatchingResourceTree(appObj), m.consumeTreeEvent())
 			}
 		} else {
@@ -1036,8 +1035,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.state.SaveNavigationState()
 					m.state.Navigation.View = model.ViewTree
 					// Clear single-app tracker
-					m.state.UI.TreeAppName = nil
-					m.state.UI.TreeAppNamespace = nil
+					m.clearTreeApp()
 					m.treeLoading = true
 					for _, n := range names {
 						var appObj *model.App
@@ -1235,8 +1233,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					appObj = *found
 				}
 				m.state.Navigation.View = model.ViewTree
-				m.state.UI.TreeAppName = &msg.AppName
-				m.state.UI.TreeAppNamespace = appObj.AppNamespace
+				m.setTreeApp(appObj)
 				return m, tea.Batch(m.startLoadingResourceTree(appObj), m.startWatchingResourceTree(appObj), m.consumeTreeEvent())
 			}
 		} else {
@@ -1443,6 +1440,24 @@ func (m *Model) applyBatchAppUpdate(upd model.AppUpdatedMsg) {
 			m.treeView.SetResourceStatuses(upd.App.Name, resources)
 		}
 	}
+}
+
+// setTreeApp atomically stores all relevant info about the app being shown in
+// the tree view. Always use this instead of assigning UI.TreeApp fields directly,
+// so that adding new fields only requires updating this one function.
+func (m *Model) setTreeApp(app model.App) {
+	m.state.UI.TreeApp = &model.TreeAppInfo{
+		Name:          app.Name,
+		AppNamespace:  app.AppNamespace,
+		DestNamespace: app.Namespace,
+		Project:       app.Project,
+	}
+}
+
+// clearTreeApp clears all tree-app state. Always use this instead of nil-ing
+// individual fields.
+func (m *Model) clearTreeApp() {
+	m.state.UI.TreeApp = nil
 }
 
 func (m *Model) applyBatchAppDelete(name string) bool {

--- a/cmd/app/sync_tree_reset_test.go
+++ b/cmd/app/sync_tree_reset_test.go
@@ -56,9 +56,9 @@ func TestSyncCompletedMsg_ResetsTreeView(t *testing.T) {
 		t.Errorf("Expected view to be ViewTree, got %s", m.state.Navigation.View)
 	}
 
-	// Verify TreeAppName is set to app B
-	if m.state.UI.TreeAppName == nil || *m.state.UI.TreeAppName != "app-b" {
-		t.Errorf("Expected TreeAppName to be 'app-b', got %v", m.state.UI.TreeAppName)
+	// Verify TreeApp is set to app B
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.Name != "app-b" {
+		t.Errorf("Expected TreeApp.Name to be 'app-b', got %v", m.state.UI.TreeApp)
 	}
 }
 
@@ -190,9 +190,9 @@ func TestRollbackExecutedMsg_ResetsTreeView(t *testing.T) {
 		t.Errorf("Expected view to be ViewTree, got %s", m.state.Navigation.View)
 	}
 
-	// Verify TreeAppName is set to app B
-	if m.state.UI.TreeAppName == nil || *m.state.UI.TreeAppName != "app-b" {
-		t.Errorf("Expected TreeAppName to be 'app-b', got %v", m.state.UI.TreeAppName)
+	// Verify TreeApp is set to app B
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.Name != "app-b" {
+		t.Errorf("Expected TreeApp.Name to be 'app-b', got %v", m.state.UI.TreeApp)
 	}
 }
 
@@ -217,8 +217,8 @@ func TestSyncCompletedMsg_WithNamespace_OpensCorrectApp(t *testing.T) {
 	if m.state.Navigation.View != model.ViewTree {
 		t.Fatalf("expected ViewTree, got %s", m.state.Navigation.View)
 	}
-	if m.state.UI.TreeAppNamespace == nil || *m.state.UI.TreeAppNamespace != nsTeamA {
-		t.Errorf("expected TreeAppNamespace %q, got %v", nsTeamA, m.state.UI.TreeAppNamespace)
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.AppNamespace == nil || *m.state.UI.TreeApp.AppNamespace != nsTeamA {
+		t.Errorf("expected TreeApp.AppNamespace %q, got %v", nsTeamA, m.state.UI.TreeApp)
 	}
 }
 
@@ -241,8 +241,8 @@ func TestRollbackExecutedMsg_WithNamespace_OpensCorrectApp(t *testing.T) {
 	if m.state.Navigation.View != model.ViewTree {
 		t.Fatalf("expected ViewTree, got %s", m.state.Navigation.View)
 	}
-	if m.state.UI.TreeAppNamespace == nil || *m.state.UI.TreeAppNamespace != nsTeamA {
-		t.Errorf("expected TreeAppNamespace %q, got %v", nsTeamA, m.state.UI.TreeAppNamespace)
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.AppNamespace == nil || *m.state.UI.TreeApp.AppNamespace != nsTeamA {
+		t.Errorf("expected TreeApp.AppNamespace %q, got %v", nsTeamA, m.state.UI.TreeApp)
 	}
 }
 

--- a/cmd/app/tree_navigation_namespace_test.go
+++ b/cmd/app/tree_navigation_namespace_test.go
@@ -21,19 +21,18 @@ func TestHandleNavigateToChildApp_UsesNamespaceDisambiguation(t *testing.T) {
 		{Name: "child", AppNamespace: &childNSB},
 	}
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = &m.state.Apps[0].Name
-	m.state.UI.TreeAppNamespace = m.state.Apps[0].AppNamespace
+	m.setTreeApp(m.state.Apps[0])
 	m.treeView = treeview.NewTreeView(0, 0)
 
 	_, _ = m.handleNavigateToChildApp("child", childNSB)
 
-	if m.state.UI.TreeAppName == nil || *m.state.UI.TreeAppName != "child" {
-		t.Fatalf("expected child app to be opened, got %v", m.state.UI.TreeAppName)
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.Name != "child" {
+		t.Fatalf("expected child app to be opened, got %v", m.state.UI.TreeApp)
 	}
-	if m.state.UI.TreeAppNamespace == nil || *m.state.UI.TreeAppNamespace != childNSB {
-		t.Fatalf("expected child namespace %q, got %v", childNSB, m.state.UI.TreeAppNamespace)
+	if m.state.UI.TreeApp.AppNamespace == nil || *m.state.UI.TreeApp.AppNamespace != childNSB {
+		t.Fatalf("expected child namespace %q, got %v", childNSB, m.state.UI.TreeApp.AppNamespace)
 	}
-	if len(m.state.SavedNavigation) == 0 || m.state.SavedNavigation[0].TreeAppNamespace == nil || *m.state.SavedNavigation[0].TreeAppNamespace != parentNS {
+	if len(m.state.SavedNavigation) == 0 || m.state.SavedNavigation[0].TreeApp == nil || m.state.SavedNavigation[0].TreeApp.AppNamespace == nil || *m.state.SavedNavigation[0].TreeApp.AppNamespace != parentNS {
 		t.Fatalf("expected saved parent namespace %q, got %#v", parentNS, m.state.SavedNavigation)
 	}
 }
@@ -55,8 +54,7 @@ func TestHandleNavigateToChildApp_ThreeLevels_SupportsDeepNesting(t *testing.T) 
 
 	// Start in app-a's tree
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = &m.state.Apps[0].Name
-	m.state.UI.TreeAppNamespace = m.state.Apps[0].AppNamespace
+	m.setTreeApp(m.state.Apps[0])
 	m.treeView = treeview.NewTreeView(0, 0)
 
 	// Navigate from app-a to app-b
@@ -74,11 +72,11 @@ func TestHandleNavigateToChildApp_ThreeLevels_SupportsDeepNesting(t *testing.T) 
 	if m.state.Navigation.View != model.ViewTree {
 		t.Fatalf("first escape: expected ViewTree, got %s", m.state.Navigation.View)
 	}
-	if m.state.UI.TreeAppName == nil || *m.state.UI.TreeAppName != "app-b" {
-		t.Fatalf("first escape: expected app-b's tree, got %v", m.state.UI.TreeAppName)
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.Name != "app-b" {
+		t.Fatalf("first escape: expected app-b's tree, got %v", m.state.UI.TreeApp)
 	}
-	if m.state.UI.TreeAppNamespace == nil || *m.state.UI.TreeAppNamespace != nsB {
-		t.Fatalf("first escape: expected namespace %q, got %v", nsB, m.state.UI.TreeAppNamespace)
+	if m.state.UI.TreeApp.AppNamespace == nil || *m.state.UI.TreeApp.AppNamespace != nsB {
+		t.Fatalf("first escape: expected namespace %q, got %v", nsB, m.state.UI.TreeApp.AppNamespace)
 	}
 
 	// Second Escape: B → A
@@ -88,11 +86,11 @@ func TestHandleNavigateToChildApp_ThreeLevels_SupportsDeepNesting(t *testing.T) 
 	if m.state.Navigation.View != model.ViewTree {
 		t.Fatalf("second escape: expected ViewTree (back to app-a), got %s", m.state.Navigation.View)
 	}
-	if m.state.UI.TreeAppName == nil || *m.state.UI.TreeAppName != "app-a" {
-		t.Fatalf("second escape: expected app-a's tree, got %v", m.state.UI.TreeAppName)
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.Name != "app-a" {
+		t.Fatalf("second escape: expected app-a's tree, got %v", m.state.UI.TreeApp)
 	}
-	if m.state.UI.TreeAppNamespace == nil || *m.state.UI.TreeAppNamespace != nsA {
-		t.Fatalf("second escape: expected namespace %q, got %v", nsA, m.state.UI.TreeAppNamespace)
+	if m.state.UI.TreeApp.AppNamespace == nil || *m.state.UI.TreeApp.AppNamespace != nsA {
+		t.Fatalf("second escape: expected namespace %q, got %v", nsA, m.state.UI.TreeApp.AppNamespace)
 	}
 
 	// Third Escape: A → apps list
@@ -120,12 +118,10 @@ func TestHandleEscape_ReturnsToParentTreeUsingNamespace(t *testing.T) {
 		{Name: childName, AppNamespace: &childNS},
 	}
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = &childName
-	m.state.UI.TreeAppNamespace = &childNS
+	m.setTreeApp(model.App{Name: childName, AppNamespace: &childNS})
 	m.state.SavedNavigation = []model.NavigationState{{
-		View:             model.ViewTree,
-		TreeAppName:      &parentName,
-		TreeAppNamespace: &parentNSB,
+		View:    model.ViewTree,
+		TreeApp: &model.TreeAppInfo{Name: parentName, AppNamespace: &parentNSB},
 	}}
 	m.treeView = treeview.NewTreeView(0, 0)
 	m.treeView.SetAppMeta(childName, "Healthy", "Synced")
@@ -138,11 +134,11 @@ func TestHandleEscape_ReturnsToParentTreeUsingNamespace(t *testing.T) {
 	if m.state.Navigation.View != model.ViewTree {
 		t.Fatalf("expected to remain in tree view, got %s", m.state.Navigation.View)
 	}
-	if m.state.UI.TreeAppName == nil || *m.state.UI.TreeAppName != parentName {
-		t.Fatalf("expected parent app name %q, got %v", parentName, m.state.UI.TreeAppName)
+	if m.state.UI.TreeApp == nil || m.state.UI.TreeApp.Name != parentName {
+		t.Fatalf("expected parent app name %q, got %v", parentName, m.state.UI.TreeApp)
 	}
-	if m.state.UI.TreeAppNamespace == nil || *m.state.UI.TreeAppNamespace != parentNSB {
-		t.Fatalf("expected parent namespace %q, got %v", parentNSB, m.state.UI.TreeAppNamespace)
+	if m.state.UI.TreeApp.AppNamespace == nil || *m.state.UI.TreeApp.AppNamespace != parentNSB {
+		t.Fatalf("expected parent namespace %q, got %v", parentNSB, m.state.UI.TreeApp.AppNamespace)
 	}
 	if len(m.state.SavedNavigation) != 0 {
 		t.Fatalf("expected saved navigation to be cleared after restore, got %#v", m.state.SavedNavigation)

--- a/cmd/app/view_banner.go
+++ b/cmd/app/view_banner.go
@@ -234,36 +234,19 @@ func scopeToText(set map[string]bool) string {
 }
 
 func (m *Model) effectiveNamespaceProjectScope() (string, string) {
-	namespaceScope := scopeToText(m.state.Selections.ScopeNamespaces)
-	projectScope := scopeToText(m.state.Selections.ScopeProjects)
+	ns := scopeToText(m.state.Selections.ScopeNamespaces)
+	pr := scopeToText(m.state.Selections.ScopeProjects)
 
-	if m.state.Navigation.View != model.ViewTree || m.state.UI.TreeAppName == nil {
-		return namespaceScope, projectScope
-	}
-
-	if namespaceScope != "—" && projectScope != "—" {
-		return namespaceScope, projectScope
-	}
-
-	appName := strings.TrimSpace(*m.state.UI.TreeAppName)
-	if appName == "" {
-		return namespaceScope, projectScope
-	}
-
-	for i := range m.state.Apps {
-		if m.state.Apps[i].Name != appName {
-			continue
+	if m.state.Navigation.View == model.ViewTree && m.state.UI.TreeApp != nil {
+		if ns == "—" && m.state.UI.TreeApp.DestNamespace != nil && strings.TrimSpace(*m.state.UI.TreeApp.DestNamespace) != "" {
+			ns = *m.state.UI.TreeApp.DestNamespace
 		}
-		if namespaceScope == "—" && m.state.Apps[i].Namespace != nil && strings.TrimSpace(*m.state.Apps[i].Namespace) != "" {
-			namespaceScope = *m.state.Apps[i].Namespace
+		if pr == "—" && m.state.UI.TreeApp.Project != nil && strings.TrimSpace(*m.state.UI.TreeApp.Project) != "" {
+			pr = *m.state.UI.TreeApp.Project
 		}
-		if projectScope == "—" && m.state.Apps[i].Project != nil && strings.TrimSpace(*m.state.Apps[i].Project) != "" {
-			projectScope = *m.state.Apps[i].Project
-		}
-		break
 	}
 
-	return namespaceScope, projectScope
+	return ns, pr
 }
 
 func hostFromURL(s string) string {

--- a/cmd/app/view_banner_test.go
+++ b/cmd/app/view_banner_test.go
@@ -16,19 +16,18 @@ func TestRenderContextBlock_UsesTreeAppNamespaceProjectWhenScopeEmpty(t *testing
 	m.ready = true
 	m.state.Server = &model.Server{BaseURL: "https://argo.example.com"}
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = strp("app-a")
-	m.state.Apps = []model.App{{
-		Name:      "app-a",
-		Namespace: strp("payments"),
-		Project:   strp("billing"),
-	}}
+	m.state.UI.TreeApp = &model.TreeAppInfo{
+		Name:          "app-a",
+		DestNamespace: strp("payments"),
+		Project:       strp("billing"),
+	}
 
 	out := stripANSI(m.renderContextBlock(false))
 	if !strings.Contains(out, "Namespace: payments") {
-		t.Fatalf("expected Namespace fallback from selected app, got:\n%s", out)
+		t.Fatalf("expected Namespace from tree app info, got:\n%s", out)
 	}
 	if !strings.Contains(out, "Project: billing") {
-		t.Fatalf("expected Project fallback from selected app, got:\n%s", out)
+		t.Fatalf("expected Project from tree app info, got:\n%s", out)
 	}
 }
 
@@ -37,14 +36,13 @@ func TestRenderContextBlock_ScopeOverridesTreeAppFallback(t *testing.T) {
 	m.ready = true
 	m.state.Server = &model.Server{BaseURL: "https://argo.example.com"}
 	m.state.Navigation.View = model.ViewTree
-	m.state.UI.TreeAppName = strp("app-a")
+	m.state.UI.TreeApp = &model.TreeAppInfo{
+		Name:          "app-a",
+		DestNamespace: strp("payments"),
+		Project:       strp("billing"),
+	}
 	m.state.Selections.ScopeNamespaces = model.StringSetFromSlice([]string{"scoped-ns"})
 	m.state.Selections.ScopeProjects = model.StringSetFromSlice([]string{"scoped-proj"})
-	m.state.Apps = []model.App{{
-		Name:      "app-a",
-		Namespace: strp("payments"),
-		Project:   strp("billing"),
-	}}
 
 	out := stripANSI(m.renderContextBlock(false))
 	if !strings.Contains(out, "Namespace: scoped-ns") {

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -6,15 +6,24 @@ import (
 	apperrors "github.com/darksworm/argonaut/pkg/errors"
 )
 
+// TreeAppInfo holds all relevant info about the app currently shown in the tree view.
+// It is set atomically via Model.setTreeApp when entering the tree, so callers
+// never have to remember to update individual fields.
+type TreeAppInfo struct {
+	Name          string  `json:"name"`
+	AppNamespace  *string `json:"appNamespace,omitempty"`  // ArgoCD Application CR namespace
+	DestNamespace *string `json:"destNamespace,omitempty"` // deployment target namespace
+	Project       *string `json:"project,omitempty"`
+}
+
 // NavigationState holds navigation-related state
 type NavigationState struct {
-	View             View    `json:"view"`
-	SelectedIdx      int     `json:"selectedIdx"`
-	LastGPressed     int64   `json:"lastGPressed"`
-	LastEscPressed   int64   `json:"lastEscPressed"`
-	LastZPressed     int64   `json:"lastZPressed"`
-	TreeAppName      *string `json:"treeAppName,omitempty"`
-	TreeAppNamespace *string `json:"treeAppNamespace,omitempty"`
+	View           View         `json:"view"`
+	SelectedIdx    int          `json:"selectedIdx"`
+	LastGPressed   int64        `json:"lastGPressed"`
+	LastEscPressed int64        `json:"lastEscPressed"`
+	LastZPressed   int64        `json:"lastZPressed"`
+	TreeApp        *TreeAppInfo `json:"treeApp,omitempty"`
 }
 
 // SelectionState holds selection-related state using map[string]bool for sets
@@ -107,8 +116,7 @@ type UIState struct {
 	LatestVersion      *string         `json:"latestVersion,omitempty"`
 	UpdateInfo         *UpdateInfo     `json:"updateInfo,omitempty"`
 	CommandInputKey    int             `json:"commandInputKey"`
-	TreeAppName        *string         `json:"treeAppName,omitempty"`
-	TreeAppNamespace   *string         `json:"treeAppNamespace,omitempty"`
+	TreeApp            *TreeAppInfo    `json:"treeApp,omitempty"`
 	ThemeSelectedIndex int             `json:"themeSelectedIndex"`
 	ThemeScrollOffset  int             `json:"themeScrollOffset"`
 	ThemeOriginalName  string          `json:"themeOriginalName,omitempty"`
@@ -235,8 +243,7 @@ func (s *AppState) SaveNavigationState() {
 		LastGPressed:     s.Navigation.LastGPressed,
 		LastEscPressed:   s.Navigation.LastEscPressed,
 		LastZPressed:     s.Navigation.LastZPressed,
-		TreeAppName:      s.UI.TreeAppName,
-		TreeAppNamespace: s.UI.TreeAppNamespace,
+		TreeApp: s.UI.TreeApp,
 	})
 	s.SavedSelections = &SelectionState{
 		ScopeClusters:        copyStringSet(s.Selections.ScopeClusters),


### PR DESCRIPTION
When navigating to an app from apps view, the namespace and project from the app are not shown, this PR determines the ns and project to show it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context block and compact banner now display namespace and project more intelligently, falling back to the selected app’s destination/project when explicit scopes are empty and ensuring consistent display during tree navigation.

* **Tests**
  * Added unit tests verifying context block fallback behavior and that explicit scopes override the app-based fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->