### PR TITLE
fix(ui): saturated colours leaking through modal overlays

### DIFF
--- a/cmd/app/testdata/snapshots/modal_app_delete_confirm.golden
+++ b/cmd/app/testdata/snapshots/modal_app_delete_confirm.golden
@@ -1,12 +1,12 @@
                                                     
  ╭────────────────────────────────────────────────╮ 
  │                                                │ 
- │                 Delete test-app?               │ 
+ │                Delete test-app?                │ 
  │                                                │ 
- │                    Delete (y)                  │ 
+ │                   Delete (y)                   │ 
  │                                                │ 
- │      c: Cascade On (all resources deleted)     │ 
- │     p: Policy foreground (wait for cleanup)    │ 
+ │     c: Cascade On (all resources deleted)      │ 
+ │    p: Policy foreground (wait for cleanup)     │ 
  │                                                │ 
  ╰────────────────────────────────────────────────╯ 
                                                     

--- a/cmd/app/testdata/snapshots/modal_app_delete_confirm_no_cascade.golden
+++ b/cmd/app/testdata/snapshots/modal_app_delete_confirm_no_cascade.golden
@@ -1,13 +1,13 @@
                                           
  ╭──────────────────────────────────────╮ 
  │                                      │ 
- │        Delete non-cascade-app?       │ 
+ │       Delete non-cascade-app?        │ 
  │                                      │ 
- │               Delete (y)             │ 
+ │              Delete (y)              │ 
  │                                      │ 
- │  c: Cascade Off (resources           │ 
- │  orphaned)                           │ 
- │     p: Policy orphan (no cleanup)    │ 
+ │      c: Cascade Off (resources       │ 
+ │              orphaned)               │ 
+ │    p: Policy orphan (no cleanup)     │ 
  │                                      │ 
  ╰──────────────────────────────────────╯ 
                                           

--- a/cmd/app/testdata/snapshots/modal_app_delete_confirm_with_input.golden
+++ b/cmd/app/testdata/snapshots/modal_app_delete_confirm_with_input.golden
@@ -1,12 +1,12 @@
                                                     
  ╭────────────────────────────────────────────────╮ 
  │                                                │ 
- │                Delete my-service?              │ 
+ │               Delete my-service?               │ 
  │                                                │ 
- │                      Delete                    │ 
+ │                     Delete                     │ 
  │                                                │ 
- │      c: Cascade On (all resources deleted)     │ 
- │       p: Policy background (async cleanup)     │ 
+ │     c: Cascade On (all resources deleted)      │ 
+ │      p: Policy background (async cleanup)      │ 
  │                                                │ 
  ╰────────────────────────────────────────────────╯ 
                                                     

--- a/cmd/app/testdata/snapshots/modal_app_delete_error.golden
+++ b/cmd/app/testdata/snapshots/modal_app_delete_error.golden
@@ -1,16 +1,15 @@
                                                     
  ╭────────────────────────────────────────────────╮ 
  │                                                │ 
- │                Delete error-app?               │ 
+ │               Delete error-app?                │ 
  │                                                │ 
- │                    Delete (y)                  │ 
+ │                   Delete (y)                   │ 
  │                                                │ 
- │       c: Cascade Off (resources orphaned)      │ 
- │                    p: Policy                   │ 
+ │      c: Cascade Off (resources orphaned)       │ 
+ │                   p: Policy                    │ 
  │                                                │ 
- │  Error: Failed to delete application:          │ 
- │  resource                                      │ 
- │                    not found                   │ 
+ │      Error: Failed to delete application:      │ 
+ │               resource not found               │ 
  │                                                │ 
  ╰────────────────────────────────────────────────╯ 
                                                     

--- a/cmd/app/testdata/snapshots/modal_resource_action_execute_error.golden
+++ b/cmd/app/testdata/snapshots/modal_resource_action_execute_error.golden
@@ -1,13 +1,13 @@
                                                     
  ╭────────────────────────────────────────────────╮ 
  │                                                │ 
- │       Actions on Rollout/payments/checkout     │ 
+ │      Actions on Rollout/payments/checkout      │ 
  │                                                │ 
- │                abort       promote             │ 
+ │               abort       promote              │ 
  │                                                │ 
- │            type to select • Enter run          │ 
+ │           type to select • Enter run           │ 
  │                                                │ 
- │    Error: rpc error: code = PermissionDenied   │ 
+ │   Error: rpc error: code = PermissionDenied    │ 
  │                                                │ 
  ╰────────────────────────────────────────────────╯ 
                                                     

--- a/cmd/app/testdata/snapshots/modal_resource_action_filter.golden
+++ b/cmd/app/testdata/snapshots/modal_resource_action_filter.golden
@@ -1,13 +1,13 @@
                                                     
  ╭────────────────────────────────────────────────╮ 
  │                                                │ 
- │       Actions on Rollout/payments/checkout     │ 
+ │      Actions on Rollout/payments/checkout      │ 
  │                                                │ 
- │             abort            promote           │ 
- │          promote-full        restart           │ 
- │                      retry                     │ 
+ │            abort            promote            │ 
+ │         promote-full        restart            │ 
+ │                     retry                      │ 
  │                                                │ 
- │              Esc clear • Enter run             │ 
+ │             Esc clear • Enter run              │ 
  │                                                │ 
  ╰────────────────────────────────────────────────╯ 
                                                     

--- a/cmd/app/testdata/snapshots/modal_resource_action_list.golden
+++ b/cmd/app/testdata/snapshots/modal_resource_action_list.golden
@@ -1,13 +1,13 @@
                                                     
  ╭────────────────────────────────────────────────╮ 
  │                                                │ 
- │       Actions on Rollout/payments/checkout     │ 
+ │      Actions on Rollout/payments/checkout      │ 
  │                                                │ 
- │             abort            promote           │ 
- │          promote-full        restart           │ 
- │                      retry                     │ 
+ │            abort            promote            │ 
+ │         promote-full        restart            │ 
+ │                     retry                      │ 
  │                                                │ 
- │            type to select • Enter run          │ 
+ │           type to select • Enter run           │ 
  │                                                │ 
  ╰────────────────────────────────────────────────╯ 
                                                     

--- a/cmd/app/testdata/snapshots/tree_view_ctrld_highlight_preserved.golden
+++ b/cmd/app/testdata/snapshots/tree_view_ctrld_highlight_preserved.golden
@@ -1,6 +1,6 @@
 [95m╭────────────────────────────────────────────────────────────────────────────────────────────────╮[m
 [95m│[m [97m[m[97mApplication[m [90m[highlight-test][m ([92mHealthy[m, [92mSynced[m)                                                 [95m│[m
-[95m│[m [97m├── [m[97;105mDeployment[m[105m [m[30;105m[default/web][m[105m [m[105m([m[92;105mHealthy[m[105m)[m                                                         [95m│[m
+[95m│[m [97m├── [m[97;105mDeployment[m[105m [m[30;105m[default/web][m[105m [m[30;105m(Healthy)[m                                                         [95m│[m
 [95m│[m [97m└── [m[97mService[m [90m[default/web][m [92m(Healthy)[m                                                            [95m│[m
 [95m│[m                                                                                                [95m│[m
 [95m│[m                                                                                                [95m│[m

--- a/cmd/app/testdata/snapshots/tree_view_ctrld_multi_select.golden
+++ b/cmd/app/testdata/snapshots/tree_view_ctrld_multi_select.golden
@@ -1,18 +1,18 @@
- Context: argo.example.com                                                           Argonaut dev 
+ Context: argo.example.com                                                           Argonaut dev   
  ╭────────────────────────────────────────────────────────────────────────────────────────────────╮ 
  │ Application [multi-app] (Healthy, Synced)                                                      │ 
- │ ├── Deployment [staging/backend] (Healthy)                                                     │
- │ ├── Service [staging/backend-svc] (Healthy)                                                    │
- │ ├── Deployment [stagi                                                                          │
+ │ ├── Deployment [staging/backend] (Healthy)                                                     │ 
+ │ ├── Service [staging/backend-svc] (Healthy)                                                    │ 
+ │ ├── Deployment [stagi                                                                          │ 
  │ └── Service [staging/ ╭────────────────────────────────────────────────╮                       │ 
  │                       │                                                │                       │ 
- │                       │              Delete 3 resource(s)?             │                       │ 
+ │                       │             Delete 3 resource(s)?              │                       │ 
  │                       │                                                │                       │ 
- │                       │                    Delete (y)                  │                       │ 
+ │                       │                   Delete (y)                   │                       │ 
  │                       │                                                │                       │ 
- │                       │      c: Cascade On (all resources deleted)     │                       │ 
- │                       │       p: Policy background (async cleanup)     │                       │ 
- │                       │                   f: Force Off                 │                       │ 
+ │                       │     c: Cascade On (all resources deleted)      │                       │ 
+ │                       │      p: Policy background (async cleanup)      │                       │ 
+ │                       │                  f: Force Off                  │                       │ 
  │                       │                                                │                       │ 
  │                       ╰────────────────────────────────────────────────╯                       │ 
  │                                                                                                │ 

--- a/cmd/app/testdata/snapshots/tree_view_ctrld_single_resource.golden
+++ b/cmd/app/testdata/snapshots/tree_view_ctrld_single_resource.golden
@@ -1,4 +1,4 @@
- Context: argo.example.com                                                           Argonaut dev 
+ Context: argo.example.com                                                           Argonaut dev   
  ╭────────────────────────────────────────────────────────────────────────────────────────────────╮ 
  │ Application [my-app] (Healthy, Synced)                                                         │ 
  │ ├── Deployment [production/api-server] (Healthy)                                               │ 
@@ -6,13 +6,13 @@
  │ └── ConfigMap [produc                                                                          │ 
  │                       ╭────────────────────────────────────────────────╮                       │ 
  │                       │                                                │                       │ 
- │                       │     Delete Deployment/production/api-server?   │                       │ 
+ │                       │    Delete Deployment/production/api-server?    │                       │ 
  │                       │                                                │                       │ 
- │                       │                    Delete (y)                  │                       │ 
+ │                       │                   Delete (y)                   │                       │ 
  │                       │                                                │                       │ 
- │                       │      c: Cascade On (all resources deleted)     │                       │ 
- │                       │     p: Policy foreground (wait for cleanup)    │                       │ 
- │                       │                   f: Force Off                 │                       │ 
+ │                       │     c: Cascade On (all resources deleted)      │                       │ 
+ │                       │    p: Policy foreground (wait for cleanup)     │                       │ 
+ │                       │                  f: Force Off                  │                       │ 
  │                       │                                                │                       │ 
  │                       ╰────────────────────────────────────────────────╯                       │ 
  │                                                                                                │ 

--- a/cmd/app/testdata/snapshots/tree_view_selection.golden
+++ b/cmd/app/testdata/snapshots/tree_view_selection.golden
@@ -1,5 +1,5 @@
 [95m╭────────────────────────────────────────────────────────────────────────────────────────────────╮[m
-[95m│[m [97;105m[m[97;105mApplication[m[105m [m[30;105m[demo-app][m[105m [m[105m([m[92;105mHealthy[m[105m, [m[92;105mSynced[m[105m)[m                                                       [95m│[m
+[95m│[m [97;105m[m[97;105mApplication[m[105m [m[30;105m[demo-app][m[105m [m[30;105m(Healthy, Synced)[m                                                       [95m│[m
 [95m│[m [97m├── [m[97mDeployment[m [90m[ns-a/web][m [92m(Healthy)[m                                                            [95m│[m
 [95m│[m [97m└── [m[97mService[m [90m[ns-a/web][m [92m(Healthy)[m                                                               [95m│[m
 [95m│[m                                                                                                [95m│[m

--- a/cmd/app/view.go
+++ b/cmd/app/view.go
@@ -409,24 +409,119 @@ func normalizeLinesToWidth(s string, width int) string {
 // ANSI escape sequence regex for colors/styles
 var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
-// Regex to detect background color codes in ANSI sequences
-// Matches: 4X (basic bg), 10X (bright bg), 48;5;X (256-color bg), 48;2;R;G;B (truecolor bg)
+// Regex to detect background color codes in ANSI sequences. Used by
+// tests; the runtime path in segmentHasBgColor parses SGR parameters
+// properly to avoid false positives where a trailing truecolor-fg
+// blue byte (e.g. ";106m" in `\x1b[38;2;158;206;106m`) accidentally
+// looks like the bright-bg pattern `10[0-7]m`.
 var bgColorRE = regexp.MustCompile("\x1b\\[(?:[0-9;]*;)?(?:4[0-7]|10[0-7]|48;[25];[0-9;]+)m")
 
-// desaturateANSI strips ANSI color/style codes and recolors text.
-// Lines with background colors are preserved as-is (they represent selected items).
-// Other lines are dimmed.
-func desaturateANSI(s string) string {
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		if bgColorRE.MatchString(line) {
-			// Line has background color - preserve it as-is (selected item)
-			// Don't modify - keep the original styling from tree view
+// segmentHasBgColor reports whether the given styled segment contains
+// any SGR sequence that sets a background color. It walks the SGR
+// parameter list properly (instead of regex-matching the raw byte
+// stream) so a truecolor foreground like 38;2;R;G;B isn't confused
+// with a bright-bg byte just because B happens to fall in 100-107.
+//
+// Recognised bg forms:
+//   - 40-47       basic bg
+//   - 100-107     bright bg
+//   - 48;5;N      256-color bg
+//   - 48;2;R;G;B  truecolor bg
+//
+// 38-prefixed (fg) sequences and any other params are skipped over,
+// including their parameter tails (38;5;N consumes 3 params,
+// 38;2;R;G;B consumes 5).
+func segmentHasBgColor(seg string) bool {
+	sgrs := ansiRE.FindAllString(seg, -1)
+	for _, sgr := range sgrs {
+		inner := sgr
+		if strings.HasPrefix(inner, "\x1b[") {
+			inner = inner[2:]
+		}
+		if strings.HasSuffix(inner, "m") {
+			inner = inner[:len(inner)-1]
+		}
+		if inner == "" {
 			continue
 		}
-		// Regular line - dim it
-		plain := ansiRE.ReplaceAllString(line, "")
-		lines[i] = lipgloss.NewStyle().Foreground(dimColor).Render(plain)
+		params := strings.Split(inner, ";")
+		for i := 0; i < len(params); i++ {
+			p := params[i]
+			switch {
+			case len(p) == 2 && p[0] == '4' && p[1] >= '0' && p[1] <= '7':
+				return true
+			case len(p) == 3 && p[0] == '1' && p[1] == '0' && p[2] >= '0' && p[2] <= '7':
+				return true
+			case p == "48":
+				return true
+			case p == "38":
+				// Skip the fg payload so its bytes can't be
+				// misread as a bg code.
+				if i+1 < len(params) {
+					switch params[i+1] {
+					case "5":
+						i += 2 // 38;5;N
+					case "2":
+						i += 4 // 38;2;R;G;B
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// Matches an SGR reset: both `\x1b[0m` and the shorthand `\x1b[m`
+// (lipgloss emits the shorthand). Used by desaturateANSI to split a
+// styled line into segments.
+var resetRE = regexp.MustCompile("\x1b\\[0?m")
+
+// desaturateANSI strips foreground colors from a styled string so a
+// popup overlay can sit cleanly on top of a dimmed base. Lines are
+// processed per-ANSI-segment (split on SGR reset) so a single styled
+// span on a line doesn't cause the whole line to be skipped.
+//
+// For each segment:
+//   - If the segment carries a background color, the styled run is kept
+//     intact (bg + original fg). Bg-styled runs are deliberate UI
+//     elements — selection highlights, the ":upgrade" token in the
+//     status bar, the "Argonaut dev" badge — and dimming their fg
+//     would either bleed the bg across nearby unstyled text or change
+//     the badge's contrast. Saturated status hues that ride alongside
+//     a selection bg are addressed at the source (see
+//     renderStatusPartNeutralBG in pkg/tui/treeview).
+//   - Segments without a bg are stripped of all ANSI and re-rendered
+//     with the dim foreground.
+func desaturateANSI(s string) string {
+	dim := lipgloss.NewStyle().Foreground(dimColor)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "\x1b") {
+			lines[i] = dim.Render(line)
+			continue
+		}
+		var b strings.Builder
+		locs := resetRE.FindAllStringIndex(line, -1)
+		cursor := 0
+		emit := func(seg, reset string) {
+			if seg == "" && reset == "" {
+				return
+			}
+			if segmentHasBgColor(seg) {
+				b.WriteString(seg)
+				if reset != "" {
+					b.WriteString(reset)
+				}
+				return
+			}
+			b.WriteString(dim.Render(ansiRE.ReplaceAllString(seg, "")))
+		}
+		for _, loc := range locs {
+			emit(line[cursor:loc[0]], line[loc[0]:loc[1]])
+			cursor = loc[1]
+		}
+		emit(line[cursor:], "")
+		lines[i] = b.String()
 	}
 	return strings.Join(lines, "\n")
 }

--- a/cmd/app/view_desaturate_test.go
+++ b/cmd/app/view_desaturate_test.go
@@ -1,0 +1,553 @@
+package main
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/darksworm/argonaut/pkg/model"
+	"github.com/darksworm/argonaut/pkg/theme"
+)
+
+// Regression tests for desaturateANSI — see fix for the bug where lines
+// containing any background-color escape were preserved wholesale,
+// leaving popup-adjacent rows (e.g. the selected tree row's prefix and
+// the status bar around the styled :upgrade/:changelog token)
+// undimmed when a modal was overlaid.
+
+func containsDimFG(s string) bool {
+	// Match the dim-color foreground escape produced by lipgloss for
+	// dimColor (palette index 8). Lipgloss may emit `\x1b[38;5;8m` or
+	// `\x1b[90m` depending on profile; check both.
+	return strings.Contains(s, "\x1b[38;5;8m") ||
+		strings.Contains(s, "\x1b[90m")
+}
+
+func TestDesaturateANSI_PlainLineDimmed(t *testing.T) {
+	out := desaturateANSI("hello world")
+	if !containsDimFG(out) {
+		t.Fatalf("expected plain line to be dimmed, got %q", out)
+	}
+	if !strings.Contains(out, "hello world") {
+		t.Fatalf("expected text to be preserved, got %q", out)
+	}
+}
+
+func TestDesaturateANSI_OnlyForegroundSegmentDimmed(t *testing.T) {
+	// A line styled with only foreground color (no bg) should be dimmed
+	// regardless of any embedded fg escapes.
+	yellow := lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("warning")
+	out := desaturateANSI(yellow)
+	if !containsDimFG(out) {
+		t.Fatalf("expected fg-only segment to be dimmed, got %q", out)
+	}
+	if strings.Contains(out, "\x1b[38;5;11m") || strings.Contains(out, "\x1b[33m") {
+		t.Fatalf("expected original yellow fg to be stripped, got %q", out)
+	}
+}
+
+func TestDesaturateANSI_BackgroundSegmentPreserved(t *testing.T) {
+	bg := lipgloss.NewStyle().
+		Background(lipgloss.Color("13")).
+		Foreground(lipgloss.Color("0")).
+		Render(":upgrade")
+	out := desaturateANSI(bg)
+	if !bgColorRE.MatchString(out) {
+		t.Fatalf("expected bg-styled segment to retain its background, got %q", out)
+	}
+}
+
+func TestDesaturateANSI_MixedSegmentsOnSameLine(t *testing.T) {
+	// Simulates a status-bar-style line: plain text, then a styled
+	// :upgrade token with a background, then more plain text. Before the
+	// fix, the entire line was preserved unmodified because it contained
+	// any bg color anywhere.
+	plain := "Ready • "
+	styled := lipgloss.NewStyle().
+		Background(lipgloss.Color("13")).
+		Foreground(lipgloss.Color("15")).
+		Render(":upgrade")
+	tail := " • 1/12"
+	line := plain + styled + tail
+
+	out := desaturateANSI(line)
+
+	// The bg-styled :upgrade token must still carry a background.
+	if !bgColorRE.MatchString(out) {
+		t.Fatalf("expected styled :upgrade token to keep its background, got %q", out)
+	}
+	// The plain prefix and suffix must now be dim — meaning the dim
+	// foreground escape appears in the output.
+	if !containsDimFG(out) {
+		t.Fatalf("expected non-bg portions to be dimmed, got %q", out)
+	}
+	// And the original textual content must still be intact.
+	for _, want := range []string{"Ready", ":upgrade", "1/12"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q to survive desaturation, got %q", want, out)
+		}
+	}
+}
+
+func TestDesaturateANSI_TreeRowPrefixDimmedSelectionPreserved(t *testing.T) {
+	// Mirrors the desaturate-mode tree row layout from
+	// pkg/tui/treeview/treeview.go: a foreground-only prefix segment
+	// followed by background-bearing segments for the kind/name/status.
+	prefix := lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Render("  ├─ ")
+	bg := lipgloss.NewStyle().Background(lipgloss.Color("13")).Foreground(lipgloss.Color("0"))
+	kind := bg.Render("Pod")
+	name := bg.Render(" [my-pod]")
+	line := prefix + kind + name
+
+	out := desaturateANSI(line)
+
+	if !bgColorRE.MatchString(out) {
+		t.Fatalf("expected selected row's bg highlight to survive, got %q", out)
+	}
+	if !containsDimFG(out) {
+		t.Fatalf("expected non-bg prefix to be dimmed, got %q", out)
+	}
+	if !strings.Contains(out, "├─") || !strings.Contains(out, "[my-pod]") {
+		t.Fatalf("expected text content to be preserved, got %q", out)
+	}
+}
+
+func TestDesaturateANSI_PreservesNewlines(t *testing.T) {
+	in := "alpha\nbeta\ngamma"
+	out := desaturateANSI(in)
+	if got := strings.Count(out, "\n"); got != 2 {
+		t.Fatalf("expected 2 newlines preserved, got %d in %q", got, out)
+	}
+}
+
+// TestRender_AppsList_SyncModal_DesaturatesNonSelected verifies the
+// scenario the user reported: with a confirm-sync modal up and one app
+// selected for sync, only the selected app keeps its bg highlight.
+// Other rows — including the cursor row — must not retain a bright
+// selection-style background, and per-cell status colors (Synced /
+// Healthy) on inactive rows must be dimmed.
+func TestRender_AppsList_SyncModal_DesaturatesNonSelected(t *testing.T) {
+	m := buildTestModelWithApps(100, 30)
+	// Cursor on app-a (index 0); app-b (index 1) is the one selected
+	// for sync — mirrors the "test-prod selected, test-dev at cursor"
+	// case the user reported.
+	m.state.Navigation.SelectedIdx = 0
+	m.state.Selections.SelectedApps = map[string]bool{"app-b": true}
+	m.state.Mode = model.ModeConfirmSync
+
+	if !m.willDesaturateBase() {
+		t.Fatalf("expected willDesaturateBase to be true under ModeConfirmSync")
+	}
+
+	// Render the list view and apply the same desaturation pipeline the
+	// real overlay path uses (view_layout.go calls desaturateANSI on
+	// the assembled baseView).
+	listOut := m.renderListView(10)
+	desaturated := desaturateANSI(listOut)
+
+	// Sanity: the cursor row (app-a) must NOT carry the selectedStyle
+	// bg color (magentaBright = 13 / bright magenta) after desaturation.
+	// We split the output into lines and inspect the line containing
+	// "app-a" — it should have no bg color codes, since the cursor
+	// highlight was suppressed.
+	for _, line := range strings.Split(desaturated, "\n") {
+		if !strings.Contains(line, "app-a") {
+			continue
+		}
+		if bgColorRE.MatchString(line) {
+			t.Fatalf("cursor row (app-a) should not retain bg under desaturating modal: %q", line)
+		}
+	}
+
+	// The selected row (app-b) MUST still carry a bg highlight so the
+	// user can see what's being synced.
+	foundSelectedHighlight := false
+	for _, line := range strings.Split(desaturated, "\n") {
+		if strings.Contains(line, "app-b") && bgColorRE.MatchString(line) {
+			foundSelectedHighlight = true
+			break
+		}
+	}
+	if !foundSelectedHighlight {
+		t.Fatalf("selected row (app-b) should retain bg highlight; output=\n%s", desaturated)
+	}
+
+	// Inactive rows render Sync/Health with fg-only color. After
+	// desaturation those segments must be dimmed — i.e. the original
+	// status fg colors (green for Synced/Healthy, red for OutOfSync,
+	// yellow for Progressing) must not appear on the cursor row.
+	// Check that the line containing the unrelated cursor row (app-a)
+	// no longer carries the green fg used for Synced/Healthy.
+	for _, line := range strings.Split(desaturated, "\n") {
+		if !strings.Contains(line, "app-a") {
+			continue
+		}
+		// 256-color green (10) and ANSI bright green
+		for _, fg := range []string{"\x1b[38;5;10m", "\x1b[92m"} {
+			if strings.Contains(line, fg) {
+				t.Fatalf("cursor row should not retain status fg %q after desaturation: %q", fg, line)
+			}
+		}
+	}
+}
+
+// TestClipAnsiToWidth_ClosesOpenSGR is the regression for the "cursor
+// highlight bleeds onto the next visual line" bug. When a styled tree
+// row exceeds the panel width and gets clipped, the clipped portion can
+// end mid-styled-run with the bg still active. Without an appended
+// reset, the bg "leaks" into whatever the terminal renders after.
+func TestClipAnsiToWidth_ClosesOpenSGR(t *testing.T) {
+	bg := lipgloss.NewStyle().Background(lipgloss.Color("13")).Render("highlighted row content beyond panel width")
+	clipped := clipAnsiToWidth(bg, 10)
+	if !strings.HasSuffix(clipped, "\x1b[m") && !strings.HasSuffix(clipped, "\x1b[0m") {
+		t.Fatalf("clipped output must end with an SGR reset to prevent style bleed; got %q", clipped)
+	}
+}
+
+func TestClipAnsiToWidth_PlainStringUntouched(t *testing.T) {
+	out := clipAnsiToWidth("hello world", 5)
+	if out != "hello" {
+		t.Fatalf("expected exact clip to %q, got %q", "hello", out)
+	}
+}
+
+// TestRender_AppsList_SyncModal_NoColorLeaks_RealTheme is the
+// integration test for the user-reported "(Healthy) is still green /
+// header still yellow / random app stays bright" cluster of bugs,
+// exercised through the FULL pipeline a real session uses: the nord
+// theme is applied (so SGR codes are truecolor like in production),
+// and the assertion runs against the post-canvas-compose output.
+//
+// Earlier versions of this test ran without applying any theme,
+// which meant `dimColor` resolved to the bare ANSI 8 / `\x1b[90m`
+// path and never exercised the truecolor (`\x1b[38;2;R;G;Bm`)
+// branches — masking any regex-or-segment bug that only triggers on
+// truecolor SGRs.
+func TestRender_AppsList_SyncModal_NoColorLeaks_RealTheme(t *testing.T) {
+	palette, ok := theme.Get("nord")
+	if !ok {
+		t.Skip("nord theme not available")
+	}
+	applyTheme(palette)
+	// Restore default theme afterwards so we don't leak global
+	// theme state into other tests in the package.
+	t.Cleanup(func() { applyTheme(theme.Default()) })
+
+	m := buildTestModelWithApps(100, 30)
+	m.applyThemeToModel()
+	m.state.Navigation.SelectedIdx = 0
+	m.state.Selections.SelectedApps = map[string]bool{"app-b": true}
+	m.state.UI.RefreshFlashApps = map[string]bool{"app-c": true}
+	m.state.Mode = model.ModeConfirmSync
+
+	// Run the full render: this includes desaturateANSI AND
+	// composeOverlay (lipgloss canvas). If the canvas were to revert
+	// dimmed runs to the original colors, we'd see saturated codes
+	// here — that hypothesis was disproved (lipgloss preserves the
+	// SGR we emit) but this test gates the full pipeline regardless.
+	out := m.renderMainLayout()
+
+	// nord palette saturated truecolor codes that must NOT survive
+	// outside of explicit modal/badge/selected-row regions:
+	//   Success #a3be8c  → 163;190;140 (green)
+	//   Danger  #bf616a  → 191;97;106  (red)
+	//   Warning #ebcb8b  → 235;203;139 (yellow)
+	saturatedSGRs := []string{
+		"38;2;163;190;140", // green fg
+		"38;2;191;97;106",  // red fg
+		"38;2;235;203;139", // yellow fg
+	}
+
+	for i, line := range strings.Split(out, "\n") {
+		plain := stripANSI(line)
+		if strings.Contains(plain, "app-b") {
+			continue // selected sync target keeps its highlight
+		}
+		// Skip the modal body — it's allowed to be vivid.
+		if strings.Contains(plain, "Sync") && strings.Contains(plain, "?") {
+			continue
+		}
+		if strings.Contains(plain, "Confirm") || strings.Contains(plain, "[Sync]") {
+			continue
+		}
+		// The "Argonaut dev" badge keeps its bg/fg styling on purpose.
+		if strings.Contains(plain, "Argonaut") {
+			continue
+		}
+		for _, sgr := range saturatedSGRs {
+			if strings.Contains(line, sgr) {
+				t.Errorf("line %d carries saturated truecolor fg %q under sync modal: %q", i, sgr, line)
+			}
+		}
+	}
+}
+
+// TestSegmentHasBgColor_TruecolorFgFalsePositives is the regression
+// for the regex false-positive that left "(Healthy)" / "(OutOfSync)"
+// colored under modals on themes whose status colors happen to encode
+// an RGB byte in the 40-47 / 100-107 range (which the old
+// `bgColorRE` regex confused with basic-bg / bright-bg SGR).
+//
+// nord Danger        #bf616a → 191;97;106  (B=106  → 106m)
+// solarized Danger   #dc322f → 220;50;47   (B=47   → 47m)
+// monokai Success    #a6e22e → 166;226;46  (B=46   → 46m)
+// tokyo-storm Success#9ece6a → 158;206;106 (B=106  → 106m)
+//
+// All of these are foreground SGRs and must be classified as
+// "fg-only" so desaturateANSI dims them rather than preserving them.
+func TestSegmentHasBgColor_TruecolorFgFalsePositives(t *testing.T) {
+	fgOnly := []string{
+		"\x1b[38;2;191;97;106m",
+		"\x1b[38;2;220;50;47m",
+		"\x1b[38;2;166;226;46m",
+		"\x1b[38;2;158;206;106m",
+		"\x1b[38;2;76;86;106m",
+		"\x1b[1;38;2;163;190;140m",
+		"\x1b[33m", "\x1b[1;33m", "\x1b[38;5;10m",
+	}
+	for _, c := range fgOnly {
+		if segmentHasBgColor(c) {
+			t.Errorf("expected fg-only SGR to NOT be classified as bg: %q", c)
+		}
+	}
+	bgPresent := []string{
+		"\x1b[40m", "\x1b[42m", "\x1b[47m",
+		"\x1b[100m", "\x1b[105m", "\x1b[107m",
+		"\x1b[48;5;235m",
+		"\x1b[48;2;30;30;80m",
+		"\x1b[97;48;2;30;30;80m",
+		"\x1b[38;2;255;255;255;48;2;30;30;80m",
+	}
+	for _, c := range bgPresent {
+		if !segmentHasBgColor(c) {
+			t.Errorf("expected bg SGR to be classified as bg: %q", c)
+		}
+	}
+}
+
+// TestDesaturateANSI_AllPaletteColorsCollapseToDim is the
+// exhaustive unit test: walk every shipped theme preset, render a
+// string in every palette color as a plain foreground (no bg), run
+// the result through desaturateANSI, and assert the surviving
+// foreground SGR is identical to the dim foreground SGR for that
+// theme. If any palette color escapes the dimmer (as nord Danger /
+// monokai Success / solarized-light Danger did before the SGR-param
+// parser fix), the test fails and pinpoints the offending
+// preset+field.
+func TestDesaturateANSI_AllPaletteColorsCollapseToDim(t *testing.T) {
+	t.Cleanup(func() { applyTheme(theme.Default()) })
+
+	// Pull the SGR run that wraps the rendered text: the sequence
+	// from the first \x1b[ to its terminating m. Returns "" when the
+	// rendered string has no styling.
+	extractFgSGR := func(s string) string {
+		i := strings.Index(s, "\x1b[")
+		if i < 0 {
+			return ""
+		}
+		j := strings.Index(s[i:], "m")
+		if j < 0 {
+			return ""
+		}
+		return s[i : i+j+1]
+	}
+
+	type field struct {
+		name string
+		get  func(p theme.Palette) color.Color
+	}
+	fields := []field{
+		{"Accent", func(p theme.Palette) color.Color { return p.Accent }},
+		{"Warning", func(p theme.Palette) color.Color { return p.Warning }},
+		{"Dim", func(p theme.Palette) color.Color { return p.Dim }},
+		{"Success", func(p theme.Palette) color.Color { return p.Success }},
+		{"Danger", func(p theme.Palette) color.Color { return p.Danger }},
+		{"Progress", func(p theme.Palette) color.Color { return p.Progress }},
+		{"Unknown", func(p theme.Palette) color.Color { return p.Unknown }},
+		{"Info", func(p theme.Palette) color.Color { return p.Info }},
+		{"Text", func(p theme.Palette) color.Color { return p.Text }},
+		{"Gray", func(p theme.Palette) color.Color { return p.Gray }},
+	}
+
+	for _, themeName := range []string{
+		"nord", "dracula", "solarized-light", "solarized-dark",
+		"monokai", "tokyo-night", "gruvbox-dark", "gruvbox-light",
+		"one-dark", "one-light",
+	} {
+		palette, ok := theme.Get(themeName)
+		if !ok {
+			continue
+		}
+		t.Run(themeName, func(t *testing.T) {
+			applyTheme(palette)
+			expected := extractFgSGR(lipgloss.NewStyle().Foreground(dimColor).Render("X"))
+			if expected == "" {
+				t.Fatalf("could not derive expected dim SGR for theme %s", themeName)
+			}
+			for _, f := range fields {
+				c := f.get(palette)
+				if c == nil {
+					continue
+				}
+				styled := lipgloss.NewStyle().Foreground(c).Render("Healthy")
+				out := desaturateANSI(styled)
+				got := extractFgSGR(out)
+				if got != expected {
+					t.Errorf("theme=%s field=%s: fg-only color survived desaturation\n  input  = %q\n  output = %q\n  expected fg SGR = %q\n  got fg SGR      = %q",
+						themeName, f.name, styled, out, expected, got)
+				}
+				// Sanity: visible text must be intact.
+				if !strings.Contains(out, "Healthy") {
+					t.Errorf("theme=%s field=%s: visible text lost: %q", themeName, f.name, out)
+				}
+			}
+		})
+	}
+}
+
+// TestRender_TreeUnderModal_AllThemes_NoStatusColorLeak iterates
+// every preset and asserts that when a modal is up over the tree
+// view, no row carries a saturated truecolor fg matching the
+// theme's Success/Danger/Warning hues. This catches future themes
+// whose RGB bytes fall in the same trap as nord/monokai/etc.
+func TestRender_TreeUnderModal_AllThemes_NoStatusColorLeak(t *testing.T) {
+	t.Cleanup(func() { applyTheme(theme.Default()) })
+
+	themes := []string{"nord", "dracula", "solarized-light", "solarized-dark", "monokai", "tokyo-night", "gruvbox-dark", "gruvbox-light", "one-dark", "one-light"}
+	for _, name := range themes {
+		palette, ok := theme.Get(name)
+		if !ok {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			applyTheme(palette)
+			m := buildBaseModel(120, 30)
+			m.applyThemeToModel()
+			m.state.Navigation.View = model.ViewTree
+			m.state.Mode = model.ModeConfirmSync
+
+			out := m.renderMainLayout()
+
+			toSGR := func(c interface{ RGBA() (uint32, uint32, uint32, uint32) }) string {
+				r, g, b, _ := c.RGBA()
+				// Match the truecolor fg payload anywhere in an SGR run:
+				// standalone (`\x1b[38;2;R;G;Bm`), preceded by attrs
+				// (`\x1b[1;38;2;R;G;Bm`), or followed by another param
+				// like a bg (`\x1b[38;2;R;G;B;48;2;...m`).
+				return "38;2;" + itoa(int(r>>8)) + ";" + itoa(int(g>>8)) + ";" + itoa(int(b>>8))
+			}
+			banned := []string{}
+			if palette.Success != nil {
+				if c, ok := palette.Success.(interface {
+					RGBA() (uint32, uint32, uint32, uint32)
+				}); ok {
+					banned = append(banned, toSGR(c))
+				}
+			}
+			if palette.Danger != nil {
+				if c, ok := palette.Danger.(interface {
+					RGBA() (uint32, uint32, uint32, uint32)
+				}); ok {
+					banned = append(banned, toSGR(c))
+				}
+			}
+			for _, line := range strings.Split(out, "\n") {
+				plain := stripANSI(line)
+				// Skip the "Argonaut" badge — it intentionally keeps
+				// its bg/fg.
+				if strings.Contains(plain, "Argonaut") {
+					continue
+				}
+				for _, b := range banned {
+					if strings.Contains(line, b) {
+						t.Errorf("theme %s: tree base under modal still carries banned saturated SGR %q in line: %q", name, b, line)
+					}
+				}
+			}
+		})
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [12]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// Original 16-color check, kept for the no-theme/baseline harness path.
+func TestRender_AppsList_SyncModal_NoColorLeaks(t *testing.T) {
+	m := buildTestModelWithApps(100, 30)
+	// cursor on app-a, sync target = app-b, app-c is mid-flash from
+	// a previous refresh.
+	m.state.Navigation.SelectedIdx = 0
+	m.state.Selections.SelectedApps = map[string]bool{"app-b": true}
+	m.state.UI.RefreshFlashApps = map[string]bool{"app-c": true}
+	m.state.Mode = model.ModeConfirmSync
+
+	out := m.renderMainLayout()
+
+	// Saturated status fg colors that must NOT appear on rows other
+	// than the selected one. (Health/Sync use truecolor in real
+	// themes; in the default test palette they fall back to the
+	// 16-color set — we check both.)
+	saturatedFG := []string{
+		"\x1b[32m", "\x1b[92m", // green
+		"\x1b[31m", "\x1b[91m", // red
+		"\x1b[33m", "\x1b[93m", // yellow
+		"\x1b[38;5;10m", "\x1b[38;5;9m", "\x1b[38;5;11m",
+	}
+
+	for i, line := range strings.Split(out, "\n") {
+		plain := stripANSI(line)
+		// Skip the modal lines (they're allowed to be vivid).
+		if strings.Contains(plain, "Sync") && strings.Contains(plain, "?") {
+			continue
+		}
+		if strings.Contains(plain, "Confirm") || strings.Contains(plain, "y/n") || strings.Contains(plain, "[Sync]") {
+			continue
+		}
+		// The selected sync target keeps its bg highlight; that's OK.
+		isSelectedRow := strings.Contains(plain, "app-b")
+		if isSelectedRow {
+			continue
+		}
+		for _, sgr := range saturatedFG {
+			if strings.Contains(line, sgr) {
+				t.Errorf("line %d carries saturated fg %q under sync modal: %q", i, sgr, line)
+			}
+		}
+	}
+}
+
+func TestWillDesaturateBase_TogglesWithModalState(t *testing.T) {
+	m := buildTestModelWithApps(80, 24)
+	if m.willDesaturateBase() {
+		t.Fatal("expected false in normal mode")
+	}
+	m.state.Mode = model.ModeConfirmSync
+	if !m.willDesaturateBase() {
+		t.Fatal("expected true under ModeConfirmSync")
+	}
+	m.state.Mode = model.ModeNormal
+	m.state.Modals.ConfirmSyncLoading = true
+	if !m.willDesaturateBase() {
+		t.Fatal("expected true while ConfirmSyncLoading")
+	}
+}

--- a/cmd/app/view_layout.go
+++ b/cmd/app/view_layout.go
@@ -10,6 +10,138 @@ import (
 
 // moved: full-screen helpers remain in view.go
 
+// overlaySpec describes a modal/spinner currently being shown above
+// the base view. activeOverlay returns one of these (or nil) so the
+// "what modal is up?" decision lives in exactly one place — both
+// renderMainLayout (which does the actual composition) and row
+// renderers via willDesaturateBase consult the same function.
+type overlaySpec struct {
+	modal       string           // primary modal content; centered on screen
+	extraLayers []*lipgloss.Layer // any additional layers below the modal (e.g. a corner badge)
+	desaturate  bool             // whether the base view should be dimmed under the modal
+}
+
+// activeOverlay returns the overlay currently shown above the base
+// view, or nil if none. Branch order matches the original
+// renderMainLayout decision tree so behaviour is preserved.
+func (m *Model) activeOverlay() *overlaySpec {
+	// Non-desaturating overlays (the modal carries its own opaque
+	// content; we don't want to dim what's beneath it).
+	if m.state.Mode == model.ModeTheme {
+		return &overlaySpec{modal: m.renderThemeSelectionModal()}
+	}
+	if m.state.Mode == model.ModeK9sContextSelect {
+		return &overlaySpec{modal: m.renderK9sContextSelectionModal()}
+	}
+
+	// Desaturating overlays.
+	if m.state.Mode == model.ModeRollback && m.state.Rollback != nil && m.state.Rollback.Loading {
+		return &overlaySpec{modal: m.renderRollbackLoadingModal(), desaturate: true}
+	}
+	if m.state.Navigation.View == model.ViewTree && m.treeLoading {
+		return &overlaySpec{modal: m.renderTreeLoadingSpinner(), desaturate: true}
+	}
+	if m.state.Mode == model.ModeConfirmSync || m.state.Modals.ConfirmSyncLoading {
+		modal := m.renderConfirmSyncModal()
+		if m.state.Modals.ConfirmSyncLoading {
+			modal = m.renderSyncLoadingModal()
+		}
+		return &overlaySpec{modal: modal, desaturate: true}
+	}
+	if m.state.Modals.ChangelogLoading {
+		return &overlaySpec{modal: m.renderChangelogLoadingModal(), desaturate: true}
+	}
+	if m.state.Mode == model.ModeUpgrade || m.state.Mode == model.ModeUpgradeError || m.state.Mode == model.ModeUpgradeSuccess {
+		var modal string
+		switch {
+		case m.state.Mode == model.ModeUpgradeError:
+			modal = m.renderUpgradeErrorModal()
+		case m.state.Mode == model.ModeUpgradeSuccess:
+			modal = m.renderUpgradeSuccessModal()
+		case m.state.Modals.UpgradeLoading:
+			modal = m.renderUpgradeLoadingModal()
+		default:
+			modal = m.renderUpgradeConfirmModal()
+		}
+		return &overlaySpec{modal: modal, desaturate: true}
+	}
+	if m.state.Mode == model.ModeNoDiff {
+		return &overlaySpec{modal: m.renderNoDiffModal(), desaturate: true}
+	}
+	if m.state.Mode == model.ModeK9sError {
+		return &overlaySpec{modal: m.renderK9sErrorModal(), desaturate: true}
+	}
+	if m.state.Mode == model.ModeDefaultViewWarning {
+		return &overlaySpec{modal: m.renderDefaultViewWarningModal(), desaturate: true}
+	}
+	if m.state.Mode == model.ModeConfirmAppDelete {
+		modal := m.renderAppDeleteConfirmModal()
+		if m.state.Modals.DeleteLoading {
+			modal = m.renderAppDeleteLoadingModal()
+		}
+		return &overlaySpec{modal: modal, desaturate: true}
+	}
+	if m.state.Mode == model.ModeConfirmResourceDelete {
+		modal := m.renderResourceDeleteConfirmModal()
+		if m.state.Modals.ResourceDeleteLoading {
+			modal = m.renderResourceDeleteLoadingModal()
+		}
+		return &overlaySpec{modal: modal, desaturate: true}
+	}
+	if m.state.Mode == model.ModeConfirmResourceSync {
+		modal := m.renderResourceSyncConfirmModal()
+		if m.state.Modals.ResourceSyncLoading {
+			modal = m.renderResourceSyncLoadingModal()
+		}
+		return &overlaySpec{modal: modal, desaturate: true}
+	}
+	if m.state.Mode == model.ModeResourceAction {
+		var modal string
+		st := m.state.Modals.ResourceAction
+		switch {
+		case st == nil || st.Loading:
+			modal = m.renderResourceActionLoadingModal()
+		case st.Executing:
+			modal = m.renderResourceActionExecutingModal()
+		case len(st.Actions) == 0:
+			modal = m.renderResourceActionInfoModal()
+		default:
+			modal = m.renderResourceActionModal()
+		}
+		return &overlaySpec{modal: modal, desaturate: true}
+	}
+	if m.state.Mode == model.ModeLoading && m.state.Navigation.View != model.ViewContexts {
+		spec := &overlaySpec{modal: m.renderInitialLoadingModal(), desaturate: true}
+		// Diff loading badge in the top-left corner, layered below the
+		// loading modal but above the desaturated base.
+		if m.state.Diff != nil && m.state.Diff.Loading {
+			badge := m.renderSmallBadge(true, m.state.Terminal.Cols >= 72)
+			spec.extraLayers = append(spec.extraLayers,
+				lipgloss.NewLayer(badge).X(1).Y(1).Z(1))
+		}
+		return spec
+	}
+	if len(m.state.Apps) == 0 && m.state.Mode == model.ModeNormal && m.state.Navigation.View != model.ViewContexts {
+		return &overlaySpec{modal: m.renderNoServerModal(), desaturate: true}
+	}
+	if m.state.Diff != nil && m.state.Diff.Loading {
+		return &overlaySpec{modal: m.renderDiffLoadingSpinner(), desaturate: true}
+	}
+	return nil
+}
+
+// willDesaturateBase reports whether the base view will be rendered
+// behind a desaturating overlay. Row renderers consult this so the
+// cursor's bg highlight is suppressed while a modal is up — otherwise
+// the bg-styled segment survives the per-segment desaturation pass
+// and the cursor row leaks through. Single source of truth: derived
+// directly from activeOverlay so it can never drift from the actual
+// composition.
+func (m *Model) willDesaturateBase() bool {
+	ov := m.activeOverlay()
+	return ov != nil && ov.desaturate
+}
+
 // renderTreePanel renders the resource tree view inside a bordered container with scrolling
 func (m *Model) renderTreePanel(availableRows int) string {
 	contentWidth := max(0, m.contentInnerWidth())
@@ -134,14 +266,7 @@ func (m *Model) renderMainLayout() string {
 	// Set desaturate mode on tree view if a modal with desaturation will be shown
 	// This makes the tree view only highlight selected items (not cursor) with scoped highlights
 	if m.treeView != nil && m.state.Navigation.View == model.ViewTree {
-		willDesaturate := m.state.Mode == model.ModeConfirmResourceDelete ||
-			m.state.Mode == model.ModeConfirmResourceSync ||
-			m.state.Mode == model.ModeConfirmAppDelete ||
-			m.state.Mode == model.ModeConfirmSync ||
-			m.state.Mode == model.ModeResourceAction ||
-			m.state.Modals.ConfirmSyncLoading ||
-			m.state.Modals.ResourceSyncLoading
-		m.treeView.SetDesaturateMode(willDesaturate)
+		m.treeView.SetDesaturateMode(m.willDesaturateBase())
 	}
 
 	if m.state.Navigation.View == model.ViewTree {
@@ -154,225 +279,28 @@ func (m *Model) renderMainLayout() string {
 	content := strings.Join(sections, "\n")
 	baseView := mainContainerStyle.Render(content)
 
-	// Overlays
-	// Theme selection overlay
-	if m.state.Mode == model.ModeTheme {
-		modal := m.renderThemeSelectionModal()
-		baseLayer := lipgloss.NewLayer(baseView)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
+	ov := m.activeOverlay()
+	if ov == nil {
+		return baseView
 	}
-	// k9s context selection overlay
-	if m.state.Mode == model.ModeK9sContextSelect {
-		modal := m.renderK9sContextSelectionModal()
-		baseLayer := lipgloss.NewLayer(baseView)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Rollback loading overlay (history load or executing rollback)
-	if m.state.Mode == model.ModeRollback && m.state.Rollback != nil && m.state.Rollback.Loading {
-		modal := m.renderRollbackLoadingModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Tree loading overlay when entering resources view
-	if m.state.Navigation.View == model.ViewTree && m.treeLoading {
-		spinner := m.renderTreeLoadingSpinner()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		spinnerLayer := lipgloss.NewLayer(spinner).
-			X((m.state.Terminal.Cols - lipgloss.Width(spinner)) / 2).
-			Y((m.state.Terminal.Rows - lipgloss.Height(spinner)) / 2).
-			Z(1)
-		return m.composeOverlay(baseLayer, spinnerLayer)
-	}
-	// Confirm Sync modal (confirmation or loading state)
-	if m.state.Mode == model.ModeConfirmSync || m.state.Modals.ConfirmSyncLoading {
-		modal := ""
-		if m.state.Modals.ConfirmSyncLoading {
-			modal = m.renderSyncLoadingModal()
-		} else {
-			modal = m.renderConfirmSyncModal()
-		}
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Changelog loading modal
-	if m.state.Modals.ChangelogLoading {
-		modal := m.renderChangelogLoadingModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Upgrade modal (confirmation, loading, success, or error state)
-	if m.state.Mode == model.ModeUpgrade || m.state.Mode == model.ModeUpgradeError || m.state.Mode == model.ModeUpgradeSuccess {
-		modal := ""
-		if m.state.Mode == model.ModeUpgradeError {
-			modal = m.renderUpgradeErrorModal()
-		} else if m.state.Mode == model.ModeUpgradeSuccess {
-			modal = m.renderUpgradeSuccessModal()
-		} else if m.state.Modals.UpgradeLoading {
-			modal = m.renderUpgradeLoadingModal()
-		} else {
-			modal = m.renderUpgradeConfirmModal()
-		}
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// No diff modal (overlaid on existing content)
-	if m.state.Mode == model.ModeNoDiff {
-		modal := m.renderNoDiffModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// K9s error modal
-	if m.state.Mode == model.ModeK9sError {
-		modal := m.renderK9sErrorModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Default view warning modal
-	if m.state.Mode == model.ModeDefaultViewWarning {
-		modal := m.renderDefaultViewWarningModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// App Delete modal (confirmation or loading state)
-	if m.state.Mode == model.ModeConfirmAppDelete {
-		modal := ""
-		if m.state.Modals.DeleteLoading {
-			modal = m.renderAppDeleteLoadingModal()
-		} else {
-			modal = m.renderAppDeleteConfirmModal()
-		}
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Resource Delete modal (confirmation or loading state)
-	if m.state.Mode == model.ModeConfirmResourceDelete {
-		modal := ""
-		if m.state.Modals.ResourceDeleteLoading {
-			modal = m.renderResourceDeleteLoadingModal()
-		} else {
-			modal = m.renderResourceDeleteConfirmModal()
-		}
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Resource Sync modal (confirmation or loading state)
-	if m.state.Mode == model.ModeConfirmResourceSync {
-		modal := ""
-		if m.state.Modals.ResourceSyncLoading {
-			modal = m.renderResourceSyncLoadingModal()
-		} else {
-			modal = m.renderResourceSyncConfirmModal()
-		}
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Resource Action modal (loading, executing, info, or button selector)
-	if m.state.Mode == model.ModeResourceAction {
-		var modal string
-		st := m.state.Modals.ResourceAction
-		switch {
-		case st == nil || st.Loading:
-			modal = m.renderResourceActionLoadingModal()
-		case st.Executing:
-			modal = m.renderResourceActionExecutingModal()
-		case len(st.Actions) == 0:
-			modal = m.renderResourceActionInfoModal()
-		default:
-			modal = m.renderResourceActionModal()
-		}
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	if m.state.Mode == model.ModeLoading && m.state.Navigation.View != model.ViewContexts {
-		modal := m.renderInitialLoadingModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		if m.state.Diff != nil && m.state.Diff.Loading {
-			badge := m.renderSmallBadge(true, m.state.Terminal.Cols >= 72)
-			badgeLayer := lipgloss.NewLayer(badge).X(1).Y(1).Z(1)
-			modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(2)
-			return m.composeOverlay(baseLayer, badgeLayer, modalLayer)
-		}
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
-	}
-	// Show loading modal when we have no data loaded yet (initial startup or server not running)
-	// Check if we have no apps loaded (apps are the main data source)
-	hasNoData := len(m.state.Apps) == 0
 
-	if hasNoData && m.state.Mode == model.ModeNormal && m.state.Navigation.View != model.ViewContexts {
-		modal := m.renderNoServerModal()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		modalX := (m.state.Terminal.Cols - lipgloss.Width(modal)) / 2
-		modalY := (m.state.Terminal.Rows - lipgloss.Height(modal)) / 2
-		modalLayer := lipgloss.NewLayer(modal).X(modalX).Y(modalY).Z(1)
-		return m.composeOverlay(baseLayer, modalLayer)
+	base := baseView
+	if ov.desaturate {
+		base = desaturateANSI(baseView)
 	}
-	if m.state.Diff != nil && m.state.Diff.Loading {
-		spinner := m.renderDiffLoadingSpinner()
-		grayBase := desaturateANSI(baseView)
-		baseLayer := lipgloss.NewLayer(grayBase)
-		spinnerLayer := lipgloss.NewLayer(spinner).
-			X((m.state.Terminal.Cols - lipgloss.Width(spinner)) / 2).
-			Y((m.state.Terminal.Rows - lipgloss.Height(spinner)) / 2).
-			Z(1)
-		return m.composeOverlay(baseLayer, spinnerLayer)
+	layers := []*lipgloss.Layer{lipgloss.NewLayer(base)}
+	layers = append(layers, ov.extraLayers...)
+
+	modalX := (m.state.Terminal.Cols - lipgloss.Width(ov.modal)) / 2
+	modalY := (m.state.Terminal.Rows - lipgloss.Height(ov.modal)) / 2
+	// Modal sits above any extra layers (badges, etc.) the spec carries.
+	modalZ := 1
+	if len(ov.extraLayers) > 0 {
+		modalZ = 2
 	}
-	return baseView
+	layers = append(layers, lipgloss.NewLayer(ov.modal).X(modalX).Y(modalY).Z(modalZ))
+
+	return m.composeOverlay(layers...)
 }
 
 // composeOverlay composites the given layers onto a full-screen canvas and

--- a/cmd/app/view_lists.go
+++ b/cmd/app/view_lists.go
@@ -214,6 +214,14 @@ func (m *Model) renderListHeader() string {
 func (m *Model) renderAppRow(app model.App, isCursor bool) string {
 	// Selection checking (matches ListView isChecked logic)
 	isSelected := m.state.Selections.HasSelectedApp(app.Name)
+	// While a desaturating modal is up, suppress the cursor-only highlight
+	// so unrelated rows don't appear bright behind the popup. Truly
+	// selected rows still keep their bg so the user can see what's
+	// being acted on.
+	desaturating := m.willDesaturateBase()
+	if desaturating {
+		isCursor = false
+	}
 	active := isCursor || isSelected
 
 	// Get project name (for future use)
@@ -275,8 +283,11 @@ func (m *Model) renderAppRow(app model.App, isCursor bool) string {
 		row = clipAnsiToWidth(row, fullRowWidth)
 	}
 
-	// Check if this app should flash (refresh feedback)
-	isFlashing := m.state.UI.RefreshFlashApps != nil && m.state.UI.RefreshFlashApps[app.Name]
+	// Check if this app should flash (refresh feedback). Suppress
+	// flash highlight while a desaturating modal is up — a transient
+	// success-color flash on an unrelated row reads as "this random
+	// app is highlighted" against the dimmed base.
+	isFlashing := m.state.UI.RefreshFlashApps != nil && m.state.UI.RefreshFlashApps[app.Name] && !desaturating
 
 	// Apply highlight: use a distinct style when cursor overlaps a selected row
 	if isFlashing {
@@ -307,6 +318,9 @@ func (m *Model) renderSimpleRow(label string, isCursor bool) string {
 		isSelected = m.state.Selections.HasProject(label)
 	}
 
+	if m.willDesaturateBase() {
+		isCursor = false
+	}
 	active := isCursor || isSelected
 
 	// Calculate available width for simple rows (full content width minus padding)

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -89,12 +89,9 @@ func (m *Model) renderHelpModal() string {
 
 func (m *Model) renderDiffLoadingSpinner() string {
 	spinnerContent := fmt.Sprintf("%s Loading diff...", m.spinner.View())
-	spinnerFG := ensureContrastingForeground(spinnerBG, whiteBright)
 	spinnerStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(yellowBright).
-		Background(spinnerBG).
-		Foreground(spinnerFG).
 		Padding(1, 2).
 		Bold(true).
 		Align(lipgloss.Center)
@@ -105,12 +102,9 @@ func (m *Model) renderDiffLoadingSpinner() string {
 // renderTreeLoadingSpinner displays a centered loading spinner for resources/tree operations
 func (m *Model) renderTreeLoadingSpinner() string {
 	spinnerContent := fmt.Sprintf("%s Loading resources...", m.spinner.View())
-	spinnerFG := ensureContrastingForeground(spinnerBG, whiteBright)
 	spinnerStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(cyanBright).
-		Background(spinnerBG).
-		Foreground(spinnerFG).
 		Padding(1, 2).
 		Bold(true).
 		Align(lipgloss.Center)

--- a/cmd/app/view_modals.go
+++ b/cmd/app/view_modals.go
@@ -526,7 +526,7 @@ func (m *Model) renderAppDeleteConfirmModal() string {
 	// Modal width: compact and centered (like sync modal)
 	half := m.state.Terminal.Cols / 2
 	modalWidth := min(max(36, half), m.state.Terminal.Cols-6)
-	innerWidth := max(0, modalWidth-4) // border(2)+padding(2)
+	innerWidth := max(0, modalWidth-6) // border(2) + padding(2*2)
 
 	// Message: make all title text bright and readable
 	var titleLine string
@@ -645,7 +645,7 @@ func (m *Model) renderResourceDeleteConfirmModal() string {
 	// Modal width: compact and centered (like sync modal)
 	half := m.state.Terminal.Cols / 2
 	modalWidth := min(max(36, half), m.state.Terminal.Cols-6)
-	innerWidth := max(0, modalWidth-4) // border(2)+padding(2)
+	innerWidth := max(0, modalWidth-6) // border(2) + padding(2*2)
 
 	// Message: make all title text bright and readable
 	var titleLine string
@@ -779,7 +779,7 @@ func (m *Model) renderResourceSyncConfirmModal() string {
 	// Modal width: compact and centered (like sync modal)
 	half := m.state.Terminal.Cols / 2
 	modalWidth := min(max(36, half), m.state.Terminal.Cols-6)
-	innerWidth := max(0, modalWidth-4) // border(2)+padding(2)
+	innerWidth := max(0, modalWidth-6) // border(2) + padding(2*2)
 
 	// Message: make all title text bright and readable
 	var titleLine string
@@ -898,7 +898,7 @@ func (m *Model) renderResourceActionModal() string {
 	// Modal width: compact and centered (like sync modal)
 	half := m.state.Terminal.Cols / 2
 	modalWidth := min(max(36, half), m.state.Terminal.Cols-6)
-	innerWidth := max(0, modalWidth-4) // border(2)+padding(2)
+	innerWidth := max(0, modalWidth-6) // border(2) + padding(2*2)
 
 	center := lipgloss.NewStyle().Width(innerWidth).Align(lipgloss.Center)
 	dim := lipgloss.NewStyle().Foreground(dimColor)
@@ -923,12 +923,18 @@ func (m *Model) renderResourceActionModal() string {
 		}
 	}
 	btnWidth := maxName + 4
-	active := lipgloss.NewStyle().Background(syncedColor).Foreground(textOnDanger).Bold(true).Padding(0, 2).Width(btnWidth).Align(lipgloss.Center)
-	inactive := lipgloss.NewStyle().Background(inactiveBG).Foreground(inactiveFG).Padding(0, 2).Width(btnWidth).Align(lipgloss.Center)
 
-	// Highlight styles for the matched type-ahead prefix. Each one inherits
-	// the parent button's background so the highlight overlays cleanly
-	// instead of punching a transparent hole through the colored cell.
+	// Render each button as a SINGLE styled block: pre-pad the label to
+	// btnWidth and then style the whole thing in one Render call. This
+	// avoids lipgloss emitting multiple adjacent bg-styled segments
+	// (`[bg]center-pad[/bg][bg]padding[/bg][bg]text[/bg]…`) which some
+	// terminals render with visible seams — the bug shows up as right-
+	// column buttons appearing narrower than left-column ones.
+	activeBase := lipgloss.NewStyle().Background(syncedColor).Foreground(textOnDanger).Bold(true)
+	inactiveBase := lipgloss.NewStyle().Background(inactiveBG).Foreground(inactiveFG)
+	// Underline highlight for the matched type-ahead prefix. Inherits
+	// the active button's bg so the underline doesn't punch a transparent
+	// hole through the colored cell.
 	matchHLActive := lipgloss.NewStyle().Background(syncedColor).Foreground(textOnDanger).Bold(true).Underline(true)
 
 	prefixLen := 0
@@ -937,21 +943,43 @@ func (m *Model) renderResourceActionModal() string {
 		prefixLen = len(st.Filter)
 	}
 
+	// padToCenter centers raw text in n columns using plain spaces. The
+	// caller will style the full padded string as one bg-colored run.
+	padToCenter := func(text string, n int) string {
+		w := lipgloss.Width(text)
+		if w >= n {
+			return text
+		}
+		left := (n - w) / 2
+		right := n - w - left
+		return strings.Repeat(" ", left) + text + strings.Repeat(" ", right)
+	}
+
 	rendered := make([]string, len(st.Actions))
 	widths := make([]int, len(st.Actions))
 	for i, name := range st.Actions {
 		isSel := i == st.SelectedIdx
-		var label string
-		if isSel && prefixLen > 0 && prefixLen <= len(name) {
-			label = matchHLActive.Render(name[:prefixLen]) + name[prefixLen:]
-		} else {
-			label = name
-		}
 		var btn string
-		if isSel {
-			btn = active.Render(label)
+		if isSel && prefixLen > 0 && prefixLen <= len(name) {
+			// Selected with prefix highlight: split into 3 styled runs
+			// (left bg-pad, underlined-prefix, suffix+bg-pad) but each
+			// run is a single contiguous styled block.
+			suffix := name[prefixLen:]
+			contentW := btnWidth // total cell width including padding
+			textW := lipgloss.Width(name)
+			leftPad := (contentW - textW) / 2
+			rightPad := contentW - textW - leftPad
+			leftPart := activeBase.Render(strings.Repeat(" ", leftPad))
+			matchPart := matchHLActive.Render(name[:prefixLen])
+			rightPart := activeBase.Render(suffix + strings.Repeat(" ", rightPad))
+			btn = leftPart + matchPart + rightPart
 		} else {
-			btn = inactive.Render(label)
+			padded := padToCenter(name, btnWidth)
+			if isSel {
+				btn = activeBase.Render(padded)
+			} else {
+				btn = inactiveBase.Render(padded)
+			}
 		}
 		rendered[i] = btn
 		widths[i] = lipgloss.Width(btn)

--- a/cmd/app/view_utils.go
+++ b/cmd/app/view_utils.go
@@ -21,7 +21,15 @@ func clipAnsiToWidth(s string, width int) string {
 		}
 		b.WriteRune(r)
 	}
-	return b.String()
+	out := b.String()
+	// If the clipped portion contains an opening SGR with no trailing
+	// reset, append one. Otherwise the active fg/bg bleeds onto the
+	// next visual line — visible as a selected-row highlight or status
+	// color carrying past the clip point.
+	if strings.Contains(out, "\x1b[") && !strings.HasSuffix(out, "\x1b[0m") && !strings.HasSuffix(out, "\x1b[m") {
+		out += "\x1b[m"
+	}
+	return out
 }
 
 // wrapAnsiToWidth wraps a string into visual lines that fit the given width (ANSI-aware)

--- a/pkg/tui/treeview/treeview.go
+++ b/pkg/tui/treeview/treeview.go
@@ -583,7 +583,7 @@ func (v *TreeView) Render() string {
 			ps := lipgloss.NewStyle().Foreground(v.palette.Text).Background(flashBG).Render(prefix + disc)
 			ks := lipgloss.NewStyle().Foreground(v.palette.Text).Background(flashBG).Render(n.kind)
 			ns := lipgloss.NewStyle().Foreground(v.palette.DarkBG).Background(flashBG).Render("[" + name + "]")
-			st := v.renderStatusPartWithBG(n, flashBG)
+			st := v.renderStatusPartNeutralBG(n, flashBG)
 			sp := bgStyle.Render(" ")
 			line = ps + ks + sp + ns + sp + st
 			line = padRightWithBG(line, v.innerWidth(), flashBG)
@@ -600,10 +600,16 @@ func (v *TreeView) Render() string {
 				bgStyle := lipgloss.NewStyle().Background(rowBG)
 				// Prefix rendered WITHOUT background (will be dimmed by desaturateANSI)
 				ps := lipgloss.NewStyle().Foreground(v.palette.Text).Render(prefix + disc)
-				// Only resource text (kind, name, status) gets background
+				// Only resource text (kind, name, status) gets background.
+				// In desaturate mode the row's status uses the neutral
+				// text color rather than status hues — otherwise the
+				// green/red fg survives our outer per-segment preserve
+				// logic (the bg keeps the segment, but the saturated fg
+				// rides along) and "(Healthy)" / "(OutOfSync)" stay
+				// brightly colored under a popup.
 				ks := lipgloss.NewStyle().Foreground(v.palette.Text).Background(rowBG).Render(n.kind)
 				ns := lipgloss.NewStyle().Foreground(v.palette.DarkBG).Background(rowBG).Render("[" + name + "]")
-				st := v.renderStatusPartWithBG(n, rowBG)
+				st := v.renderStatusPartNeutralBG(n, rowBG)
 				sp := bgStyle.Render(" ")
 				line = ps + ks + sp + ns + sp + st
 				// NO padRightWithBG - don't extend highlight to full width
@@ -632,7 +638,11 @@ func (v *TreeView) Render() string {
 				ps := lipgloss.NewStyle().Foreground(v.palette.Text).Background(rowBG).Render(prefix + disc)
 				ks := lipgloss.NewStyle().Foreground(v.palette.Text).Background(rowBG).Render(n.kind)
 				ns := lipgloss.NewStyle().Foreground(v.palette.DarkBG).Background(rowBG).Render("[" + name + "]")
-				st := v.renderStatusPartWithBG(n, rowBG)
+				// Use the inverted/neutral fg for status too. The
+				// natural status hue (e.g. yellow for Suspended) can
+				// blend into rowBG and make the text disappear when
+				// the row is hovered/selected.
+				st := v.renderStatusPartNeutralBG(n, rowBG)
 				sp := bgStyle.Render(" ")
 				line = ps + ks + sp + ns + sp + st
 				line = padRightWithBG(line, v.innerWidth(), rowBG)
@@ -647,7 +657,7 @@ func (v *TreeView) Render() string {
 				ps := lipgloss.NewStyle().Foreground(v.palette.Text).Background(matchBG).Render(prefix + disc)
 				ks := lipgloss.NewStyle().Foreground(v.palette.DarkBG).Background(matchBG).Render(n.kind)
 				ns := lipgloss.NewStyle().Foreground(v.palette.DarkBG).Background(matchBG).Render("[" + name + "]")
-				st := v.renderStatusPartWithBG(n, matchBG)
+				st := v.renderStatusPartNeutralBG(n, matchBG)
 				sp := bgStyle.Render(" ")
 				line = ps + ks + sp + ns + sp + st
 				line = padRightWithBG(line, v.innerWidth(), matchBG)
@@ -699,26 +709,27 @@ func (v *TreeView) renderStatusPart(n *treeNode) string {
 	return ""
 }
 
-// renderStatusPartWithBG returns styled status string with a background color
-func (v *TreeView) renderStatusPartWithBG(n *treeNode, bg color.Color) string {
+// renderStatusPartNeutralBG renders the status with a contrasting,
+// non-status-hue foreground over the given background. Used when the
+// row already conveys highlight via bg — keeping the status fg in its
+// natural green/red/yellow either makes the text unreadable against
+// the highlight bg, or (under a desaturating modal overlay) leaves a
+// saturated patch that survives outer dimming. Mirrors the contrast
+// treatment used for the "[name]" portion of selected rows.
+func (v *TreeView) renderStatusPartNeutralBG(n *treeNode, bg color.Color) string {
 	health := n.health
 	sync := n.status
 
-	bgStyle := lipgloss.NewStyle().Background(bg)
+	textStyle := lipgloss.NewStyle().Foreground(v.palette.DarkBG).Background(bg)
 
-	// Both present and different: show both
 	if health != "" && sync != "" && !strings.EqualFold(health, sync) {
-		healthStyled := v.statusStyle(health).Background(bg).Render(health)
-		syncStyled := v.statusStyle(sync).Background(bg).Render(sync)
-		return bgStyle.Render("(") + healthStyled + bgStyle.Render(", ") + syncStyled + bgStyle.Render(")")
+		return textStyle.Render(fmt.Sprintf("(%s, %s)", health, sync))
 	}
-	// Only health present (or both same)
 	if health != "" {
-		return bgStyle.Render("(") + v.statusStyle(health).Background(bg).Render(health) + bgStyle.Render(")")
+		return textStyle.Render(fmt.Sprintf("(%s)", health))
 	}
-	// Only sync present
 	if sync != "" {
-		return bgStyle.Render("(") + v.statusStyle(sync).Background(bg).Render(sync) + bgStyle.Render(")")
+		return textStyle.Render(fmt.Sprintf("(%s)", sync))
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- Desaturated base view under modal overlays was leaking saturated colours back through. Multiple independent causes; fixes split into four commits.
- `(Healthy)` / `(OutOfSync)` stayed bright on the dimmed base on themes whose status truecolor RGB happened to land on certain byte ranges (nord, solarized-light, monokai, tokyo-night, …).
- Apps list cursor row + refresh-flash row stayed highlighted under a sync modal, reading as "this random app is being synced".
- Resource-action modal right-column buttons rendered ~2 cells short, looking cut off.

## Commits
1. **`fix(modals): correct inner content width and render action buttons cleanly`** — `innerWidth = modalWidth-4` was off by 2 (border 2 + padding 4 = 6); the rightmost column overflowed. Resource-action buttons now render as a single bg-styled run instead of multi-segment width+padding to avoid terminal-side seams.
2. **`fix(ui): close open SGR runs when clipping styled lines`** — `clipAnsiToWidth` could leave an active fg/bg without a trailing reset; the styling bled onto the next visual line (visible as a selection highlight or status colour spilling across an empty line).
3. **`fix(treeview): use neutral fg for status text under bg highlights`** — selected / cursor / search-match / refresh-flash rows now render the status with `palette.DarkBG` over the row bg (mirroring what `[name]` already does). Without this, saturated status fg either blends into the row bg (e.g. yellow Suspended on Warning bg becomes invisible) or survives the outer desaturation pass and shows through the modal.
4. **`fix(ui): properly desaturate base view under modal overlays`** — three subfixes:
   - process the base view per ANSI segment (split on SGR resets) so a single styled span on a line doesn't cause the whole line to be skipped.
   - replace the bg-detection regex with `segmentHasBgColor`, which actually parses the SGR parameter list. The old regex's `[0-9;]*;` group could greedily eat most of a `38;2;R;G;B` truecolor fg and leave just the B byte, false-matching as bright-bg `10[0-7]m` for B in 100-107 or basic-bg `4[0-7]m` for B in 40-47. This is the root cause of the per-theme regressions reported during the back-and-forth (nord Danger 191;97;**106**, monokai Success 166;226;**46**, solarized-light Danger 220;50;**47**, tokyo-storm Success 158;206;**106**, …).
   - suppress cursor and refresh-flash bg highlights on the apps list while a desaturating modal is up. Truly selected rows still keep their bg so the user can see what's being acted on.

## Test plan
- [x] `go test ./...` (full suite) — green
- [x] `TestDesaturateANSI_AllPaletteColorsCollapseToDim` — exhaustive matrix: every shipped theme × every palette colour, asserts the surviving fg SGR after desaturation matches the theme's dim SGR. Verified to fail on the broken regex (caught nord Danger, monokai Success, tokyo-night Warning/Success/Progress, solarized-light Danger by name with concrete SGR diffs) and pass after the SGR-parser fix.
- [x] `TestRender_TreeUnderModal_AllThemes_NoStatusColorLeak` — runs every preset, asserts theme `Success` / `Danger` truecolor SGRs do not appear in the rendered base under a sync modal.
- [x] `TestRender_AppsList_SyncModal_DesaturatesNonSelected` — cursor row no bg, selected target keeps bg, status fg dimmed on inactive rows.
- [x] `TestRender_AppsList_SyncModal_NoColorLeaks_RealTheme` — same, but with the nord theme applied so the truecolor branch is exercised.
- [x] `TestSegmentHasBgColor_TruecolorFgFalsePositives` — pinpoints each user-reported preset's offending RGB.
- [x] `TestClipAnsiToWidth_ClosesOpenSGR` — clipped output ends with a reset.
- [x] Manual smoke: `go run ./cmd/app` across nord / dracula / solarized-light / monokai / tokyo-night while opening sync / delete / resource-action modals over both apps and tree views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better ANSI handling to prevent style bleed and ensure consistent text dimming when overlays are active
  * Improved desaturation behavior for overlays and more consistent status indicator rendering and modal button visuals

* **Tests**
  * Added comprehensive regression tests for ANSI desaturation, clipping safety, and theme color behavior

* **Chores**
  * Updated golden snapshot outputs to align spacing/centering and normalize trailing-newline behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->