### PR TITLE
fix: identify apps by (name, appNamespace) in index and watch pipeline

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -232,9 +232,9 @@ func (m *Model) fetchAPIVersion() tea.Cmd {
 
 // eventResult holds the classification of a single watch event
 type eventResult struct {
-	update     *model.AppUpdatedMsg // non-nil for app-updated events
-	deleteName string               // non-empty for app-deleted events
-	immediate  tea.Msg              // non-nil for non-batchable events (auth-error, api-error, etc.)
+	update    *model.AppUpdatedMsg // non-nil for app-updated events
+	delete    *model.AppDeletedMsg // non-nil for app-deleted events
+	immediate tea.Msg              // non-nil for non-batchable events (auth-error, api-error, etc.)
 }
 
 func (r eventResult) toBatchOperation() (model.AppBatchOperation, bool) {
@@ -244,17 +244,17 @@ func (r eventResult) toBatchOperation() (model.AppBatchOperation, bool) {
 			Update: r.update,
 		}, true
 	}
-	if r.deleteName != "" {
+	if r.delete != nil {
 		return model.AppBatchOperation{
 			Type:   model.AppBatchOperationDelete,
-			Delete: r.deleteName,
+			Delete: r.delete,
 		}, true
 	}
 	return model.AppBatchOperation{}, false
 }
 
 // classifyWatchEvent converts a service event into an eventResult for batching.
-// Batchable events (app-updated, app-deleted) are returned via update/deleteName fields.
+// Batchable events (app-updated, app-deleted) are returned via update/delete fields.
 // Non-batchable events (auth-error, api-error, etc.) are returned via immediate field.
 // epoch is included in all immediate messages so they pass epoch gating when re-dispatched.
 func classifyWatchEvent(ev services.ArgoApiEvent, epoch int) eventResult {
@@ -269,7 +269,7 @@ func classifyWatchEvent(ev services.ArgoApiEvent, epoch int) eventResult {
 		}
 	case "app-deleted":
 		if ev.AppName != "" {
-			return eventResult{deleteName: ev.AppName}
+			return eventResult{delete: &model.AppDeletedMsg{AppName: ev.AppName, AppNamespace: ev.AppNamespace}}
 		}
 	case "apps-loaded":
 		if ev.Apps != nil {
@@ -369,13 +369,13 @@ func (m *Model) consumeWatchEvents() tea.Cmd {
 
 		// Start batching
 		var updates []model.AppUpdatedMsg
-		var deletes []string
+		var deletes []model.AppDeletedMsg
 		var operations []model.AppBatchOperation
 		if result.update != nil {
 			updates = append(updates, *result.update)
 		}
-		if result.deleteName != "" {
-			deletes = append(deletes, result.deleteName)
+		if result.delete != nil {
+			deletes = append(deletes, *result.delete)
 		}
 		if op, ok := result.toBatchOperation(); ok {
 			operations = append(operations, op)
@@ -402,8 +402,8 @@ func (m *Model) consumeWatchEvents() tea.Cmd {
 				if result.update != nil {
 					updates = append(updates, *result.update)
 				}
-				if result.deleteName != "" {
-					deletes = append(deletes, result.deleteName)
+				if result.delete != nil {
+					deletes = append(deletes, *result.delete)
 				}
 				if op, ok := result.toBatchOperation(); ok {
 					operations = append(operations, op)
@@ -908,7 +908,7 @@ func (m *Model) deleteApplication(req model.AppDeleteRequestMsg) tea.Cmd {
 		}
 
 		cblog.With("component", "app-delete").Info("Delete completed", "app", req.AppName)
-		return model.AppDeleteSuccessMsg{AppName: req.AppName, SwitchEpoch: epoch}
+		return model.AppDeleteSuccessMsg{AppName: req.AppName, AppNamespace: req.AppNamespace, SwitchEpoch: epoch}
 	}
 }
 
@@ -1433,7 +1433,7 @@ func (m *Model) deleteSingleApplication(params AppDeleteParams) tea.Cmd {
 			}
 		}
 
-		return model.AppDeleteSuccessMsg{AppName: params.AppName, SwitchEpoch: epoch}
+		return model.AppDeleteSuccessMsg{AppName: params.AppName, AppNamespace: params.Namespace, SwitchEpoch: epoch}
 	}
 }
 

--- a/cmd/app/batch_identity_test.go
+++ b/cmd/app/batch_identity_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+	"github.com/darksworm/argonaut/pkg/services"
+)
+
+// Two apps sharing a name in different ArgoCD namespaces (ADR-0004): a watch
+// delete for one must not remove the other.
+func TestBatchAppDelete_SameName_RemovesOnlyMatchingNamespace(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+	nsArgocd := "argocd"
+	nsTeamA := "team-a"
+	m.state.Apps = []model.App{
+		{Name: "my-app", AppNamespace: &nsArgocd},
+		{Name: "my-app", AppNamespace: &nsTeamA},
+	}
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+
+	msg := model.AppsBatchUpdateMsg{
+		Operations: []model.AppBatchOperation{{
+			Type:   model.AppBatchOperationDelete,
+			Delete: &model.AppDeletedMsg{AppName: "my-app", AppNamespace: &nsTeamA},
+		}},
+	}
+	newModel, _ := m.Update(msg)
+	m = newModel.(*Model)
+
+	if len(m.state.Apps) != 1 {
+		t.Fatalf("expected 1 app left, got %d", len(m.state.Apps))
+	}
+	if got := *m.state.Apps[0].AppNamespace; got != nsArgocd {
+		t.Errorf("wrong app deleted: survivor is in %q, want %q", got, nsArgocd)
+	}
+}
+
+// A watch update for one of two same-named apps must patch that app's row,
+// not the first name-match.
+func TestBatchAppUpdate_SameName_UpdatesOnlyMatchingNamespace(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+	nsArgocd := "argocd"
+	nsTeamA := "team-a"
+	m.state.Apps = []model.App{
+		{Name: "my-app", AppNamespace: &nsArgocd, Health: "Healthy"},
+		{Name: "my-app", AppNamespace: &nsTeamA, Health: "Healthy"},
+	}
+	m.state.Index = model.BuildAppIndex(m.state.Apps)
+
+	msg := model.AppsBatchUpdateMsg{
+		Operations: []model.AppBatchOperation{{
+			Type:   model.AppBatchOperationUpdate,
+			Update: &model.AppUpdatedMsg{App: model.App{Name: "my-app", AppNamespace: &nsTeamA, Health: "Degraded"}},
+		}},
+	}
+	newModel, _ := m.Update(msg)
+	m = newModel.(*Model)
+
+	if len(m.state.Apps) != 2 {
+		t.Fatalf("expected 2 apps, got %d", len(m.state.Apps))
+	}
+	if m.state.Apps[0].Health != "Healthy" {
+		t.Errorf("argocd app was patched but the event targeted team-a")
+	}
+	if m.state.Apps[1].Health != "Degraded" {
+		t.Errorf("team-a app not patched: health %q, want Degraded", m.state.Apps[1].Health)
+	}
+}
+
+// The DELETED watch event carries the CR namespace; classification must not
+// drop it.
+func TestClassifyWatchEvent_Delete_CarriesAppNamespace(t *testing.T) {
+	ns := "team-a"
+	ev := services.ArgoApiEvent{Type: "app-deleted", AppName: "my-app", AppNamespace: &ns}
+	result := classifyWatchEvent(ev, 0)
+
+	if result.delete == nil {
+		t.Fatal("expected delete to be set for app-deleted")
+	}
+	if result.delete.AppNamespace == nil || *result.delete.AppNamespace != ns {
+		t.Errorf("delete lost the app namespace: %v", result.delete.AppNamespace)
+	}
+}

--- a/cmd/app/batch_watch_test.go
+++ b/cmd/app/batch_watch_test.go
@@ -24,8 +24,8 @@ func TestClassifyWatchEvent_AppUpdated(t *testing.T) {
 	if result.immediate != nil {
 		t.Error("expected immediate to be nil for batchable event")
 	}
-	if result.deleteName != "" {
-		t.Error("expected deleteName to be empty")
+	if result.delete != nil {
+		t.Error("expected delete to be nil")
 	}
 }
 
@@ -33,8 +33,8 @@ func TestClassifyWatchEvent_AppDeleted(t *testing.T) {
 	ev := services.ArgoApiEvent{Type: "app-deleted", AppName: "removed-app"}
 	result := classifyWatchEvent(ev, 0)
 
-	if result.deleteName != "removed-app" {
-		t.Errorf("expected deleteName 'removed-app', got %q", result.deleteName)
+	if result.delete == nil || result.delete.AppName != "removed-app" {
+		t.Errorf("expected delete of 'removed-app', got %+v", result.delete)
 	}
 	if result.update != nil {
 		t.Error("expected update to be nil")
@@ -54,7 +54,7 @@ func TestClassifyWatchEvent_AuthError(t *testing.T) {
 	if _, ok := result.immediate.(model.AuthErrorMsg); !ok {
 		t.Errorf("expected AuthErrorMsg, got %T", result.immediate)
 	}
-	if result.update != nil || result.deleteName != "" {
+	if result.update != nil || result.delete != nil {
 		t.Error("expected update/delete fields to be empty for non-batchable event")
 	}
 }
@@ -135,8 +135,8 @@ func TestConsumeWatchEvents_MixedUpdatesAndDeletes(t *testing.T) {
 	if len(batch.Deletes) != 1 {
 		t.Errorf("expected 1 delete, got %d", len(batch.Deletes))
 	}
-	if batch.Deletes[0] != "app-2" {
-		t.Errorf("expected delete of 'app-2', got %q", batch.Deletes[0])
+	if batch.Deletes[0].AppName != "app-2" {
+		t.Errorf("expected delete of 'app-2', got %q", batch.Deletes[0].AppName)
 	}
 	if len(batch.Operations) != 3 {
 		t.Fatalf("expected 3 ordered operations, got %d", len(batch.Operations))
@@ -144,7 +144,7 @@ func TestConsumeWatchEvents_MixedUpdatesAndDeletes(t *testing.T) {
 	if batch.Operations[0].Type != model.AppBatchOperationUpdate || batch.Operations[0].Update == nil || batch.Operations[0].Update.App.Name != "app-1" {
 		t.Fatalf("unexpected operation[0]: %#v", batch.Operations[0])
 	}
-	if batch.Operations[1].Type != model.AppBatchOperationDelete || batch.Operations[1].Delete != "app-2" {
+	if batch.Operations[1].Type != model.AppBatchOperationDelete || batch.Operations[1].Delete == nil || batch.Operations[1].Delete.AppName != "app-2" {
 		t.Fatalf("unexpected operation[1]: %#v", batch.Operations[1])
 	}
 	if batch.Operations[2].Type != model.AppBatchOperationUpdate || batch.Operations[2].Update == nil || batch.Operations[2].Update.App.Name != "app-3" {
@@ -671,7 +671,7 @@ func TestAppsBatchUpdateMsg_PreservesDeleteThenUpdateOrder(t *testing.T) {
 
 	msg := model.AppsBatchUpdateMsg{
 		Operations: []model.AppBatchOperation{
-			{Type: model.AppBatchOperationDelete, Delete: "app-a"},
+			{Type: model.AppBatchOperationDelete, Delete: &model.AppDeletedMsg{AppName: "app-a"}},
 			{Type: model.AppBatchOperationUpdate, Update: &model.AppUpdatedMsg{App: model.App{Name: "app-a", Health: "New"}}},
 		},
 		Generation: 0,
@@ -695,7 +695,7 @@ func TestAppsBatchUpdateMsg_PreservesUpdateThenDeleteOrder(t *testing.T) {
 	msg := model.AppsBatchUpdateMsg{
 		Operations: []model.AppBatchOperation{
 			{Type: model.AppBatchOperationUpdate, Update: &model.AppUpdatedMsg{App: model.App{Name: "app-a", Health: "New"}}},
-			{Type: model.AppBatchOperationDelete, Delete: "app-a"},
+			{Type: model.AppBatchOperationDelete, Delete: &model.AppDeletedMsg{AppName: "app-a"}},
 		},
 		Generation: 0,
 	}

--- a/cmd/app/context_switch_test.go
+++ b/cmd/app/context_switch_test.go
@@ -65,7 +65,7 @@ func TestStaleAppsBatchUpdateMsgDiscarded(t *testing.T) {
 		Updates: []model.AppUpdatedMsg{
 			{App: model.App{Name: "stale-update"}},
 		},
-		Deletes:     []string{"existing"},
+		Deletes:     []model.AppDeletedMsg{{AppName: "existing"}},
 		SwitchEpoch: 3, // old epoch
 		Generation:  0,
 	}

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -504,7 +504,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.applyBatchAppUpdate(*op.Update)
 					}
 				case model.AppBatchOperationDelete:
-					if op.Delete != "" && m.applyBatchAppDelete(op.Delete) {
+					if op.Delete != nil && m.applyBatchAppDelete(*op.Delete) {
 						deletesApplied++
 					}
 				}
@@ -514,8 +514,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			for _, upd := range msg.Updates {
 				m.applyBatchAppUpdate(upd)
 			}
-			for _, name := range msg.Deletes {
-				if m.applyBatchAppDelete(name) {
+			for _, del := range msg.Deletes {
+				if m.applyBatchAppDelete(del) {
 					deletesApplied++
 				}
 			}
@@ -898,27 +898,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Handle successful application deletion
 		m.statusService.Set(fmt.Sprintf("Application %s deleted successfully", msg.AppName))
 
-		// Remove app from local state using index for O(1) lookup
-		if idx := m.state.Index; idx != nil {
-			if i, ok := idx.NameToIndex[msg.AppName]; ok && i < len(m.state.Apps) && m.state.Apps[i].Name == msg.AppName {
-				m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
-			} else {
-				// Index stale — fall through to linear scan
-				for i, app := range m.state.Apps {
-					if app.Name == msg.AppName {
-						m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
-						break
-					}
-				}
-			}
-		} else {
-			for i, app := range m.state.Apps {
-				if app.Name == msg.AppName {
-					m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
-					break
-				}
-			}
-		}
+		// Remove app from local state, matching full identity (ADR-0004)
+		m.applyBatchAppDelete(model.AppDeletedMsg{AppName: msg.AppName, AppNamespace: msg.AppNamespace})
 		m.state.Index = model.BuildAppIndex(m.state.Apps)
 
 		// Clear modal state and return to normal mode
@@ -1554,9 +1535,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) applyBatchAppUpdate(upd model.AppUpdatedMsg) {
+	key := upd.App.Key()
 	found := false
 	if idx := m.state.Index; idx != nil {
-		if i, ok := idx.NameToIndex[upd.App.Name]; ok && i < len(m.state.Apps) && m.state.Apps[i].Name == upd.App.Name {
+		if i, ok := idx.ByIdentity[key]; ok && i < len(m.state.Apps) && m.state.Apps[i].Key() == key {
 			m.state.Apps[i] = upd.App
 			found = true
 		}
@@ -1564,7 +1546,7 @@ func (m *Model) applyBatchAppUpdate(upd model.AppUpdatedMsg) {
 	if !found {
 		// Fallback to linear scan (index may be stale during in-batch mutations)
 		for i, a := range m.state.Apps {
-			if a.Name == upd.App.Name {
+			if a.Key() == key {
 				m.state.Apps[i] = upd.App
 				found = true
 				break
@@ -1626,18 +1608,30 @@ func (m *Model) resolveActionRefreshApp(msg model.ResourceActionExecutedMsg) *mo
 	return &model.App{Name: msg.AppName, AppNamespace: msg.Target.AppNamespace}
 }
 
-func (m *Model) applyBatchAppDelete(name string) bool {
-	if name == "" {
+func (m *Model) applyBatchAppDelete(del model.AppDeletedMsg) bool {
+	if del.AppName == "" {
 		return false
 	}
-	if idx := m.state.Index; idx != nil {
-		if i, ok := idx.NameToIndex[name]; ok && i < len(m.state.Apps) && m.state.Apps[i].Name == name {
-			m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
-			return true
+	// Producers that don't know the CR namespace (AppNamespace == nil) fall
+	// back to name-only matching; with it we match full identity (ADR-0004).
+	if del.AppNamespace != nil {
+		key := model.AppKeyFor(del.AppName, del.AppNamespace)
+		if idx := m.state.Index; idx != nil {
+			if i, ok := idx.ByIdentity[key]; ok && i < len(m.state.Apps) && m.state.Apps[i].Key() == key {
+				m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
+				return true
+			}
 		}
+		for i, a := range m.state.Apps {
+			if a.Key() == key {
+				m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
+				return true
+			}
+		}
+		return false
 	}
 	for i, a := range m.state.Apps {
-		if a.Name == name {
+		if a.Name == del.AppName {
 			m.state.Apps = append(m.state.Apps[:i], m.state.Apps[i+1:]...)
 			return true
 		}

--- a/pkg/model/index.go
+++ b/pkg/model/index.go
@@ -17,8 +17,8 @@ type AppIndex struct {
 	ByProject        map[string][]int
 	ByApplicationSet map[string][]int
 
-	// App name → index in the Apps slice for O(1) upsert/delete
-	NameToIndex map[string]int
+	// App identity (ADR-0004) → index in the Apps slice for O(1) upsert/delete
+	ByIdentity map[AppKey]int
 
 	// Total number of apps when the index was built
 	Total int
@@ -32,7 +32,7 @@ func BuildAppIndex(apps []App) *AppIndex {
 		ByNamespace:      make(map[string][]int),
 		ByProject:        make(map[string][]int),
 		ByApplicationSet: make(map[string][]int),
-		NameToIndex:      make(map[string]int, len(apps)),
+		ByIdentity:       make(map[AppKey]int, len(apps)),
 		Total:            len(apps),
 	}
 
@@ -42,7 +42,7 @@ func BuildAppIndex(apps []App) *AppIndex {
 	appsetSet := make(map[string]bool)
 
 	for i, app := range apps {
-		idx.NameToIndex[app.Name] = i
+		idx.ByIdentity[app.Key()] = i
 
 		// Cluster
 		cl := ""

--- a/pkg/model/index_test.go
+++ b/pkg/model/index_test.go
@@ -15,8 +15,8 @@ func TestBuildAppIndex_Empty(t *testing.T) {
 	if len(idx.Clusters) != 0 {
 		t.Errorf("expected 0 clusters, got %d", len(idx.Clusters))
 	}
-	if len(idx.NameToIndex) != 0 {
-		t.Errorf("expected empty NameToIndex, got %d entries", len(idx.NameToIndex))
+	if len(idx.ByIdentity) != 0 {
+		t.Errorf("expected empty ByIdentity, got %d entries", len(idx.ByIdentity))
 	}
 }
 
@@ -41,8 +41,8 @@ func TestBuildAppIndex_SingleApp(t *testing.T) {
 	if !reflect.DeepEqual(idx.ApplicationSets, []string{"web-set"}) {
 		t.Errorf("ApplicationSets = %v, want [web-set]", idx.ApplicationSets)
 	}
-	if i, ok := idx.NameToIndex["web"]; !ok || i != 0 {
-		t.Errorf("NameToIndex[web] = %d, %v; want 0, true", i, ok)
+	if i, ok := idx.ByIdentity[AppKey{Name: "web"}]; !ok || i != 0 {
+		t.Errorf("ByIdentity[web] = %d, %v; want 0, true", i, ok)
 	}
 }
 
@@ -67,8 +67,8 @@ func TestBuildAppIndex_NilFields(t *testing.T) {
 	if len(idx.ApplicationSets) != 0 {
 		t.Errorf("expected 0 appsets for nil ApplicationSet, got %v", idx.ApplicationSets)
 	}
-	if _, ok := idx.NameToIndex["bare"]; !ok {
-		t.Error("expected NameToIndex to contain 'bare'")
+	if _, ok := idx.ByIdentity[AppKey{Name: "bare"}]; !ok {
+		t.Error("expected ByIdentity to contain 'bare'")
 	}
 }
 
@@ -102,10 +102,10 @@ func TestBuildAppIndex_MultipleApps_SortedUnique(t *testing.T) {
 	if !reflect.DeepEqual(idx.ByCluster["staging"], []int{1}) {
 		t.Errorf("ByCluster[staging] = %v, want [1]", idx.ByCluster["staging"])
 	}
-	// NameToIndex
+	// ByIdentity
 	for i, app := range apps {
-		if idx.NameToIndex[app.Name] != i {
-			t.Errorf("NameToIndex[%s] = %d, want %d", app.Name, idx.NameToIndex[app.Name], i)
+		if idx.ByIdentity[app.Key()] != i {
+			t.Errorf("ByIdentity[%s] = %d, want %d", app.Name, idx.ByIdentity[app.Key()], i)
 		}
 	}
 }
@@ -260,5 +260,28 @@ func TestScopedApps_NilIndex(t *testing.T) {
 	result := idx.ScopedApps(apps, sel)
 	if len(result) != 1 {
 		t.Errorf("expected passthrough from nil index, got %d apps", len(result))
+	}
+}
+
+func TestBuildAppIndex_SameNameDifferentNamespace_IndexesBoth(t *testing.T) {
+	apps := []App{
+		{Name: "my-app", AppNamespace: strPtr("argocd")},
+		{Name: "my-app", AppNamespace: strPtr("team-a")},
+	}
+	idx := BuildAppIndex(apps)
+
+	if i, ok := idx.ByIdentity[AppKey{Name: "my-app", AppNamespace: "argocd"}]; !ok || i != 0 {
+		t.Errorf("ByIdentity[my-app/argocd] = %d, %v; want 0, true", i, ok)
+	}
+	if i, ok := idx.ByIdentity[AppKey{Name: "my-app", AppNamespace: "team-a"}]; !ok || i != 1 {
+		t.Errorf("ByIdentity[my-app/team-a] = %d, %v; want 1, true", i, ok)
+	}
+}
+
+func TestAppKey_NilNamespaceEqualsEmpty(t *testing.T) {
+	withNil := App{Name: "app"}
+	withEmpty := App{Name: "app", AppNamespace: strPtr("")}
+	if withNil.Key() != withEmpty.Key() {
+		t.Errorf("nil and empty AppNamespace should produce the same key: %v vs %v", withNil.Key(), withEmpty.Key())
 	}
 }

--- a/pkg/model/messages.go
+++ b/pkg/model/messages.go
@@ -168,9 +168,12 @@ type AppUpdatedMsg struct {
 	ResourcesJSON []byte // JSON encoded []api.ResourceStatus for sync status updates
 }
 
-// AppDeletedMsg is sent when an app is deleted (from watch stream)
+// AppDeletedMsg is sent when an app is deleted (from watch stream).
+// AppNamespace disambiguates same-named apps per ADR-0004; nil means the
+// producer could not determine it and matching falls back to name-only.
 type AppDeletedMsg struct {
-	AppName string
+	AppName      string
+	AppNamespace *string
 }
 
 // AppsBatchUpdateMsg is sent when multiple app updates/deletes are batched together
@@ -178,7 +181,7 @@ type AppDeletedMsg struct {
 // Matches ArgoCD web UI's 500ms event batching strategy.
 type AppsBatchUpdateMsg struct {
 	Updates     []AppUpdatedMsg
-	Deletes     []string
+	Deletes     []AppDeletedMsg
 	Operations  []AppBatchOperation // Ordered stream operations (preserves update/delete ordering)
 	Immediate   tea.Msg             // Non-batchable event encountered during batching (auth-error, api-error, etc.)
 	Generation  int                 // Watch generation that produced this batch (for safe watch restarts)
@@ -197,7 +200,7 @@ const (
 type AppBatchOperation struct {
 	Type   AppBatchOperationType
 	Update *AppUpdatedMsg
-	Delete string
+	Delete *AppDeletedMsg
 }
 
 // AppDeleteRequestMsg represents a request to delete an application
@@ -210,8 +213,9 @@ type AppDeleteRequestMsg struct {
 
 // AppDeleteSuccessMsg represents a successful application deletion
 type AppDeleteSuccessMsg struct {
-	AppName     string
-	SwitchEpoch int // Context switch epoch for stale message gating
+	AppName      string
+	AppNamespace *string
+	SwitchEpoch  int // Context switch epoch for stale message gating
 }
 
 // AppDeleteErrorMsg represents an application deletion error

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -68,6 +68,27 @@ func (a App) SortKey() SortKey {
 	return SortKey{Health: a.Health, Sync: a.Sync, Name: a.Name}
 }
 
+// AppKey identifies an application per ADR-0004: (Name, AppNamespace), never
+// Name alone. A nil AppNamespace normalizes to "".
+type AppKey struct {
+	Name         string
+	AppNamespace string
+}
+
+// Key returns the app's identity key.
+func (a App) Key() AppKey {
+	return AppKeyFor(a.Name, a.AppNamespace)
+}
+
+// AppKeyFor builds an AppKey from a name and optional ArgoCD CR namespace.
+func AppKeyFor(name string, appNamespace *string) AppKey {
+	k := AppKey{Name: name}
+	if appNamespace != nil {
+		k.AppNamespace = *appNamespace
+	}
+	return k
+}
+
 // Server represents an ArgoCD server configuration
 type Server struct {
 	BaseURL         string `json:"baseUrl"`

--- a/pkg/services/argo.go
+++ b/pkg/services/argo.go
@@ -59,13 +59,16 @@ type ArgoApiService interface {
 
 // ArgoApiEvent represents events from the ArgoCD API
 type ArgoApiEvent struct {
-	Type      string               `json:"type"`
-	Apps      []model.App          `json:"apps,omitempty"`
-	App       *model.App           `json:"app,omitempty"`
-	AppName   string               `json:"appName,omitempty"`
-	Error     error                `json:"error,omitempty"`
-	Status    string               `json:"status,omitempty"`
-	Resources []api.ResourceStatus `json:"resources,omitempty"` // Resource sync statuses for tree view
+	Type    string      `json:"type"`
+	Apps    []model.App `json:"apps,omitempty"`
+	App     *model.App  `json:"app,omitempty"`
+	AppName string      `json:"appName,omitempty"`
+	// AppNamespace is the ArgoCD Application CR namespace for app-deleted
+	// events (ADR-0004); app-updated events carry it inside App.
+	AppNamespace *string              `json:"appNamespace,omitempty"`
+	Error        error                `json:"error,omitempty"`
+	Status       string               `json:"status,omitempty"`
+	Resources    []api.ResourceStatus `json:"resources,omitempty"` // Resource sync statuses for tree view
 }
 
 // ResourceDiff represents a resource difference
@@ -406,9 +409,14 @@ func (s *ArgoApiServiceImpl) handleWatchEvent(event api.ApplicationWatchEvent, e
 
 	switch event.Type {
 	case "DELETED":
+		var appNamespace *string
+		if ns := event.Application.Metadata.Namespace; ns != "" {
+			appNamespace = &ns
+		}
 		eventChan <- ArgoApiEvent{
-			Type:    "app-deleted",
-			AppName: appName,
+			Type:         "app-deleted",
+			AppName:      appName,
+			AppNamespace: appNamespace,
 		}
 	default:
 		// Convert to our model


### PR DESCRIPTION
Per ADR-0004, two apps may share a name across ArgoCD namespaces. The app index was keyed by name alone, so watch update/delete events patched or removed the wrong row; the DELETED watch event also dropped the CR namespace entirely.

Major decisions:
- `AppIndex.NameToIndex` → `ByIdentity map[AppKey]int` where `AppKey` = (Name, AppNamespace), nil namespace normalized to "".
- `AppDeletedMsg` now carries `AppNamespace`; producers that can't know it (nil) fall back to name-only matching.
- Out of scope, noted for follow-up: `SelectionState.SelectedApps` is still name-keyed (multi-select/multi-sync surface).

Stacked on #253.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application update and deletion handling when applications share the same name across different namespaces.
  * Preserved namespace information in application deletion events and success notifications.
  * Ensured batched watch events correctly target the intended application.
* **Reliability**
  * Added coverage for namespace-aware indexing, updates, deletions, event handling, and stale batch messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->