### PR TITLE
docs(adr): add ADR-0003 async message gating, ADR-0004 app identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,5 @@
 # Architecture
 
-Before modifying API call sites, timeout handling, or the HTTP client layer, read the relevant ADRs in `docs/architecture/decisions/`:
+Before changing API call sites, async message handlers, the HTTP client layer, or anything that resolves Argo CD applications, skim the relevant ADR.
 
-- **ADR-0002**: API timeout strategy — timeouts must be set at call sites using `appcontext.WithAPITimeout()` or `WithMinAPITimeout()`, never hardcoded with `context.WithTimeout()` and never inside `Client.Get/Post/Put/Delete`. See the ADR for the full rationale.
-
+See [`docs/architecture/decisions/`](./docs/architecture/decisions/README.md) for the full index.

--- a/docs/architecture/decisions/0003-async-message-gating.md
+++ b/docs/architecture/decisions/0003-async-message-gating.md
@@ -1,0 +1,77 @@
+# ADR-0003: Async Message Gating (Epoch + Target)
+
+## Status
+
+Accepted
+
+## Context
+
+Argonaut is a Bubble Tea TUI: most API calls are dispatched as `tea.Cmd`s that run asynchronously and return a `tea.Msg` to the `Update` loop. Two events break the naive "the message I get back belongs to the operation I just started" assumption:
+
+1. **Context switch.** When the user switches ArgoCD contexts (`switchEpoch++`), in-flight commands keyed to the old server can still complete and deliver messages to the new context, where they don't apply.
+2. **Target switch.** When a modal is open and waiting on a load/execute, the user can dismiss it and open a new one (different resource) before the original request returns. The late completion can then clobber the unrelated newer modal.
+
+Both have happened in practice. A single missing field on one message variant is enough to silently corrupt UI state — there's no compile-time check that says "this `tea.Msg` is stale, drop it."
+
+## Decision
+
+### Rule 1: Capture `m.switchEpoch` *before* every early return in a `tea.Cmd` producer.
+
+```go
+func (m *Model) loadX(target T) tea.Cmd {
+    epoch := m.switchEpoch          // capture FIRST
+    if m.state.Server == nil {
+        return func() tea.Msg {
+            return XErrorMsg{Target: target, Error: "...", SwitchEpoch: epoch}
+        }
+    }
+    return func() tea.Msg {
+        // ... uses epoch
+    }
+}
+```
+
+A nil-server (or any other) fast path that returns before `epoch := m.switchEpoch` will emit `SwitchEpoch: 0`. Once the user has ever switched contexts, the receiver drops it as stale and the UI hangs on Loading.
+
+### Rule 2: Every message variant in a flow carries `SwitchEpoch` and (when the flow targets a specific resource) `Target`.
+
+If `XLoadedMsg` carries `Target`, then `XErrorMsg` and `XExecutedMsg` and any tick/refresh messages in the same flow carry `Target` too. Asymmetry is the bug.
+
+### Rule 3: Receivers gate by both, in this order, before mutating modal state:
+
+```go
+case XErrorMsg:
+    if msg.SwitchEpoch != m.switchEpoch { return m, nil }
+    st := m.state.Modals.X
+    if st == nil || m.state.Mode != ModeX { return m, nil }
+    if st.Target != msg.Target { return m, nil }
+    // ... safe to mutate st
+```
+
+### Rule 4: Side effects that aren't tied to the modal run *outside* the gate.
+
+Status messages and resource-tree refreshes belong to the operation, not the modal. They should fire even if the user has already moved on from the modal that started them. Only the modal-state mutation (close, set Error, set Loading) is gated by Target.
+
+```go
+case XExecutedMsg:
+    if msg.SwitchEpoch != m.switchEpoch { return m, nil }
+    m.statusService.Set("...")  // always runs
+    if st := m.state.Modals.X; st != nil && st.Target == msg.Target {
+        m.state.Mode = ModeNormal
+        m.state.Modals.X = nil  // gated
+    }
+    return m, m.refreshTree(...) // always runs
+```
+
+## Consequences
+
+- A late tick/error/completion from a previous modal session cannot clobber a newer modal.
+- Context switches cleanly cut off all in-flight work without per-handler ad-hoc cleanup.
+- Adding a new async flow is a checklist: every msg variant gets `SwitchEpoch` + `Target`; producer captures epoch first; receivers gate both. Reviewers can grep for the pattern.
+- Mechanical cost: `Target` field on every msg variant, two extra checks per receiver. Cheap.
+
+## References
+
+- `cmd/app/api_integration.go` — producers (`loadResourceActions`, `executeResourceAction`, etc.)
+- `cmd/app/model.go` — receivers
+- `pkg/model/messages.go` — message definitions

--- a/docs/architecture/decisions/0004-app-identity.md
+++ b/docs/architecture/decisions/0004-app-identity.md
@@ -1,0 +1,69 @@
+# ADR-0004: App Identity Is `(Name, AppNamespace)`, Never Name Alone
+
+## Status
+
+Accepted
+
+## Context
+
+ArgoCD supports multi-tenant deployments where the same `Application` name can exist in different ArgoCD namespaces (`spec.application.namespaces` in the ArgoCD ConfigMap). For example, two teams each have an Application called `my-app`, one in `argocd`, one in `team-a`.
+
+The ArgoCD REST API treats these as distinct: every endpoint that operates on an Application accepts both `name` and `appNamespace` (sometimes called `appNs`). Sending only the name resolves to whichever app the server picks first — which may not be the one the user is looking at.
+
+Argonaut's `m.state.Apps` is a flat slice. A first-name-match lookup —
+
+```go
+for i := range m.state.Apps {
+    if m.state.Apps[i].Name == sel.AppName {
+        appNamespace = m.state.Apps[i].AppNamespace
+        break
+    }
+}
+```
+
+— silently picks the wrong app whenever names collide. The bug is invisible in single-tenant environments and is hard to reproduce in tests unless you remember to seed two apps with the same name.
+
+## Decision
+
+### Rule 1: Apps are identified by `(Name, AppNamespace)`. Never by Name alone.
+
+Anywhere code constructs an API call, builds a target struct, looks up cluster info, or compares apps for equality, both fields are required. A function signature that takes only `appName string` is a bug waiting to happen — pass the whole `model.App` or both fields.
+
+### Rule 2: The current view's app is `m.state.UI.TreeApp` (a `*TreeAppInfo`).
+
+`TreeAppInfo` carries `Name`, `AppNamespace`, `DestNamespace`, and `Project` together. It is set atomically by `Model.setTreeApp` when entering the tree view, so callers in tree-scoped code never have to reconstruct it.
+
+> Note: `NavigationState.TreeApp` also exists in the schema for legacy reasons. **Use `m.state.UI.TreeApp`** — that's the field everything else reads and writes.
+
+### Rule 3: When the selection's app name matches `UI.TreeApp.Name`, prefer `UI.TreeApp.AppNamespace`.
+
+In tree view the user is by definition looking at exactly one app. Use the scoped app's namespace before falling back to any name-only scan over `m.state.Apps`:
+
+```go
+var appNamespace *string
+if treeApp := m.state.UI.TreeApp; treeApp != nil && treeApp.Name == sel.AppName {
+    appNamespace = treeApp.AppNamespace
+}
+if appNamespace == nil {
+    // last-resort fallback for app-of-apps child selections, etc.
+    for i := range m.state.Apps {
+        if m.state.Apps[i].Name == sel.AppName { ... }
+    }
+}
+```
+
+### Rule 4: Tests for any feature that issues an API call against an app must include a "two apps share a name" case.
+
+`TestHandleResourceAction_DisambiguatesAppByNamespace`, `TestResCommand_CursorPos_PreservesNamespace`, and `TestHandleOpenK9s_UsesAppNamespaceForClusterLookup` are the templates. The setup is small (two apps with the same `Name`, different `AppNamespace`) and catches the entire bug class.
+
+## Consequences
+
+- Multi-tenant ArgoCD deployments work correctly. Single-tenant users see no behavior change.
+- New features that touch apps must thread `AppNamespace` through the call chain. This is occasionally noisier but ensures correctness by construction.
+- Any helper that takes `appName string` should be reviewed for upgrade to `(name, appNamespace *string)` or `model.App`.
+
+## References
+
+- `pkg/model/state.go` — `TreeAppInfo`, `NavigationState.TreeApp`, `UIState.TreeApp`
+- `cmd/app/namespace_disambiguation_test.go` — canonical test pattern
+- `cmd/app/input_handlers.go:handleResourceAction` — example of correct lookup

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -22,6 +22,9 @@ ADRs are numbered sequentially with descriptive names:
 | ADR | Title | Status |
 |-----|-------|--------|
 | [0001](./0001-custom-sse-reader-implementation.md) | Custom SSE Reader Implementation | Accepted |
+| [0002](./0002-api-timeout-strategy.md) | API Timeout Strategy | Accepted |
+| [0003](./0003-async-message-gating.md) | Async Message Gating (Epoch + Target) | Accepted |
+| [0004](./0004-app-identity.md) | App Identity Is `(Name, AppNamespace)` | Accepted |
 
 ## Guidelines
 


### PR DESCRIPTION
ADR-0003 captures the SwitchEpoch + Target gating pattern that ResourceAction handlers (and earlier handlers) keep regressing on: capture epoch before any early return, every msg variant in a flow carries Target, receivers gate on both before mutating modal state, and side effects run outside the gate.

ADR-0004 captures the multi-tenant ArgoCD reality: applications are identified by (Name, AppNamespace), not Name alone. The current view's app lives at m.state.UI.TreeApp.

Trim CLAUDE.md to a single pointer at docs/architecture/decisions/ so the index has one home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision records to expand guidance on application identification and asynchronous message handling.
  * Simplified initial development documentation with streamlined references to architectural decision records.
  * Enhanced documentation index with newly formalized architecture decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->