### PR TITLE
feat: refresh events pane on watch updates for its app

### DIFF
--- a/cmd/app/events_pane.go
+++ b/cmd/app/events_pane.go
@@ -128,10 +128,10 @@ func (m *Model) paneShowsApp(app model.App) bool {
 // for the pane's app.
 func (m *Model) armPaneWatchRefresh() tea.Cmd {
 	st := m.state.Events
-	if st == nil || m.paneWatchRefreshArmed {
+	if st == nil || m.paneWatchRefreshArmedSeq == st.LoadSeq {
 		return nil
 	}
-	m.paneWatchRefreshArmed = true
+	m.paneWatchRefreshArmedSeq = st.LoadSeq
 	epoch := m.switchEpoch
 	seq := st.LoadSeq
 	return tea.Tick(paneWatchRefreshDebounce, func(time.Time) tea.Msg {

--- a/cmd/app/events_pane.go
+++ b/cmd/app/events_pane.go
@@ -99,6 +99,46 @@ func (m *Model) paneRefreshCmds() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+// paneWatchRefreshDebounce is the coalescing window for watch-triggered pane
+// refreshes: a sync emits a burst of watch updates, and one armed tick turns
+// the whole burst into a single refetch.
+const paneWatchRefreshDebounce = time.Second
+
+// paneWatchRefreshDueMsg fires after the coalescing window of a watch update
+// that touched the pane's app; the refetch runs only if LoadSeq still matches.
+type paneWatchRefreshDueMsg struct {
+	switchEpoch int
+	loadSeq     int
+}
+
+// paneShowsApp reports whether the open pane is scoped to the given app.
+func (m *Model) paneShowsApp(app model.App) bool {
+	st := m.state.Events
+	if st == nil || app.Name != st.Target.AppName {
+		return false
+	}
+	ns := ""
+	if app.AppNamespace != nil {
+		ns = *app.AppNamespace
+	}
+	return ns == st.Target.AppNamespace
+}
+
+// armPaneWatchRefresh schedules a pane refetch in response to a watch update
+// for the pane's app.
+func (m *Model) armPaneWatchRefresh() tea.Cmd {
+	st := m.state.Events
+	if st == nil || m.paneWatchRefreshArmed {
+		return nil
+	}
+	m.paneWatchRefreshArmed = true
+	epoch := m.switchEpoch
+	seq := st.LoadSeq
+	return tea.Tick(paneWatchRefreshDebounce, func(time.Time) tea.Msg {
+		return paneWatchRefreshDueMsg{switchEpoch: epoch, loadSeq: seq}
+	})
+}
+
 // paneAgeTickMsg re-renders the open pane once a second so the border's
 // "updated Ns ago" stays honest between refreshes. Display only.
 type paneAgeTickMsg struct {

--- a/cmd/app/events_pane_test.go
+++ b/cmd/app/events_pane_test.go
@@ -894,6 +894,159 @@ func TestAppsBatchUpdate_RefreshesTreeSyncSummaryLive(t *testing.T) {
 	}
 }
 
+// The watch stream is the pane's freshness signal: an update for the app the
+// pane is showing arms a debounced refresh, so a sync or health change shows
+// up without waiting for the polling interval.
+func TestAppsBatchUpdate_ForPaneApp_ArmsWatchRefresh(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+	m.watchGeneration = 7 // a foreign generation keeps the consume chain out of cmd
+	updated := m.state.Apps[0]
+	updated.SyncOp = &model.SyncOpSummary{Phase: "Succeeded", FinishedAt: time.Now()}
+
+	_, cmd := m.Update(model.AppsBatchUpdateMsg{
+		Updates:     []model.AppUpdatedMsg{{App: updated}},
+		SwitchEpoch: m.switchEpoch,
+	})
+
+	if cmd == nil {
+		t.Fatal("expected a watch update for the pane's app to arm a refresh")
+	}
+}
+
+// A sync emits a burst of watch updates; one armed tick absorbs the burst
+// instead of refetching per update.
+func TestAppsBatchUpdate_WhileRefreshArmed_Coalesces(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+	m.watchGeneration = 7
+	updated := m.state.Apps[0]
+	batch := model.AppsBatchUpdateMsg{
+		Updates:     []model.AppUpdatedMsg{{App: updated}},
+		SwitchEpoch: m.switchEpoch,
+	}
+	teaModel, cmd := m.Update(batch)
+	if cmd == nil {
+		t.Fatal("setup: the first update must arm the refresh")
+	}
+
+	_, cmd = teaModel.(*Model).Update(batch)
+
+	if cmd != nil {
+		t.Error("expected updates within the armed window to coalesce into the pending tick")
+	}
+}
+
+// Only the app the pane is showing is a freshness signal; churn on other
+// apps must not refetch it.
+func TestAppsBatchUpdate_ForOtherApp_DoesNotArmWatchRefresh(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+	m.watchGeneration = 7
+	other := m.state.Apps[1] // zzz-other-app
+
+	_, cmd := m.Update(model.AppsBatchUpdateMsg{
+		Updates:     []model.AppUpdatedMsg{{App: other}},
+		SwitchEpoch: m.switchEpoch,
+	})
+
+	if cmd != nil {
+		t.Error("expected an unrelated app's update to leave the pane alone")
+	}
+}
+
+// When the coalescing window closes, the pane refetches in the background —
+// no loading placeholder — and the next watch update can arm again.
+func TestPaneWatchRefreshDue_RefetchesAndDisarms(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+	m.watchGeneration = 7
+	teaModel, _ := m.Update(model.EventsLoadedMsg{
+		Target:      m.state.Events.Target,
+		Items:       []model.ResourceEvent{{Reason: "BackOff"}},
+		SwitchEpoch: m.switchEpoch,
+		LoadSeq:     m.state.Events.LoadSeq,
+	})
+	m = teaModel.(*Model)
+	teaModel, _ = m.Update(model.SyncStatusLoadedMsg{
+		Target:      model.SyncStatusTarget{AppName: "test-app", AppNamespace: "test-namespace"},
+		Details:     &model.SyncStatusDetails{Phase: "Succeeded"},
+		SwitchEpoch: m.switchEpoch,
+		LoadSeq:     m.state.Events.LoadSeq,
+	})
+	m = teaModel.(*Model)
+	batch := model.AppsBatchUpdateMsg{
+		Updates:     []model.AppUpdatedMsg{{App: m.state.Apps[0]}},
+		SwitchEpoch: m.switchEpoch,
+	}
+	teaModel, _ = m.Update(batch)
+	m = teaModel.(*Model)
+
+	teaModel, cmd := m.Update(paneWatchRefreshDueMsg{switchEpoch: m.switchEpoch, loadSeq: m.state.Events.LoadSeq})
+	m = teaModel.(*Model)
+
+	if m.state.Events.Loading || len(m.state.Events.Items) != 1 {
+		t.Errorf("a watch-triggered refresh must not blank the pane, got %+v", m.state.Events)
+	}
+	if cmd == nil {
+		t.Fatal("expected the refresh fetches to dispatch")
+	}
+	var gotEvents bool
+	for _, msg := range collectMsgs(t, cmd) {
+		if _, ok := msg.(model.EventsErrorMsg); ok {
+			gotEvents = true
+		}
+	}
+	if !gotEvents {
+		t.Error("expected an events refetch to dispatch")
+	}
+
+	if _, cmd = m.Update(batch); cmd == nil {
+		t.Error("expected the fired tick to disarm, letting the next update arm again")
+	}
+}
+
+// A retarget between the arm and the tick supersedes the refresh: the new
+// target's own load is already running.
+func TestPaneWatchRefreshDue_FromSupersededLoad_IsDropped(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+	teaModel, _ := m.Update(model.EventsLoadedMsg{
+		Target:      m.state.Events.Target,
+		Items:       []model.ResourceEvent{{Reason: "BackOff"}},
+		SwitchEpoch: m.switchEpoch,
+		LoadSeq:     m.state.Events.LoadSeq,
+	})
+	m = teaModel.(*Model)
+	teaModel, _ = m.Update(model.SyncStatusLoadedMsg{
+		Target:      model.SyncStatusTarget{AppName: "test-app", AppNamespace: "test-namespace"},
+		Details:     &model.SyncStatusDetails{Phase: "Succeeded"},
+		SwitchEpoch: m.switchEpoch,
+		LoadSeq:     m.state.Events.LoadSeq,
+	})
+	m = teaModel.(*Model)
+
+	_, cmd := m.Update(paneWatchRefreshDueMsg{switchEpoch: m.switchEpoch, loadSeq: m.state.Events.LoadSeq - 1})
+
+	if cmd != nil {
+		t.Error("expected a superseded watch-refresh tick to be dropped")
+	}
+}
+
+// Two apps sharing a name in different ArgoCD namespaces: only the pane's
+// own app is a freshness signal (ADR-0004).
+func TestAppsBatchUpdate_SameNameOtherNamespace_DoesNotArmWatchRefresh(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+	m.watchGeneration = 7
+	otherNs := "team-a"
+	imposter := m.state.Apps[0]
+	imposter.AppNamespace = &otherNs
+
+	_, cmd := m.Update(model.AppsBatchUpdateMsg{
+		Updates:     []model.AppUpdatedMsg{{App: imposter}},
+		SwitchEpoch: m.switchEpoch,
+	})
+
+	if cmd != nil {
+		t.Error("expected the same-named app from another namespace to leave the pane alone")
+	}
+}
+
 // The pane is part of the tree view: it opens by itself once the tree loads,
 // targeting the selected row, and starts its fetches.
 func TestResourceTreeLoaded_AutoOpensThePane(t *testing.T) {

--- a/cmd/app/events_pane_test.go
+++ b/cmd/app/events_pane_test.go
@@ -1002,6 +1002,30 @@ func TestPaneWatchRefreshDue_RefetchesAndDisarms(t *testing.T) {
 	}
 }
 
+// A pending tick belongs to the load it was armed for: after a retarget,
+// updates must arm for the new load instead of being absorbed by a stale
+// tick that will die on its seq check.
+func TestAppsBatchUpdate_AfterRetarget_ArmsForTheNewLoad(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel()) // opened on the Pod row
+	m.watchGeneration = 7
+	batch := model.AppsBatchUpdateMsg{
+		Updates:     []model.AppUpdatedMsg{{App: m.state.Apps[0]}},
+		SwitchEpoch: m.switchEpoch,
+	}
+	teaModel, cmd := m.Update(batch)
+	if cmd == nil {
+		t.Fatal("setup: the first update must arm")
+	}
+	teaModel, _ = teaModel.(*Model).handleKeyMsg(testKeyMsg("k")) // retarget to the root
+	m = teaModel.(*Model)
+
+	_, cmd = m.Update(batch)
+
+	if cmd == nil {
+		t.Error("expected an update after a retarget to arm for the new load")
+	}
+}
+
 // A retarget between the arm and the tick supersedes the refresh: the new
 // target's own load is already running.
 func TestPaneWatchRefreshDue_FromSupersededLoad_IsDropped(t *testing.T) {

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -65,9 +65,11 @@ type Model struct {
 	// gates late completions (see EventsState.LoadSeq)
 	paneLoadSeq int
 
-	// True while a watch-triggered pane refresh tick is in flight; absorbs
-	// the rest of the watch burst into that one tick.
-	paneWatchRefreshArmed bool
+	// LoadSeq of the pane load a watch-triggered refresh tick is in flight
+	// for (0 = none); absorbs the rest of the watch burst into that one
+	// tick. Scoped to the load so a retarget lets the new load arm its own
+	// tick while the stale one dies on its seq check.
+	paneWatchRefreshArmedSeq int
 
 	// Watch channel for Argo events
 	watchChan chan services.ArgoApiEvent
@@ -1099,8 +1101,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case paneWatchRefreshDueMsg:
-		// The tick fires exactly once per arm, so always disarm first.
-		m.paneWatchRefreshArmed = false
+		// Each arm's tick fires exactly once; disarm only our own arm so a
+		// stale tick cannot release one armed for a newer load.
+		if m.paneWatchRefreshArmedSeq == msg.loadSeq {
+			m.paneWatchRefreshArmedSeq = 0
+		}
 		if msg.switchEpoch != m.switchEpoch {
 			return m, nil
 		}

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -65,6 +65,10 @@ type Model struct {
 	// gates late completions (see EventsState.LoadSeq)
 	paneLoadSeq int
 
+	// True while a watch-triggered pane refresh tick is in flight; absorbs
+	// the rest of the watch burst into that one tick.
+	paneWatchRefreshArmed bool
+
 	// Watch channel for Argo events
 	watchChan chan services.ArgoApiEvent
 	// Closed when the current app watch forwarder stops.
@@ -510,6 +514,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		deletesApplied := 0
+		paneAppTouched := false
 		// Preferred path: apply ordered operations to preserve stream semantics.
 		if len(msg.Operations) > 0 {
 			for _, op := range msg.Operations {
@@ -517,6 +522,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case model.AppBatchOperationUpdate:
 					if op.Update != nil {
 						m.applyBatchAppUpdate(*op.Update)
+						paneAppTouched = paneAppTouched || m.paneShowsApp(op.Update.App)
 					}
 				case model.AppBatchOperationDelete:
 					if op.Delete != "" && m.applyBatchAppDelete(op.Delete) {
@@ -528,6 +534,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Backward-compatible fallback for older/non-ordered producers.
 			for _, upd := range msg.Updates {
 				m.applyBatchAppUpdate(upd)
+				paneAppTouched = paneAppTouched || m.paneShowsApp(upd.App)
 			}
 			for _, name := range msg.Deletes {
 				if m.applyBatchAppDelete(name) {
@@ -555,6 +562,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmds []tea.Cmd
 		if msg.Generation == m.watchGeneration {
 			cmds = append(cmds, m.consumeWatchEvents())
+		}
+		if paneAppTouched {
+			cmds = append(cmds, m.armPaneWatchRefresh())
 		}
 		if msg.Immediate != nil {
 			imm := msg.Immediate
@@ -1087,6 +1097,18 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.schedulePaneAgeTick(st.LoadSeq)
 		}
 		return m, nil
+
+	case paneWatchRefreshDueMsg:
+		// The tick fires exactly once per arm, so always disarm first.
+		m.paneWatchRefreshArmed = false
+		if msg.switchEpoch != m.switchEpoch {
+			return m, nil
+		}
+		st := m.state.Events
+		if st == nil || st.LoadSeq != msg.loadSeq || st.Loading || st.DetailsLoading {
+			return m, nil
+		}
+		return m, m.paneRefreshCmds()
 
 	case model.PaneRefreshDueMsg:
 		if msg.SwitchEpoch != m.switchEpoch {


### PR DESCRIPTION
The tree root's "synced Xs ago" updates live from the watch stream, but the events pane only refetched on its 10s poll — after a sync you'd stare at stale events while the summary already said otherwise.

Now a watch update touching the pane's app (name + ArgoCD namespace) arms a single 1s tick that refetches events + sync details. Decisions:

- **Armed-flag throttle, not a resetting debounce** — constant churn can't starve the refresh; max one refetch per second during a sync burst.
- **Fires independently of `events.refresh_interval`** — it's event-driven; the poll stays as backstop for K8s events that arrive with no app change.
- Same epoch/LoadSeq/in-flight guards as the interval refresh.

```mermaid
sequenceDiagram
    participant W as Watch stream
    participant M as Model
    participant P as Events pane
    W->>M: app update (pane's app)
    M->>M: arm 1s tick
    W->>M: burst updates
    M->>M: coalesced (armed)
    M->>P: tick fires → refetch events + details
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Events panes now refresh automatically after relevant application updates.
  - Repeated updates are coalesced to prevent duplicate refreshes.
  - Unrelated applications and stale refresh requests are ignored.
  - Existing event data remains visible while updated information loads.
  - Refreshing can resume correctly after a previous refresh completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->