### PR TITLE
fix: deliver buffered watch event when stream ends

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -307,8 +307,19 @@ func (m *Model) consumeWatchEvents() tea.Cmd {
 				return nil
 			}
 		case <-done:
-			cblog.With("component", "watch").Debug("consumeWatchEvents: watchDone signaled")
-			return nil
+			// done and a buffered event can be ready at the same time (a
+			// stream that emits and then ends); select picks randomly, so
+			// drain the channel before treating the watch as finished.
+			select {
+			case ev, ok = <-ch:
+				if !ok {
+					cblog.With("component", "watch").Debug("consumeWatchEvents: watchChan closed")
+					return nil
+				}
+			default:
+				cblog.With("component", "watch").Debug("consumeWatchEvents: watchDone signaled")
+				return nil
+			}
 		}
 
 		result := classifyWatchEvent(ev, epoch)

--- a/cmd/app/batch_watch_test.go
+++ b/cmd/app/batch_watch_test.go
@@ -244,6 +244,40 @@ func TestConsumeWatchEvents_TimerFlushes(t *testing.T) {
 	}
 }
 
+// A stream that delivers an event and then ends (EOF) leaves the event
+// buffered in watchChan while watchDone is already closed. The consumer
+// must drain the buffered event instead of racing the done signal —
+// otherwise the last update of a stream is silently lost.
+func TestConsumeWatchEvents_DeliversBufferedEventWhenWatchAlreadyEnded(t *testing.T) {
+	oldDrain := watchBatchDrain
+	watchBatchDrain = time.Millisecond
+	t.Cleanup(func() { watchBatchDrain = oldDrain })
+
+	// The select between watchChan and watchDone picks randomly when both
+	// are ready, so a single run can pass by luck; require every run to
+	// deliver.
+	for i := 0; i < 50; i++ {
+		ch := make(chan services.ArgoApiEvent, 1)
+		done := make(chan struct{})
+		ch <- services.ArgoApiEvent{
+			Type: "app-updated",
+			App:  &model.App{Name: "demo", Sync: "OutOfSync"},
+		}
+		close(done)
+
+		m := &Model{watchChan: ch, watchDone: done}
+		msg := m.consumeWatchEvents()()
+
+		batch, ok := msg.(model.AppsBatchUpdateMsg)
+		if !ok {
+			t.Fatalf("iteration %d: buffered event dropped, got %T", i, msg)
+		}
+		if len(batch.Updates) != 1 || batch.Updates[0].App.Sync != "OutOfSync" {
+			t.Fatalf("iteration %d: unexpected batch %+v", i, batch)
+		}
+	}
+}
+
 func TestConsumeWatchEvents_NilChannel(t *testing.T) {
 	m := &Model{watchChan: nil}
 


### PR DESCRIPTION
When a watch stream emits an event and then ends, the event sits buffered in `watchChan` while `watchDone` is already closed — `consumeWatchEvents`'s select picks between them randomly, and picking `done` silently drops the last update. Root cause of the flaky `TestStreamingAppliesUpdates` e2e test (~65% fail at `-count=20 -parallel 20`, now 20/20).

Fix: drain the buffered event before treating the watch as finished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented watch updates from being lost when a stream ends while an event is still buffered.
  * Ensured pending updates are delivered reliably during stream shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->