### PR TITLE
fix: apps-view filter is no longer forgotten when returning from resources/k9s

### DIFF
--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -429,10 +429,20 @@ func (m *Model) handleEscape() (tea.Model, tea.Cmd) {
 					}
 				}
 			}
-			// Return to apps view from tree/resources view
+			// Return to apps view from tree/resources view. If we have a saved
+			// navigation entry from when we drilled in, restore the apps-view
+			// filter so the user lands back in the same filtered context.
 			m = m.safeChangeView(model.ViewApps)
 			m.clearTreeApp()
 			m.state.Navigation.SelectedIdx = 0
+			if n := len(m.state.SavedNavigation); n > 0 {
+				top := m.state.SavedNavigation[n-1]
+				if top.View == model.ViewApps {
+					m.state.UI.SearchQuery = top.SavedSearchQuery
+					m.state.UI.ActiveFilter = top.SavedActiveFilter
+					m.state.SavedNavigation = m.state.SavedNavigation[:n-1]
+				}
+			}
 		case model.ViewApps:
 			// Check if scoped by ApplicationSet (separate hierarchy)
 			if len(m.state.Selections.ScopeApplicationSets) > 0 {

--- a/e2e/filter_persistence_test.go
+++ b/e2e/filter_persistence_test.go
@@ -1,0 +1,123 @@
+//go:build e2e && unix
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFilterPersistsAfterResourcesAndK9s verifies that an apps-view filter
+// survives a round-trip into the resources (tree) view and through k9s.
+//
+// Reproduction:
+//  1. apps view, filter "dem"
+//  2. Enter on the filtered app → tree view
+//  3. K on a resource → k9s
+//  4. exit k9s, Esc back to apps view
+//  5. filter must still be visible
+func TestFilterPersistsAfterResourcesAndK9s(t *testing.T) {
+	t.Parallel()
+	tf := NewTUITest(t)
+	t.Cleanup(tf.Cleanup)
+
+	srv, err := MockArgoServerWithResources()
+	if err != nil {
+		t.Fatalf("mock server: %v", err)
+	}
+	t.Cleanup(srv.Close)
+
+	cfgPath, err := tf.SetupWorkspace()
+	if err != nil {
+		t.Fatalf("setup workspace: %v", err)
+	}
+	if err := WriteArgoConfig(cfgPath, srv.URL); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	mockK9s, _ := createMockK9s(t, tf.workspace, 0)
+	kubeconfigPath := setupSingleContextKubeconfig(t, tf.workspace, "cluster-a")
+
+	if err := tf.StartAppArgs([]string{"-argocd-config=" + cfgPath},
+		"ARGONAUT_K9S_COMMAND="+mockK9s,
+		"KUBECONFIG="+kubeconfigPath,
+	); err != nil {
+		t.Fatalf("start app: %v", err)
+	}
+
+	if !tf.WaitForPlain("cluster-a", 5*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("clusters not visible")
+	}
+
+	// Navigate to apps view.
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatalf("open command: %v", err)
+	}
+	_ = tf.Send("apps")
+	_ = tf.Enter()
+
+	if !tf.WaitForPlain("demo", 5*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("apps view did not load")
+	}
+
+	// Apply filter "dem".
+	if err := tf.OpenSearch(); err != nil {
+		t.Fatalf("open search: %v", err)
+	}
+	_ = tf.Send("dem")
+	_ = tf.Enter()
+
+	// Filter chip in the status bar is rendered as "<apps:dem>".
+	if !tf.WaitForScreen("<apps:dem>", 3*time.Second) {
+		t.Log(tf.Screen())
+		t.Fatal("filter chip <apps:dem> not visible after applying filter")
+	}
+
+	// Open resources for the (now filtered) app.
+	_ = tf.Enter()
+
+	if !tf.WaitForPlain("Application [demo]", 5*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("tree view did not load")
+	}
+
+	// Drill into a resource and launch k9s. Kubeconfig context name matches
+	// the ArgoCD cluster name ("cluster-a"), so the picker is skipped.
+	_ = tf.Send("jK")
+
+	if !tf.WaitForPlain("Mock k9s", 5*time.Second) {
+		t.Log(tf.SnapshotPlain())
+		t.Fatal("mock k9s did not launch")
+	}
+
+	// Mock k9s exits after ~0.2s. Wait for argonaut to regain input routing
+	// (confirmed by being able to open the command bar) before sending Esc.
+	if err := tf.OpenCommand(); err != nil {
+		t.Fatalf("argonaut input not restored after k9s: %v", err)
+	}
+	_ = tf.Send("\x1b") // close command bar
+	// Global 100ms esc debounce — wait it out before the next esc.
+	time.Sleep(150 * time.Millisecond)
+
+	// Esc back to apps view.
+	_ = tf.Send("\x1b")
+
+	// We're back in apps view AND filter should still be applied.
+	// WaitForPlain scans the cumulative output ring, which includes stale
+	// "<apps:dem>" frames from before the tree view. Re-render by toggling
+	// search mode briefly, then assert against the live screen.
+	deadline := time.Now().Add(3 * time.Second)
+	var screen string
+	for time.Now().Before(deadline) {
+		screen = tf.Screen()
+		if strings.Contains(screen, "<apps:dem>") {
+			return // pass
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Log(screen)
+	t.Fatal("filter <apps:dem> was lost after returning from tree view")
+}

--- a/pkg/model/state.go
+++ b/pkg/model/state.go
@@ -24,6 +24,11 @@ type NavigationState struct {
 	LastEscPressed int64        `json:"lastEscPressed"`
 	LastZPressed   int64        `json:"lastZPressed"`
 	TreeApp        *TreeAppInfo `json:"treeApp,omitempty"`
+	// SavedSearchQuery / SavedActiveFilter only apply to entries stored on
+	// AppState.SavedNavigation — they capture the UI filter state at the
+	// moment we drilled into a child view, so Escape can restore it.
+	SavedSearchQuery  string `json:"savedSearchQuery,omitempty"`
+	SavedActiveFilter string `json:"savedActiveFilter,omitempty"`
 }
 
 // SelectionState holds selection-related state using map[string]bool for sets
@@ -240,12 +245,14 @@ type DiffState struct {
 // Used before navigating into a child view so Escape can pop back.
 func (s *AppState) SaveNavigationState() {
 	s.SavedNavigation = append(s.SavedNavigation, NavigationState{
-		View:             s.Navigation.View,
-		SelectedIdx:      s.Navigation.SelectedIdx,
-		LastGPressed:     s.Navigation.LastGPressed,
-		LastEscPressed:   s.Navigation.LastEscPressed,
-		LastZPressed:     s.Navigation.LastZPressed,
-		TreeApp: s.UI.TreeApp,
+		View:              s.Navigation.View,
+		SelectedIdx:       s.Navigation.SelectedIdx,
+		LastGPressed:      s.Navigation.LastGPressed,
+		LastEscPressed:    s.Navigation.LastEscPressed,
+		LastZPressed:      s.Navigation.LastZPressed,
+		TreeApp:           s.UI.TreeApp,
+		SavedSearchQuery:  s.UI.SearchQuery,
+		SavedActiveFilter: s.UI.ActiveFilter,
 	})
 	s.SavedSelections = &SelectionState{
 		ScopeClusters:        copyStringSet(s.Selections.ScopeClusters),


### PR DESCRIPTION
## Summary

- After filtering the apps list, opening an app's resources, drilling into k9s and escaping back to apps, the filter was silently cleared. Restore it on the way back.
- `handleEscape` unconditionally wiped `UI.SearchQuery` / `UI.ActiveFilter` when leaving any non-apps view, and `SaveNavigationState` didn't capture the filter — so there was nothing to restore.
- Capture the filter onto `SavedNavigation` entries and reapply it in the `ViewTree → ViewApps` escape branch (also pops the matching saved entry to keep the stack bounded).

## Test plan

- [x] New e2e test `TestFilterPersistsAfterResourcesAndK9s` exercises the full filter → resources → k9s → esc round-trip. Verified red on `main`, green after fix.
- [x] Existing related e2e tests still pass (`TestK9s_*`, `TestTreeView*`, `TestContextSwitch*`, `TestSearchInputAcceptsAllCharacters`).
- [x] Full unit suite (`go test ./...`) green.
- [ ] Manual smoke: filter apps → Enter into resources → `K` into k9s → exit k9s → Esc — filter chip `<apps:…>` should still be visible.
- [ ] Manual smoke: filter apps → Esc once (no drill-down) — filter still clears on first Esc (existing edge case preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filters and search queries are now preserved when returning to the apps view from resource or tree views.

* **Tests**
  * Added end-to-end test verifying filter persistence after navigation and external actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/darksworm/argonaut/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->