### PR TITLE
fix: stop retrying mutating requests on network errors

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -173,43 +173,24 @@ func (c *Client) Get(ctx context.Context, path string) ([]byte, error) {
 	return result, err
 }
 
-// Post performs a POST request with retry logic.
+// Post performs a POST request without retries: a network error can occur
+// after the server has already executed the request, so re-sending could
+// run a sync/rollback/delete twice.
 // See Get for timeout responsibility.
 func (c *Client) Post(ctx context.Context, path string, body interface{}) ([]byte, error) {
-	var result []byte
-	err := retry.RetryNetworkOperation(ctx, fmt.Sprintf("POST %s", path), func(attempt int) error {
-		var opErr error
-		result, opErr = c.request(ctx, "POST", path, body)
-		return opErr
-	})
-
-	return result, err
+	return c.request(ctx, "POST", path, body)
 }
 
-// Put performs a PUT request with retry logic.
+// Put performs a PUT request without retries; see Post.
 // See Get for timeout responsibility.
 func (c *Client) Put(ctx context.Context, path string, body interface{}) ([]byte, error) {
-	var result []byte
-	err := retry.RetryNetworkOperation(ctx, fmt.Sprintf("PUT %s", path), func(attempt int) error {
-		var opErr error
-		result, opErr = c.request(ctx, "PUT", path, body)
-		return opErr
-	})
-
-	return result, err
+	return c.request(ctx, "PUT", path, body)
 }
 
-// Delete performs a DELETE request with retry logic.
+// Delete performs a DELETE request without retries; see Post.
 // See Get for timeout responsibility.
 func (c *Client) Delete(ctx context.Context, path string) ([]byte, error) {
-	var result []byte
-	err := retry.RetryNetworkOperation(ctx, fmt.Sprintf("DELETE %s", path), func(attempt int) error {
-		var opErr error
-		result, opErr = c.request(ctx, "DELETE", path, nil)
-		return opErr
-	})
-
-	return result, err
+	return c.request(ctx, "DELETE", path, nil)
 }
 
 // Stream performs a streaming GET request for Server-Sent Events

--- a/pkg/api/client_retry_test.go
+++ b/pkg/api/client_retry_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+// newConnectionDroppingServer returns a server that abruptly closes the
+// connection on every request, producing a retryable network error, plus a
+// counter of how many requests actually arrived.
+func newConnectionDroppingServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("hijack failed: %v", err)
+			return
+		}
+		conn.Close()
+	}))
+	t.Cleanup(server.Close)
+	return server, &hits
+}
+
+func TestMutatingRequests_NetworkError_AreNotRetried(t *testing.T) {
+	methods := []struct {
+		name string
+		call func(*Client, context.Context) error
+	}{
+		{"POST", func(c *Client, ctx context.Context) error {
+			_, err := c.Post(ctx, "/api/v1/applications/test/sync", nil)
+			return err
+		}},
+		{"PUT", func(c *Client, ctx context.Context) error {
+			_, err := c.Put(ctx, "/api/v1/applications/test", map[string]string{"k": "v"})
+			return err
+		}},
+		{"DELETE", func(c *Client, ctx context.Context) error {
+			_, err := c.Delete(ctx, "/api/v1/applications/test")
+			return err
+		}},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name, func(t *testing.T) {
+			server, hits := newConnectionDroppingServer(t)
+			client := NewClient(&model.Server{BaseURL: server.URL, Token: "test-token"})
+
+			err := m.call(client, context.Background())
+			if err == nil {
+				t.Fatal("expected an error from a dropped connection, got nil")
+			}
+			if got := hits.Load(); got != 1 {
+				t.Errorf("%s reached the server %d times; a request that may have executed server-side must not be retried", m.name, got)
+			}
+		})
+	}
+}
+
+func TestGet_NetworkError_IsRetried(t *testing.T) {
+	server, hits := newConnectionDroppingServer(t)
+	client := NewClient(&model.Server{BaseURL: server.URL, Token: "test-token"})
+
+	_, err := client.Get(context.Background(), "/api/v1/applications")
+	if err == nil {
+		t.Fatal("expected an error from a dropped connection, got nil")
+	}
+	if got := hits.Load(); got < 2 {
+		t.Errorf("GET reached the server %d times; idempotent reads should be retried", got)
+	}
+}

--- a/pkg/services/argo.go
+++ b/pkg/services/argo.go
@@ -221,10 +221,9 @@ func (s *ArgoApiServiceImpl) SyncApplication(ctx context.Context, server *model.
 		AppNamespace: ns,
 	}
 
-	// Use retry mechanism for sync operations
-	err := retry.RetryAPIOperation(ctx, "SyncApplication", func(attempt int) error {
-		return s.appService.SyncApplication(ctx, appName, opts)
-	})
+	// No retries: a network error can occur after the server has already
+	// started the sync, so re-sending could run it twice.
+	err := s.appService.SyncApplication(ctx, appName, opts)
 
 	if err != nil {
 		// Convert API errors to structured format if needed

--- a/pkg/services/argo_sync_retry_test.go
+++ b/pkg/services/argo_sync_retry_test.go
@@ -1,0 +1,36 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+func TestSyncApplication_NetworkError_IsNotRetried(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("hijack failed: %v", err)
+			return
+		}
+		conn.Close()
+	}))
+	t.Cleanup(server.Close)
+
+	srv := &model.Server{BaseURL: server.URL, Token: "test-token"}
+	svc := NewArgoApiService(srv)
+
+	err := svc.SyncApplication(context.Background(), srv, "my-app", nil, false)
+	if err == nil {
+		t.Fatal("expected an error from a dropped connection, got nil")
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("sync reached the server %d times; a sync that may have executed server-side must not be retried", got)
+	}
+}

--- a/pkg/services/enhanced.go
+++ b/pkg/services/enhanced.go
@@ -8,7 +8,6 @@ import (
 	appcontext "github.com/darksworm/argonaut/pkg/context"
 	apperrors "github.com/darksworm/argonaut/pkg/errors"
 	"github.com/darksworm/argonaut/pkg/model"
-	"github.com/darksworm/argonaut/pkg/retry"
 )
 
 // EnhancedArgoApiService provides enhanced ArgoApiService with recovery and degradation
@@ -71,10 +70,9 @@ func (s *EnhancedArgoApiService) SyncApplication(ctx context.Context, server *mo
 		AppNamespace: ns,
 	}
 
-	// Use retry mechanism for sync operations
-	err := retry.RetryAPIOperation(ctx, "SyncApplication", func(attempt int) error {
-		return s.appService.SyncApplication(ctx, appName, opts)
-	})
+	// No retries: a network error can occur after the server has already
+	// started the sync, so re-sending could run it twice.
+	err := s.appService.SyncApplication(ctx, appName, opts)
 
 	if err != nil {
 		// Report API health status


### PR DESCRIPTION
A network error can occur after the server already executed the request, so retrying POST/PUT/DELETE (client layer) or a sync (service layer) can run a sync/rollback/delete multiple times.

Major decisions:
- GET keeps its retry wrapper — reads are idempotent.
- The service-layer sync retry was already inert by accident (`fmt.Errorf` wrapping erases the structured error type the retry predicate type-asserts on); removed it so the no-retry guarantee holds by construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate application sync operations when network errors occur.
  * Mutating API requests now execute only once instead of being automatically retried.
  * Preserved retry behavior for GET requests.
  * Maintained existing validation, timeout, and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->