### PR TITLE
perf: pool SSE buffers by pointer to avoid boxing on Put

### DIFF
--- a/pkg/api/sse_reader.go
+++ b/pkg/api/sse_reader.go
@@ -346,7 +346,9 @@ func (r *AccumulatingSSEReader) ReadLine() (string, error) {
 func (r *AccumulatingSSEReader) Close() error {
 	r.releaseBufferToPool()
 	if r.stream != nil {
-		return r.stream.Close()
+		stream := r.stream
+		r.stream = nil
+		return stream.Close()
 	}
 	return nil
 }

--- a/pkg/api/sse_reader.go
+++ b/pkg/api/sse_reader.go
@@ -71,23 +71,36 @@ type SSEMetrics struct {
 	EventsProcessed  int
 }
 
-// Buffer pool for reducing GC pressure
+// Buffer pool for reducing GC pressure. Holds *[]byte rather than []byte so
+// Get/Put circulate a pointer instead of boxing the slice header on every Put
+// (staticcheck SA6002).
 var bufferPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, DefaultInitialBufferV2)
+		buffer := make([]byte, DefaultInitialBufferV2)
+		return &buffer
 	},
 }
 
 // AccumulatingSSEReader reads SSE events without data loss on buffer overflow
 type AccumulatingSSEReader struct {
-	stream      io.ReadCloser
-	buffer      []byte // Current read buffer
-	accumulated []byte // Partial event accumulator
-	bufferSize  int    // Current buffer size
-	config      *SSEConfig
-	metrics     *SSEMetrics
-	bufReader   *bufio.Reader // Unified reader for both scanning and direct reads
-	useScanner  bool          // Whether to use scanner mode
+	stream       io.ReadCloser
+	buffer       []byte  // Current read buffer
+	pooledBuffer *[]byte // Pool pointer buffer was obtained under; nil once returned
+	accumulated  []byte  // Partial event accumulator
+	bufferSize   int     // Current buffer size
+	config       *SSEConfig
+	metrics      *SSEMetrics
+	bufReader    *bufio.Reader // Unified reader for both scanning and direct reads
+	useScanner   bool          // Whether to use scanner mode
+}
+
+// releaseBufferToPool returns the pooled buffer, if any, and marks it returned
+// so a later grow or double Close cannot hand the same buffer out twice.
+func (r *AccumulatingSSEReader) releaseBufferToPool() {
+	if r.pooledBuffer != nil {
+		bufferPool.Put(r.pooledBuffer)
+		r.pooledBuffer = nil
+	}
 }
 
 // NewAccumulatingSSEReader creates a new SSE reader that handles large events gracefully
@@ -98,18 +111,21 @@ func NewAccumulatingSSEReader(stream io.ReadCloser, config *SSEConfig) *Accumula
 
 	// Get buffer from pool if it matches default size
 	var buffer []byte
+	var pooledBuffer *[]byte
 	if config.InitialBuffer == DefaultInitialBufferV2 {
-		buffer = bufferPool.Get().([]byte)
+		pooledBuffer = bufferPool.Get().(*[]byte)
+		buffer = *pooledBuffer
 	} else {
 		buffer = make([]byte, config.InitialBuffer)
 	}
 
 	reader := &AccumulatingSSEReader{
-		stream:      stream,
-		buffer:      buffer,
-		accumulated: make([]byte, 0, config.InitialBuffer),
-		bufferSize:  config.InitialBuffer,
-		config:      config,
+		stream:       stream,
+		buffer:       buffer,
+		pooledBuffer: pooledBuffer,
+		accumulated:  make([]byte, 0, config.InitialBuffer),
+		bufferSize:   config.InitialBuffer,
+		config:       config,
 		metrics: &SSEMetrics{
 			CurrentBuffer: config.InitialBuffer,
 		},
@@ -155,10 +171,7 @@ func (r *AccumulatingSSEReader) growBuffer() error {
 
 	newSize := r.calculateNextBufferSize()
 
-	// Return old buffer to pool if it was default size
-	if len(r.buffer) == DefaultInitialBufferV2 {
-		bufferPool.Put(r.buffer)
-	}
+	r.releaseBufferToPool()
 
 	r.buffer = make([]byte, newSize)
 	r.bufferSize = newSize
@@ -331,9 +344,7 @@ func (r *AccumulatingSSEReader) ReadLine() (string, error) {
 
 // Close closes the underlying stream and returns buffer to pool
 func (r *AccumulatingSSEReader) Close() error {
-	if len(r.buffer) == DefaultInitialBufferV2 {
-		bufferPool.Put(r.buffer)
-	}
+	r.releaseBufferToPool()
 	if r.stream != nil {
 		return r.stream.Close()
 	}

--- a/pkg/api/sse_reader_test.go
+++ b/pkg/api/sse_reader_test.go
@@ -11,8 +11,9 @@ import (
 
 // mockReadCloser implements io.ReadCloser for testing
 type mockReadCloser struct {
-	reader io.Reader
-	closed bool
+	reader     io.Reader
+	closed     bool
+	closeCount int
 }
 
 func (m *mockReadCloser) Read(p []byte) (n int, err error) {
@@ -24,7 +25,53 @@ func (m *mockReadCloser) Read(p []byte) (n int, err error) {
 
 func (m *mockReadCloser) Close() error {
 	m.closed = true
+	m.closeCount++
 	return nil
+}
+
+func TestAccumulatingSSEReader_CloseIsIdempotent(t *testing.T) {
+	stream := &mockReadCloser{reader: strings.NewReader("")}
+	reader := NewAccumulatingSSEReader(stream, nil)
+
+	if err := reader.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	if stream.closeCount != 1 {
+		t.Errorf("underlying stream closed %d times, want 1", stream.closeCount)
+	}
+}
+
+func TestAccumulatingSSEReader_ReturnsPooledBufferOnlyOnce(t *testing.T) {
+	stream := &mockReadCloser{reader: strings.NewReader("")}
+	reader := NewAccumulatingSSEReader(stream, nil)
+
+	if reader.pooledBuffer == nil {
+		t.Fatal("default-size reader should borrow its buffer from the pool")
+	}
+
+	_ = reader.Close()
+	if reader.pooledBuffer != nil {
+		t.Error("pooled buffer not marked returned after Close")
+	}
+	_ = reader.Close()
+	if reader.pooledBuffer != nil {
+		t.Error("second Close must not borrow or return again")
+	}
+}
+
+func TestAccumulatingSSEReader_CustomBufferSizeDoesNotUsePool(t *testing.T) {
+	config := DefaultSSEConfig()
+	config.InitialBuffer = 512 * KB
+	stream := &mockReadCloser{reader: strings.NewReader("")}
+	reader := NewAccumulatingSSEReader(stream, config)
+
+	if reader.pooledBuffer != nil {
+		t.Error("custom-size reader must not borrow from the pool")
+	}
 }
 
 // slowReader simulates a slow stream that sends data in chunks


### PR DESCRIPTION
Pool circulates `*[]byte` instead of boxing the slice header on every `Put` (staticcheck SA6002). The reader tracks the pointer it borrowed and nils it on return, which also makes double `Close()` harmless — previously the same buffer could be `Put` twice and handed to two readers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Server-Sent Events stream processing by reusing buffers more efficiently.
  * Reduced unnecessary memory allocations while handling streamed data.
  * Improved buffer cleanup during stream growth and closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->