### PR TITLE
ci: publish argonaut-git AUR package on push to main

### DIFF
--- a/.github/workflows/aur-git-publish.yml
+++ b/.github/workflows/aur-git-publish.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Compute pkgver
         id: ver

--- a/.github/workflows/aur-git-publish.yml
+++ b/.github/workflows/aur-git-publish.yml
@@ -1,0 +1,65 @@
+name: aur-git-publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: aur-git-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'darksworm/argonaut'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute pkgver
+        id: ver
+        run: |
+          set -euo pipefail
+          # Match the pkgver() logic in packaging/aur/argonaut-git/PKGBUILD:
+          # v2.17.0-3-gabc1234 -> 2.17.0.r3.gabc1234
+          if pkgver=$(git describe --long --tags --abbrev=7 2>/dev/null); then
+            pkgver=$(echo "$pkgver" | sed 's/^v//; s/\([^-]*-g\)/r\1/; s/-/./g')
+          else
+            pkgver="r$(git rev-list --count HEAD).$(git rev-parse --short=7 HEAD)"
+          fi
+          echo "pkgver=$pkgver" >> "$GITHUB_OUTPUT"
+          echo "Computed pkgver: $pkgver"
+
+      - name: Render PKGBUILD with concrete pkgver
+        run: |
+          set -euo pipefail
+          mkdir -p dist/aur
+          # Inject the computed pkgver as a static value so AUR helpers detect
+          # updates without rebuilding. The dynamic pkgver() function is retained
+          # so the package still works for users building straight from AUR.
+          sed -E 's/^pkgver=.*/pkgver=${{ steps.ver.outputs.pkgver }}/' \
+            packaging/aur/argonaut-git/PKGBUILD > dist/aur/PKGBUILD
+          echo "--- rendered PKGBUILD ---"
+          cat dist/aur/PKGBUILD
+
+      - name: Publish to AUR
+        if: env.AUR_SSH_PRIVATE_KEY != ''
+        uses: KSXGitHub/github-actions-deploy-aur@v2.7.2
+        with:
+          pkgname: argonaut-git
+          pkgbuild: dist/aur/PKGBUILD
+          commit_username: goreleaser
+          commit_email: bot@goreleaser.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "upgpkg: argonaut-git ${{ steps.ver.outputs.pkgver }}-1"
+          updpkgsums: false
+          test: false
+          force_push: false
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ brew install darksworm/tap/argonaut
 ```bash
 yay -S argonaut-bin
 ```
+
+Or, to track the latest commit on `main` (rebuilt from source on install):
+
+```bash
+yay -S argonaut-git
+```
 </details>
 
 <details>

--- a/packaging/aur/argonaut-git/PKGBUILD
+++ b/packaging/aur/argonaut-git/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: darksworm <https://github.com/darksworm>
+pkgname=argonaut-git
+_pkgname=argonaut
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="A GitOps CLI tool for managing ArgoCD applications (git version)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/darksworm/argonaut"
+license=('GPL-3.0-or-later')
+depends=('glibc')
+makedepends=('go' 'git')
+provides=("${_pkgname}")
+conflicts=("${_pkgname}" "${_pkgname}-bin")
+source=("${_pkgname}::git+https://github.com/darksworm/argonaut.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${_pkgname}"
+    # e.g. v2.17.0-3-gabc1234 -> 2.17.0.r3.gabc1234
+    git describe --long --tags --abbrev=7 2>/dev/null \
+        | sed 's/^v//; s/\([^-]*-g\)/r\1/; s/-/./g' \
+        || printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+}
+
+build() {
+    cd "${_pkgname}"
+    export CGO_ENABLED=0
+    export GOFLAGS="-trimpath -mod=readonly -modcacherw"
+    export LDFLAGS="${LDFLAGS} -s -w -X main.appVersion=${pkgver}"
+    go build -ldflags "${LDFLAGS}" -o "${_pkgname}" ./cmd/app
+}
+
+package() {
+    cd "${_pkgname}"
+    install -Dm755 "${_pkgname}" "${pkgdir}/usr/bin/${_pkgname}"
+    install -Dm644 LICENSE     "${pkgdir}/usr/share/licenses/${_pkgname}/LICENSE"
+    install -Dm644 README.md   "${pkgdir}/usr/share/doc/${_pkgname}/README.md"
+    [ -f CHANGELOG.md ] && install -Dm644 CHANGELOG.md "${pkgdir}/usr/share/doc/${_pkgname}/CHANGELOG.md"
+    return 0
+}

--- a/packaging/aur/argonaut-git/PKGBUILD
+++ b/packaging/aur/argonaut-git/PKGBUILD
@@ -26,8 +26,7 @@ build() {
     cd "${_pkgname}"
     export CGO_ENABLED=0
     export GOFLAGS="-trimpath -mod=readonly -modcacherw"
-    export LDFLAGS="${LDFLAGS} -s -w -X main.appVersion=${pkgver}"
-    go build -ldflags "${LDFLAGS}" -o "${_pkgname}" ./cmd/app
+    go build -ldflags "-s -w -X main.appVersion=${pkgver}" -o "${_pkgname}" ./cmd/app
 }
 
 package() {

--- a/packaging/aur/argonaut-git/README.md
+++ b/packaging/aur/argonaut-git/README.md
@@ -1,0 +1,30 @@
+# argonaut-git AUR package
+
+Tracks `main` of https://github.com/darksworm/argonaut. Rebuilds from HEAD on every install.
+
+## Publishing to AUR (one-time)
+
+```sh
+# 1. Clone the empty AUR repo (after creating the package page on aur.archlinux.org)
+git clone ssh://aur@aur.archlinux.org/argonaut-git.git
+cd argonaut-git
+
+# 2. Copy PKGBUILD in
+cp /path/to/argonaut/packaging/aur/argonaut-git/PKGBUILD .
+
+# 3. Generate .SRCINFO and commit
+makepkg --printsrcinfo > .SRCINFO
+git add PKGBUILD .SRCINFO
+git commit -m "initial commit: argonaut-git"
+git push
+```
+
+## Installing
+
+```sh
+yay -S argonaut-git
+# or
+paru -S argonaut-git
+```
+
+To pull the latest `main`, reinstall: `yay -S argonaut-git`.

--- a/packaging/aur/argonaut-git/README.md
+++ b/packaging/aur/argonaut-git/README.md
@@ -4,6 +4,12 @@ Tracks `main` of https://github.com/darksworm/argonaut. Rebuilds from HEAD on ev
 
 ## Publishing to AUR (one-time)
 
+> **Do not re-run these steps for routine updates.** They are only for the
+> initial package setup. Subsequent `pkgver` bumps and pushes are performed
+> automatically by `.github/workflows/aur-git-publish.yml` on every push to
+> `main`. To ship a change, merge it to `main` — do not push to the AUR repo
+> by hand.
+
 ```sh
 # 1. Clone the empty AUR repo (after creating the package page on aur.archlinux.org)
 git clone ssh://aur@aur.archlinux.org/argonaut-git.git


### PR DESCRIPTION
## Summary
- Adds a static `-git` PKGBUILD at `packaging/aur/argonaut-git/PKGBUILD` so users can install argonaut tracking `main` via `yay -S argonaut-git`.
- Adds `.github/workflows/aur-git-publish.yml` that, on every push to `main`, recomputes `pkgver` from `git describe` (matching the PKGBUILD's `pkgver()` format), rewrites the `pkgver=` line, and publishes to `ssh://aur@aur.archlinux.org/argonaut-git.git` via `KSXGitHub/github-actions-deploy-aur`. Reuses the existing `AUR_SSH_PRIVATE_KEY` secret.
- README documents the one-time manual step of creating the AUR package page; everything after that is CI-driven.

## Test plan
- [ ] Manually create the `argonaut-git` page on aur.archlinux.org and push the initial PKGBUILD/.SRCINFO (per `packaging/aur/argonaut-git/README.md`).
- [ ] Confirm the workflow's `Compute pkgver` step produces a sane value on a real push (visible in the workflow log).
- [ ] After first successful CI push, verify `yay -S argonaut-git` builds and installs cleanly, `argonaut --version` reflects the git-derived pkgver, and `conflicts=` correctly blocks coexistence with `argonaut-bin`.
- [ ] Verify `pacman -Syu` picks up subsequent main pushes as updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application is now available on Arch User Repository (AUR), installable via package managers like yay and paru.

* **Chores**
  * Configured automated publishing to AUR on every push to the main branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/darksworm/argonaut/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->