### PR TITLE
ci: run all tests with the race detector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,10 @@ jobs:
         run: go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
 
       - name: Run tests (unit + e2e)
-        # Match parallelism to the runner's core count — full CPU
-        # utilisation, no oversubscription. Anything higher introduces
-        # "command bar not ready" flakes because the PTY subprocesses +
-        # mock servers + go test framework contend for CPU. GitHub bumped
-        # the default runner from 2 to 4 cores in 2024, so $(nproc) is
-        # the right call rather than hardcoding a number.
-        run: make test PARALLEL="$(nproc)"
+        # The Makefile defaults PARALLEL to nproc/2: tests run under -race,
+        # whose CPU overhead makes one-test-per-core oversubscription and
+        # causes "command bar not ready" flakes in the PTY-driven e2e suite.
+        run: make test
 
       - name: Upload e2e test snapshots
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,13 @@
 	argocd-git-daemon argocd-git-daemon-stop \
 	argocd-password argocd-login
 
-# Default parallelism for tests. 16 matches the typical core count and
-# fully saturates the box for the e2e suite (~3.3s wall-clock). Higher
-# numbers risk port/process contention with mock servers. Override
-# via `make e2e PARALLEL=N`.
-PARALLEL ?= 16
+# Default parallelism for tests. Race-instrumented tests (all targets below)
+# cost several times the CPU of a plain build, so one test per core
+# oversubscribes the box and the PTY-driven e2e suite starts missing its
+# timing budgets. Half the cores keeps the box saturated with enough
+# headroom (measured: 12/12 green at cores/2, ~1 in 4 runs flaky at
+# 1×cores). Override via `make e2e PARALLEL=N`.
+PARALLEL ?= $(shell n=$$(nproc); echo $$(( n > 1 ? n / 2 : 1 )))
 
 # k3d/ArgoCD defaults
 K3D_CLUSTER ?= argocd-demo
@@ -26,15 +28,15 @@ GIT_DAEMON_BASE_PATH ?= $(abspath $(CURDIR)/..)
 
 # Run all tests, including e2e (unix-only), with parallelism and no cache.
 test:
-	go test -tags e2e ./... -v -count=1 -parallel $(PARALLEL)
+	go test -race -tags e2e ./... -v -count=1 -parallel $(PARALLEL)
 
 # Run only unit tests (no e2e).
 unit:
-	go test ./... -v -count=1 -parallel $(PARALLEL)
+	go test -race ./... -v -count=1 -parallel $(PARALLEL)
 
 # Run only e2e tests.
 e2e:
-	go test -tags e2e ./e2e -v -count=1 -parallel $(PARALLEL)
+	go test -race -tags e2e ./e2e -v -count=1 -parallel $(PARALLEL)
 
 # Regenerate golden snapshots for app tests.
 goldens:

--- a/e2e/driver_unix_test.go
+++ b/e2e/driver_unix_test.go
@@ -96,33 +96,6 @@ func NewTUITest(t *testing.T) *TUITestFramework {
 	return &TUITestFramework{t: t, buf: make([]byte, ringSize)}
 }
 
-// ensureBinary builds the app test binary if it doesn't exist yet.
-func ensureBinary(t *testing.T) error {
-	t.Helper()
-	// Resolve absolute binPath under e2e dir
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	p := binPath
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(cwd, p)
-	}
-	// Already exists?
-	if st, err := os.Stat(p); err == nil && st.Mode().IsRegular() {
-		binPath = p
-		return nil
-	}
-	// Build it
-	cmd := exec.Command("go", "build", "-o", p, "./cmd/app")
-	cmd.Dir = ".."
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("build failed: %v\n%s", err, string(out))
-	}
-	binPath = p
-	return nil
-}
-
 // Workspace returns the isolated workspace directory for this test
 func (tf *TUITestFramework) Workspace() string {
 	return tf.workspace
@@ -165,9 +138,6 @@ func (tf *TUITestFramework) SetupWorkspace() (string, error) {
 // StartApp runs the compiled binary under a PTY
 func (tf *TUITestFramework) StartApp(extraEnv ...string) error {
 	tf.t.Helper()
-	if err := ensureBinary(tf.t); err != nil {
-		return err
-	}
 	tf.cmd = exec.Command(binPath)
 	p, t, err := pty.Open()
 	if err != nil {
@@ -262,9 +232,6 @@ check_enabled = false`
 // StartAppArgs starts the app with explicit CLI args and optional env
 func (tf *TUITestFramework) StartAppArgs(args []string, extraEnv ...string) error {
 	tf.t.Helper()
-	if err := ensureBinary(tf.t); err != nil {
-		return err
-	}
 	tf.cmd = exec.Command(binPath, args...)
 	p, t, err := pty.Open()
 	if err != nil {
@@ -521,13 +488,13 @@ func (tf *TUITestFramework) Cleanup() {
 		tf.saveFailureSnapshot()
 	}
 
+	// Close only — do not nil the fields: readLoop still dereferences tf.pty
+	// concurrently (closing makes its Read return an error and exit).
 	if tf.pty != nil {
 		_ = tf.pty.Close()
-		tf.pty = nil
 	}
 	if tf.tty != nil {
 		_ = tf.tty.Close()
-		tf.tty = nil
 	}
 	if tf.cmd != nil && tf.cmd.Process != nil {
 		_ = tf.cmd.Process.Kill()

--- a/e2e/filter_persistence_test.go
+++ b/e2e/filter_persistence_test.go
@@ -94,12 +94,39 @@ func TestFilterPersistsAfterResourcesAndK9s(t *testing.T) {
 	}
 
 	// Mock k9s exits after ~0.2s. Wait for argonaut to regain input routing
-	// (confirmed by being able to open the command bar) before sending Esc.
-	if err := tf.OpenCommand(); err != nil {
-		t.Fatalf("argonaut input not restored after k9s: %v", err)
+	// (confirmed by the command bar opening) before sending Esc. OpenCommand
+	// is not usable here: it scans the cumulative output ring, which already
+	// contains a command-bar frame from line 55, so it can return before the
+	// app is actually accepting input again. Poll the live screen instead.
+	// Keystrokes sent before the PTY handoff completes are dropped, so keep
+	// re-sending ":" until the bar shows up. Extra ":" presses once the bar
+	// is open just type into it and are discarded by the Esc below.
+	openDeadline := time.Now().Add(10 * time.Second)
+	for {
+		_ = tf.Send(":")
+		time.Sleep(100 * time.Millisecond)
+		if strings.Contains(tf.Screen(), "│ > ") {
+			break
+		}
+		if time.Now().After(openDeadline) {
+			t.Log(tf.Screen())
+			t.Fatal("argonaut input not restored after k9s: command bar not on live screen")
+		}
 	}
 	_ = tf.Send("\x1b") // close command bar
-	// Global 100ms esc debounce — wait it out before the next esc.
+
+	// The app debounces esc presses 100ms apart by *its* clock, so sleeping
+	// between sends is only safe once we've seen the app process the first
+	// esc. Wait for the command bar to disappear from the live screen, then
+	// the debounce window is anchored: the app handled esc #1 no later than
+	// the frame we just observed.
+	closeDeadline := time.Now().Add(10 * time.Second)
+	for strings.Contains(tf.Screen(), "│ > ") {
+		if time.Now().After(closeDeadline) {
+			t.Fatal("command bar did not close after esc")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	time.Sleep(150 * time.Millisecond)
 
 	// Esc back to apps view.
@@ -107,8 +134,8 @@ func TestFilterPersistsAfterResourcesAndK9s(t *testing.T) {
 
 	// We're back in apps view AND filter should still be applied.
 	// WaitForPlain scans the cumulative output ring, which includes stale
-	// "<apps:dem>" frames from before the tree view. Re-render by toggling
-	// search mode briefly, then assert against the live screen.
+	// "<apps:dem>" frames from before the tree view, so assert against the
+	// live screen instead.
 	deadline := time.Now().Add(3 * time.Second)
 	var screen string
 	for time.Now().Before(deadline) {

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -20,7 +20,9 @@ func TestMain(m *testing.M) {
 	}
 	binPath = e2eDir + "/a9s_e2e"
 
-	// Build the TUI binary from cmd/app
+	// The app binary is deliberately built WITHOUT -race: the ~10x slowdown
+	// blows the suite's timing budgets and causes flakes. The race detector
+	// still covers the test harness itself (and all unit tests via make).
 	fmt.Println("Building a9s test binary…")
 	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/app")
 	cmd.Dir = ".."


### PR DESCRIPTION
Enables `-race` on every test target (unit + e2e) and fixes the two real harness races it caught:
- `ensureBinary` rebuilt and rewrote the global `binPath` from 28 parallel tests — deleted; TestMain already builds it before any test runs.
- `Cleanup` nil-ed `tf.pty` while `readLoop` was still dereferencing it — close without nil-ing.

Major decisions:
- The app binary itself is built WITHOUT -race for e2e: its ~10x slowdown blows the suite's timing budgets (verified flaky).
- Default `PARALLEL` is now nproc/2: race overhead makes one-test-per-core oversubscription (measured 12/12 green at cores/2 vs ~1-in-4 flaky at 1×cores).
- `TestFilterPersistsAfterResourcesAndK9s` asserted readiness against the cumulative output ring, which matched a stale command-bar frame; it now polls the live screen.

Stacked on #254.