### PR TITLE
fix: reconnect watch stream after it ends

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -34,7 +34,7 @@ func (m *Model) startLoadingApplications() tea.Cmd {
 		}
 	}
 
-	epoch := m.switchEpoch // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		cblog.With("component", "api_integration").Info("startLoadingApplications: executing load")
@@ -112,6 +112,33 @@ var watchBatchDrain = func() time.Duration {
 type watchScopeDebounceMsg struct {
 	version int
 }
+
+// watchEndedMsg indicates the watch stream ended (EOF) with no replacement
+// pending. Carries the identity of the ended watch so receivers can ignore
+// ends from superseded streams (ADR-0003).
+type watchEndedMsg struct {
+	startSequenceNum int
+	switchEpoch      int
+}
+
+// watchReconnectMsg fires after watchReconnectDelay to restart an ended
+// watch. Carries the ended watch's identity for staleness gating.
+type watchReconnectMsg struct {
+	startSequenceNum int
+	switchEpoch      int
+}
+
+// watchReconnectDelay is the pause before reconnecting an ended watch
+// stream, so a server that instantly closes streams can't drive a hot
+// reconnect loop. Overridable via ARGONAUT_WATCH_RECONNECT_DELAY for tests.
+var watchReconnectDelay = func() time.Duration {
+	if v := os.Getenv("ARGONAUT_WATCH_RECONNECT_DELAY"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			return d
+		}
+	}
+	return time.Second
+}()
 
 // startWatchingApplications starts the real-time watch stream
 func (m *Model) startWatchingApplications() tea.Cmd {
@@ -284,10 +311,12 @@ func classifyWatchEvent(ev services.ArgoApiEvent, epoch int) eventResult {
 // batch tagged with the old generation. The handler checks the generation to avoid
 // spawning duplicate consumers for the new channel.
 func (m *Model) consumeWatchEvents() tea.Cmd {
-	ch := m.watchChan        // capture at call time
-	gen := m.watchGeneration // capture at call time
-	done := m.watchDone      // capture at call time
-	epoch := m.switchEpoch   // capture at call time
+	ch := m.watchChan                 // capture at call time
+	gen := m.watchGeneration          // capture at call time
+	done := m.watchDone               // capture at call time
+	epoch := m.switchEpoch            // capture at call time
+	seq := m.watchStartSequence       // capture at call time
+	streamEnded := m.watchStreamEnded // capture at call time
 	return func() tea.Msg {
 		if ch == nil {
 			cblog.With("component", "watch").Debug("consumeWatchEvents: watchChan is nil")
@@ -318,6 +347,10 @@ func (m *Model) consumeWatchEvents() tea.Cmd {
 				}
 			default:
 				cblog.With("component", "watch").Debug("consumeWatchEvents: watchDone signaled")
+				if streamEnded != nil && streamEnded.Load() {
+					return watchEndedMsg{startSequenceNum: seq, switchEpoch: epoch}
+				}
+				// Intentional stop (cleanup) — no reconnect.
 				return nil
 			}
 		}
@@ -463,7 +496,7 @@ func (m *Model) startDiffSession(appName string, appNamespace *string) tea.Cmd {
 			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 	}
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 45*time.Second)
@@ -548,7 +581,7 @@ func (m *Model) startResourceDiffSession(res ResourceIdentifier) tea.Cmd {
 			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 	}
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 45*time.Second)
@@ -662,7 +695,7 @@ func (m *Model) startLoadingResourceTree(app model.App) tea.Cmd {
 			return model.ApiErrorMsg{Message: "No server configured"}
 		}
 	}
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
@@ -708,8 +741,8 @@ func (m *Model) startWatchingResourceTree(app model.App) tea.Cmd {
 	if m.state.Server == nil {
 		return nil
 	}
-	server := m.state.Server       // capture at call time
-	done := m.treeStreamDone       // capture at call time
+	server := m.state.Server // capture at call time
+	done := m.treeStreamDone // capture at call time
 	return func() tea.Msg {
 		ctx := context.Background()
 		apiService := services.NewArgoApiService(server)
@@ -784,7 +817,7 @@ func (m *Model) syncSelectedApplications(prune bool) tea.Cmd {
 		}
 	}
 
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		apiService := services.NewEnhancedArgoApiService(server)
@@ -833,7 +866,7 @@ func (m *Model) deleteApplication(req model.AppDeleteRequestMsg) tea.Cmd {
 		}
 	}
 
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
@@ -887,7 +920,7 @@ func (m *Model) syncSingleApplication(appName string, appNamespace *string, prun
 		}
 	}
 
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
@@ -934,7 +967,7 @@ func (m *Model) refreshSingleApplication(appName string, appNamespace *string, h
 		}
 	}
 
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
@@ -1086,7 +1119,7 @@ func (m *Model) startRollbackSession(appName string, appNamespace *string) tea.C
 			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 	}
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 30*time.Second)
@@ -1166,7 +1199,7 @@ func (m *Model) executeRollback(request model.RollbackRequest) tea.Cmd {
 			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 	}
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 60*time.Second)
@@ -1206,7 +1239,7 @@ func (m *Model) startRollbackDiffSession(appName string, appNamespace *string, r
 			return model.ApiErrorMsg{Message: "No server configured", SwitchEpoch: epoch}
 		}
 	}
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithMinAPITimeout(context.Background(), 45*time.Second)
@@ -1385,7 +1418,7 @@ func (m *Model) deleteSingleApplication(params AppDeleteParams) tea.Cmd {
 		}
 	}
 
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		ctx, cancel := appcontext.WithAPITimeout(context.Background())
@@ -1552,7 +1585,7 @@ func (m *Model) syncSelectedResources(targets []model.ResourceSyncTarget, prune,
 		appNames = append(appNames, name)
 	}
 
-	epoch := m.switchEpoch  // capture at call time
+	epoch := m.switchEpoch   // capture at call time
 	server := m.state.Server // capture at call time
 	return func() tea.Msg {
 		cblog.With("component", "resource-sync").Info("Starting resource sync",

--- a/cmd/app/batch_watch_test.go
+++ b/cmd/app/batch_watch_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -275,6 +276,133 @@ func TestConsumeWatchEvents_DeliversBufferedEventWhenWatchAlreadyEnded(t *testin
 		if len(batch.Updates) != 1 || batch.Updates[0].App.Sync != "OutOfSync" {
 			t.Fatalf("iteration %d: unexpected batch %+v", i, batch)
 		}
+	}
+}
+
+// When the stream ends and nothing is left buffered, the consumer must
+// report the end of the watch instead of letting the chain die silently —
+// the model needs that signal to reconnect.
+func TestConsumeWatchEvents_ReportsWatchEndWhenStreamEnds(t *testing.T) {
+	ch := make(chan services.ArgoApiEvent, 1)
+	done := make(chan struct{})
+	close(done)
+	streamEnded := new(atomic.Bool)
+	streamEnded.Store(true)
+
+	m := &Model{
+		watchChan:          ch,
+		watchDone:          done,
+		watchStreamEnded:   streamEnded,
+		watchStartSequence: 3,
+		switchEpoch:        2,
+	}
+	msg := m.consumeWatchEvents()()
+
+	ended, ok := msg.(watchEndedMsg)
+	if !ok {
+		t.Fatalf("expected watchEndedMsg, got %T", msg)
+	}
+	if ended.startSequenceNum != 3 {
+		t.Errorf("expected start sequence 3, got %d", ended.startSequenceNum)
+	}
+	if ended.switchEpoch != 2 {
+		t.Errorf("expected epoch 2, got %d", ended.switchEpoch)
+	}
+}
+
+// An intentional stop (cleanup during restart or context switch) is not a
+// stream end and must not be reported as one.
+func TestConsumeWatchEvents_StaysSilentWhenWatchStoppedIntentionally(t *testing.T) {
+	ch := make(chan services.ArgoApiEvent, 1)
+	done := make(chan struct{})
+	close(done)
+
+	m := &Model{
+		watchChan:        ch,
+		watchDone:        done,
+		watchStreamEnded: new(atomic.Bool), // never set: forwarder was stopped, stream did not end
+	}
+	msg := m.consumeWatchEvents()()
+
+	if msg != nil {
+		t.Fatalf("expected nil for intentionally stopped watch, got %T", msg)
+	}
+}
+
+// The end of the current watch must lead to a fresh watch start (after the
+// reconnect delay) so live updates survive a dropped stream.
+func TestWatchEndedMsg_ReconnectsCurrentWatch(t *testing.T) {
+	oldDelay := watchReconnectDelay
+	watchReconnectDelay = time.Millisecond
+	t.Cleanup(func() { watchReconnectDelay = oldDelay })
+
+	m := &Model{
+		state:              model.NewAppState(),
+		watchStartSequence: 3,
+	}
+	m.state.Server = &model.Server{BaseURL: "https://example.com", Token: "x"}
+
+	_, cmd := m.Update(watchEndedMsg{startSequenceNum: 3, switchEpoch: 0})
+	if cmd == nil {
+		t.Fatal("expected a reconnect command for the current watch's end")
+	}
+
+	// Let the delayed reconnect fire and feed it back into Update.
+	_, cmd = m.Update(cmd())
+	if cmd == nil {
+		t.Fatal("expected a watch start command after the reconnect delay")
+	}
+	if m.watchStartSequence != 4 {
+		t.Fatalf("expected a new watch start (sequence 4), got %d", m.watchStartSequence)
+	}
+}
+
+// Ends of superseded watches are routine (every restart ends the old
+// stream) and must not trigger reconnects.
+func TestWatchEndedMsg_IgnoresSupersededWatch(t *testing.T) {
+	m := &Model{
+		state:              model.NewAppState(),
+		watchStartSequence: 5,
+	}
+	m.state.Server = &model.Server{BaseURL: "https://example.com", Token: "x"}
+
+	_, cmd := m.Update(watchEndedMsg{startSequenceNum: 4, switchEpoch: 0})
+	if cmd != nil {
+		t.Fatal("expected no reconnect for a superseded watch's end")
+	}
+}
+
+// After a context switch the old context's watch end is irrelevant — the
+// new context manages its own watch.
+func TestWatchEndedMsg_IgnoresPreviousContext(t *testing.T) {
+	m := &Model{
+		state:              model.NewAppState(),
+		watchStartSequence: 5,
+		switchEpoch:        2,
+	}
+	m.state.Server = &model.Server{BaseURL: "https://example.com", Token: "x"}
+
+	_, cmd := m.Update(watchEndedMsg{startSequenceNum: 5, switchEpoch: 1})
+	if cmd != nil {
+		t.Fatal("expected no reconnect for a previous context's watch end")
+	}
+}
+
+// The reconnect tick itself re-checks currency: if the watch was replaced
+// during the delay, the tick must not start another stream.
+func TestWatchReconnectMsg_IgnoresStaleReconnect(t *testing.T) {
+	m := &Model{
+		state:              model.NewAppState(),
+		watchStartSequence: 6,
+	}
+	m.state.Server = &model.Server{BaseURL: "https://example.com", Token: "x"}
+
+	_, cmd := m.Update(watchReconnectMsg{startSequenceNum: 5, switchEpoch: 0})
+	if cmd != nil {
+		t.Fatal("expected no watch start for a stale reconnect tick")
+	}
+	if m.watchStartSequence != 6 {
+		t.Fatalf("expected sequence unchanged, got %d", m.watchStartSequence)
 	}
 }
 

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
@@ -53,6 +54,9 @@ type Model struct {
 	watchChan chan services.ArgoApiEvent
 	// Closed when the current app watch forwarder stops.
 	watchDone chan struct{}
+	// True when the current watch forwarder stopped because the upstream
+	// stream ended (as opposed to an intentional stop via cleanup).
+	watchStreamEnded *atomic.Bool
 	// Cleanup callback for active applications watcher
 	appWatchCleanup func()
 
@@ -372,8 +376,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Set up the watch channel with proper forwarding.
 		outCh := make(chan services.ArgoApiEvent, 100)
 		done := make(chan struct{})
+		streamEnded := new(atomic.Bool)
 		m.watchChan = outCh
 		m.watchDone = done
+		m.watchStreamEnded = streamEnded
 		stopForwarding := make(chan struct{})
 		var stopOnce sync.Once
 		upstreamCleanup := msg.cleanup
@@ -400,6 +406,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case ev, ok := <-msg.eventChan:
 					if !ok {
 						cblog.With("component", "watch").Debug("watchStartedMsg: eventChan closed")
+						streamEnded.Store(true)
 						return
 					}
 					eventCount++
@@ -417,6 +424,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}()
 		// Start consuming events (batched)
 		return m, m.consumeWatchEvents()
+
+	case watchEndedMsg:
+		// Only the still-current watch's end warrants a reconnect; ends of
+		// superseded or other-context streams are expected and ignored.
+		if msg.switchEpoch != m.switchEpoch || msg.startSequenceNum != m.watchStartSequence {
+			return m, nil
+		}
+		cblog.With("component", "watch").Info("watch stream ended, scheduling reconnect",
+			"delay", watchReconnectDelay)
+		return m, tea.Tick(watchReconnectDelay, func(time.Time) tea.Msg {
+			return watchReconnectMsg{startSequenceNum: msg.startSequenceNum, switchEpoch: msg.switchEpoch}
+		})
+
+	case watchReconnectMsg:
+		if msg.switchEpoch != m.switchEpoch || msg.startSequenceNum != m.watchStartSequence {
+			return m, nil
+		}
+		return m, m.startWatchingApplications()
 
 	// API Event messages
 	case model.AppsLoadedMsg:


### PR DESCRIPTION
When the watch stream ends (network blip, LB idle timeout), the consumer chain silently died and live updates froze until an unrelated watch restart. Now the consumer reports the end (`watchEndedMsg`, gated by start-sequence + epoch per ADR-0003) and the model reconnects after a 1s delay. Intentional teardown is distinguished from upstream EOF via a per-watch flag, so cleanup never triggers a reconnect.

Stacked on #247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically reconnects when a live update stream ends unexpectedly.
  * Prevents stale or superseded watch sessions from triggering incorrect reconnections.
  * Preserves intentional stops without restarting the watch.
  * Improves handling of events that arrive while a watch is ending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->