### PR TITLE
fix: sync selected child application

### DIFF
--- a/cmd/app/input_handlers.go
+++ b/cmd/app/input_handlers.go
@@ -1061,16 +1061,26 @@ func (m *Model) handleResourceSync() (tea.Model, tea.Cmd) {
 	// Get selected resources
 	selections := m.treeView.GetSelectedResources()
 
-	// If no selections, check if we're on the Application root node
+	// Without explicit resource selections, an Application row represents an
+	// application sync. A child Application must target that child rather than
+	// falling back to the synthetic root app that owns the resource tree.
 	if len(selections) == 0 {
-		// On Application root - trigger full app sync instead
-		// Get the app name from the tree view
 		appName := m.treeView.GetAppName()
+		var appNamespace *string
+
+		_, kind, selectedNamespace, selectedName, ok := m.treeView.SelectedResource()
+		if ok && kind == "Application" && !m.treeView.IsSelectedSyntheticRoot() {
+			appName = selectedName
+			if selectedNamespace != "" {
+				appNamespace = &selectedNamespace
+			}
+		} else if m.state.UI.TreeApp != nil {
+			appNamespace = m.state.UI.TreeApp.AppNamespace
+		}
+
 		if appName != "" {
 			m.state.Modals.ConfirmTarget = &appName
-			if m.state.UI.TreeApp != nil {
-				m.state.Modals.ConfirmTargetNamespace = m.state.UI.TreeApp.AppNamespace
-			}
+			m.state.Modals.ConfirmTargetNamespace = appNamespace
 			m.state.Modals.ConfirmSyncSelected = 0 // default to Yes
 			m.state.Mode = model.ModeConfirmSync
 			return m, nil

--- a/cmd/app/resource_sync_child_app_test.go
+++ b/cmd/app/resource_sync_child_app_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/api"
+	"github.com/darksworm/argonaut/pkg/model"
+	"github.com/darksworm/argonaut/pkg/tui/treeview"
+)
+
+func TestHandleResourceSync_ChildApplicationTargetsChildApp(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+
+	parentNamespace := "argocd"
+	otherChildNamespace := "team-a"
+	childNamespace := "team-b"
+	m.state.Apps = []model.App{
+		{Name: "parent", AppNamespace: &parentNamespace},
+		{Name: "child", AppNamespace: &otherChildNamespace},
+		{Name: "child", AppNamespace: &childNamespace},
+	}
+	m.state.Navigation.View = model.ViewTree
+	m.setTreeApp(m.state.Apps[0])
+	m.treeView = treeview.NewTreeView(0, 0)
+	m.treeView.SetAppMeta("parent", "Healthy", "OutOfSync")
+	m.treeView.UpsertAppTree("parent", &api.ResourceTree{Nodes: []api.ResourceNode{
+		{
+			UID:       "child-application",
+			Group:     "argoproj.io",
+			Version:   "v1alpha1",
+			Kind:      "Application",
+			Namespace: &childNamespace,
+			Name:      "child",
+			Status:    "OutOfSync",
+		},
+	}})
+	m.treeView.SetSelectedIndex(1)
+
+	updated, cmd := m.handleKeyMsg(testKeyMsg("s"))
+	m = updated.(*Model)
+
+	if cmd != nil {
+		t.Fatal("opening the sync confirmation should not execute a command")
+	}
+	if m.state.Mode != model.ModeConfirmSync {
+		t.Fatalf("expected application sync confirmation, got mode %s", m.state.Mode)
+	}
+	if m.state.Modals.ConfirmTarget == nil || *m.state.Modals.ConfirmTarget != "child" {
+		t.Fatalf("expected child sync target, got %v", m.state.Modals.ConfirmTarget)
+	}
+	if m.state.Modals.ConfirmTargetNamespace == nil || *m.state.Modals.ConfirmTargetNamespace != childNamespace {
+		t.Fatalf("expected child app namespace %q, got %v", childNamespace, m.state.Modals.ConfirmTargetNamespace)
+	}
+	if m.state.Modals.ResourceSyncAppName != nil || len(m.state.Modals.ResourceSyncTargets) != 0 {
+		t.Fatalf("expected no parent resource sync target, got app=%v resources=%v", m.state.Modals.ResourceSyncAppName, m.state.Modals.ResourceSyncTargets)
+	}
+}
+
+func TestHandleResourceSync_SyntheticRootTargetsParentApp(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+
+	parentNamespace := "argocd"
+	m.state.Apps = []model.App{{Name: "parent", AppNamespace: &parentNamespace}}
+	m.state.Navigation.View = model.ViewTree
+	m.setTreeApp(m.state.Apps[0])
+	m.treeView = treeview.NewTreeView(0, 0)
+	m.treeView.SetAppMeta("parent", "Healthy", "OutOfSync")
+	m.treeView.UpsertAppTree("parent", &api.ResourceTree{})
+	m.treeView.SetSelectedIndex(0)
+
+	updated, cmd := m.handleKeyMsg(testKeyMsg("s"))
+	m = updated.(*Model)
+
+	if cmd != nil {
+		t.Fatal("opening the sync confirmation should not execute a command")
+	}
+	if m.state.Mode != model.ModeConfirmSync {
+		t.Fatalf("expected application sync confirmation, got mode %s", m.state.Mode)
+	}
+	if m.state.Modals.ConfirmTarget == nil || *m.state.Modals.ConfirmTarget != "parent" {
+		t.Fatalf("expected parent sync target, got %v", m.state.Modals.ConfirmTarget)
+	}
+	if m.state.Modals.ConfirmTargetNamespace == nil || *m.state.Modals.ConfirmTargetNamespace != parentNamespace {
+		t.Fatalf("expected parent app namespace %q, got %v", parentNamespace, m.state.Modals.ConfirmTargetNamespace)
+	}
+}


### PR DESCRIPTION
## Summary

- detect when the current tree row is a child `Application` rather than the synthetic root
- target the child application and its Argo CD application namespace in the existing sync flow
- preserve parent sync for the synthetic root and resource-level sync for normal resources
- add regression coverage for duplicate child names across namespaces and the parent-root behavior

Fixes #259

## Verification

- `go test ./cmd/app -run 'TestHandleResourceSync_(ChildApplicationTargetsChildApp|SyntheticRootTargetsParentApp)$' -count=1`
- `go test ./cmd/app -count=1`
- `go build ./cmd/app`
- built CLI executed with `./app --help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource synchronization now targets the selected child application and its namespace when chosen from the tree view.
  * Synchronization for other selections continues to use the owning application and namespace.
  * Prevented unintended parent resource-sync targets when a child application is selected.

* **Tests**
  * Added coverage for child application and synthetic root selection during resource synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->