### PR TITLE
fix: suggest and validate :events arguments

### DIFF
--- a/cmd/app/events_command_input_test.go
+++ b/cmd/app/events_command_input_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCommand_BareEventsIsInvalid(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+
+	if m.validateCommand("events") {
+		t.Error("bare :events should be invalid, it needs on|off")
+	}
+	if !m.validateCommand("events on") {
+		t.Error(":events on should be valid")
+	}
+	if !m.validateCommand("events off always") {
+		t.Error(":events off always should be valid")
+	}
+}
+
+func TestValidateCommand_SingularEventIsUnknown(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+
+	if m.validateCommand("event on") {
+		t.Error(":event should not be accepted, only :events")
+	}
+}
+
+func TestCommandBar_EventsHintsBothFlagOptions(t *testing.T) {
+	tests := []struct {
+		typed    string
+		wantHint string
+	}{
+		{"ev", "ents on|off"},
+		{"events", " on|off"},
+		{"events ", "on|off"},
+	}
+
+	for _, tc := range tests {
+		m := buildSyncTestModel(100, 30)
+		m.inputComponents.SetCommandValue(tc.typed)
+
+		rendered := m.renderCommandInputWithAutocomplete(80)
+
+		if !strings.Contains(rendered, tc.wantHint) {
+			t.Errorf("typed %q: expected hint %q, got %q", tc.typed, tc.wantHint, rendered)
+		}
+	}
+}

--- a/cmd/app/events_command_input_test.go
+++ b/cmd/app/events_command_input_test.go
@@ -19,6 +19,20 @@ func TestValidateCommand_BareEventsIsInvalid(t *testing.T) {
 	}
 }
 
+func TestValidateCommand_EventsRejectsUnknownFlags(t *testing.T) {
+	m := buildSyncTestModel(100, 30)
+
+	invalid := []string{"events foo", "events on alwayss", "events on always extra"}
+	for _, cmd := range invalid {
+		if m.validateCommand(cmd) {
+			t.Errorf(":%s should be invalid", cmd)
+		}
+	}
+	if !m.validateCommand("events ON") {
+		t.Error(":events ON should be valid, flags are case-insensitive")
+	}
+}
+
 func TestValidateCommand_SingularEventIsUnknown(t *testing.T) {
 	m := buildSyncTestModel(100, 30)
 

--- a/cmd/app/events_pane_test.go
+++ b/cmd/app/events_pane_test.go
@@ -822,27 +822,24 @@ func TestEventsCommand_Bare_IsMarkedInvalid(t *testing.T) {
 	}
 }
 
-// A junk argument explains itself instead of guessing.
-func TestEventsCommand_JunkArgument_ExplainsUsage(t *testing.T) {
+// A junk argument is rejected at submit, same as a bare :events.
+func TestEventsCommand_JunkArgument_IsMarkedInvalid(t *testing.T) {
 	m := openEventsPane(t, buildEventsPaneTestModel())
 
 	m.state.Mode = model.ModeCommand
 	m.inputComponents.SetCommandValue("events foo")
 	m.state.UI.Command = "events foo"
-	teaModel, cmd := m.handleEnhancedCommandModeKeys(tea.KeyPressMsg{Code: tea.KeyEnter})
+	teaModel, _ := m.handleEnhancedCommandModeKeys(tea.KeyPressMsg{Code: tea.KeyEnter})
 	mm := teaModel.(*Model)
 
+	if !mm.state.UI.CommandInvalid {
+		t.Error("expected :events foo to be marked invalid")
+	}
+	if mm.state.Mode != model.ModeCommand {
+		t.Errorf("expected to stay in command mode, got %s", mm.state.Mode)
+	}
 	if mm.state.Events == nil {
 		t.Error("expected the open pane left untouched")
-	}
-	var usage string
-	for _, msg := range collectMsgs(t, cmd) {
-		if sc, ok := msg.(model.StatusChangeMsg); ok {
-			usage = sc.Status
-		}
-	}
-	if !strings.Contains(usage, "on|off") {
-		t.Errorf("expected a usage hint, got %q", usage)
 	}
 }
 

--- a/cmd/app/events_pane_test.go
+++ b/cmd/app/events_pane_test.go
@@ -801,13 +801,34 @@ func TestEventsCommand_On_ReopensThePane(t *testing.T) {
 	}
 }
 
-// A bare :events (or junk argument) explains itself instead of guessing.
-func TestEventsCommand_WithoutOnOff_ExplainsUsage(t *testing.T) {
+// A bare :events is not a command; it is rejected before it reaches the handler.
+func TestEventsCommand_Bare_IsMarkedInvalid(t *testing.T) {
 	m := openEventsPane(t, buildEventsPaneTestModel())
 
 	m.state.Mode = model.ModeCommand
 	m.inputComponents.SetCommandValue("events")
 	m.state.UI.Command = "events"
+	teaModel, _ := m.handleEnhancedCommandModeKeys(tea.KeyPressMsg{Code: tea.KeyEnter})
+	mm := teaModel.(*Model)
+
+	if !mm.state.UI.CommandInvalid {
+		t.Error("expected bare :events to be marked invalid")
+	}
+	if mm.state.Mode != model.ModeCommand {
+		t.Errorf("expected to stay in command mode, got %s", mm.state.Mode)
+	}
+	if mm.state.Events == nil {
+		t.Error("expected the open pane left untouched")
+	}
+}
+
+// A junk argument explains itself instead of guessing.
+func TestEventsCommand_JunkArgument_ExplainsUsage(t *testing.T) {
+	m := openEventsPane(t, buildEventsPaneTestModel())
+
+	m.state.Mode = model.ModeCommand
+	m.inputComponents.SetCommandValue("events foo")
+	m.state.UI.Command = "events foo"
 	teaModel, cmd := m.handleEnhancedCommandModeKeys(tea.KeyPressMsg{Code: tea.KeyEnter})
 	mm := teaModel.(*Model)
 

--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -278,6 +278,17 @@ func (m *Model) validateCommand(input string) bool {
 			// Context names are validated at execution time (re-reads config from disk)
 			// so any non-empty arg is syntactically valid here
 			return true
+		case "events":
+			if len(parts) > 3 {
+				return false
+			}
+			if !strings.EqualFold(arg, "on") && !strings.EqualFold(arg, "off") {
+				return false
+			}
+			if len(parts) == 3 && !strings.EqualFold(parts[2], "always") {
+				return false
+			}
+			return true
 		}
 	}
 

--- a/cmd/app/input_components.go
+++ b/cmd/app/input_components.go
@@ -187,6 +187,11 @@ func (m *Model) validateCommand(input string) bool {
 		return false
 	}
 
+	// :events needs its on|off flag
+	if canonical == "events" && len(parts) == 1 {
+		return false
+	}
+
 	// If command takes an argument and one is provided, validate it
 	if len(parts) >= 2 {
 		arg := parts[1]
@@ -352,6 +357,17 @@ func (m *Model) renderCommandInputWithAutocomplete(maxWidth int) string {
 				suggestionSuffix = strings.TrimPrefix(suggestionSuffix, " ")
 				dimSuggestion = lipgloss.NewStyle().Foreground(dimColor).Render(suggestionSuffix)
 			}
+		}
+	}
+
+	// :events takes a fixed flag; hint both options instead of the first completion,
+	// already while the command name itself is still being completed
+	if len(parts) == 1 {
+		dimStyle := lipgloss.NewStyle().Foreground(dimColor)
+		if hasTrailingSpace && strings.EqualFold(parts[0], "events") {
+			dimSuggestion = dimStyle.Render("on|off")
+		} else if !hasTrailingSpace && strings.EqualFold(firstPlain, "events") {
+			dimSuggestion = dimStyle.Render(firstPlain[len(currentInput):] + " on|off")
 		}
 	}
 

--- a/pkg/autocomplete/autocomplete.go
+++ b/pkg/autocomplete/autocomplete.go
@@ -577,6 +577,9 @@ func (e *AutocompleteEngine) getSecondArgumentSuggestions(command, firstArg, pre
 	case "sort":
 		options = []string{"asc", "desc"}
 	case "events":
+		if !strings.EqualFold(firstArg, "on") && !strings.EqualFold(firstArg, "off") {
+			return nil
+		}
 		options = []string{"always"}
 	default:
 		return nil

--- a/pkg/autocomplete/autocomplete.go
+++ b/pkg/autocomplete/autocomplete.go
@@ -101,10 +101,10 @@ func NewAutocompleteEngine() *AutocompleteEngine {
 		},
 		{
 			Command:     "events",
-			Aliases:     []string{"events", "event"},
+			Aliases:     []string{"events"},
 			Description: "Auto-open the events pane: on|off, add 'always' to persist",
 			TakesArg:    true,
-			ArgType:     "",
+			ArgType:     "events",
 		},
 		{
 			Command:     "logs",
@@ -265,13 +265,18 @@ func (e *AutocompleteEngine) GetCommandAutocomplete(input string, state *model.A
 			return e.getSecondArgumentSuggestions(parts[0], parts[1], "", true, state)
 		}
 		// Check if first arg exactly matches a valid option for commands with second args
-		// This shows direction suggestions right after typing a complete field name
+		// This shows second-arg suggestions right after typing a complete first arg
 		cmdInfo := e.GetCommandInfo(parts[0])
-		if cmdInfo != nil && cmdInfo.Command == "sort" {
-			firstArgSuggestions := e.getSortSuggestions("")
+		if cmdInfo != nil {
+			var firstArgSuggestions []string
+			switch cmdInfo.Command {
+			case "sort":
+				firstArgSuggestions = e.getSortSuggestions("")
+			case "events":
+				firstArgSuggestions = e.getEventsSuggestions("")
+			}
 			for _, s := range firstArgSuggestions {
 				if strings.EqualFold(s, parts[1]) {
-					// First arg is complete, suggest second argument (direction is required)
 					return e.getSecondArgumentSuggestions(parts[0], parts[1], "", false, state)
 				}
 			}
@@ -341,6 +346,8 @@ func (e *AutocompleteEngine) getArgumentSuggestions(command, argPrefix string, s
 		suggestions = e.getThemeSuggestions(argPrefix)
 	case "sort":
 		suggestions = e.getSortSuggestions(argPrefix)
+	case "events":
+		suggestions = e.getEventsSuggestions(argPrefix)
 	case "argocd-context":
 		suggestions = e.getArgocdContextSuggestions(argPrefix, state)
 	}
@@ -543,6 +550,20 @@ func (e *AutocompleteEngine) getSortSuggestions(prefix string) []string {
 	return suggestions
 }
 
+// getEventsSuggestions returns the on/off options for the events command
+func (e *AutocompleteEngine) getEventsSuggestions(prefix string) []string {
+	var suggestions []string
+	prefix = strings.ToLower(prefix)
+
+	for _, opt := range []string{"on", "off"} {
+		if strings.HasPrefix(opt, prefix) {
+			suggestions = append(suggestions, opt)
+		}
+	}
+
+	return suggestions
+}
+
 // getSecondArgumentSuggestions returns suggestions for a second argument (e.g., sort direction)
 // The hasTrailingSpace parameter indicates if the original input had a trailing space after the current token
 func (e *AutocompleteEngine) getSecondArgumentSuggestions(command, firstArg, prefix string, hasTrailingSpace bool, state *model.AppState) []string {
@@ -551,13 +572,16 @@ func (e *AutocompleteEngine) getSecondArgumentSuggestions(command, firstArg, pre
 		return nil
 	}
 
-	// Currently only sort command has a second argument
-	if cmdInfo.Command != "sort" {
+	var options []string
+	switch cmdInfo.Command {
+	case "sort":
+		options = []string{"asc", "desc"}
+	case "events":
+		options = []string{"always"}
+	default:
 		return nil
 	}
 
-	// Suggest direction options
-	options := []string{"asc", "desc"}
 	var suggestions []string
 	prefix = strings.ToLower(prefix)
 
@@ -567,21 +591,9 @@ func (e *AutocompleteEngine) getSecondArgumentSuggestions(command, firstArg, pre
 		}
 	}
 
-	// Build suggestions that match the input format exactly
-	// When hasTrailingSpace is true and prefix is empty, input is "sort name "
-	// so suggestion should be "sort name asc" (matching the space)
 	prefixedSuggestions := make([]string, len(suggestions))
 	for i, suggestion := range suggestions {
-		if hasTrailingSpace && prefix == "" {
-			// Input: "sort name " -> Suggestion: "sort name asc"
-			prefixedSuggestions[i] = ":" + command + " " + firstArg + " " + suggestion
-		} else if prefix != "" {
-			// Input: "sort name a" or "sort name as" -> Suggestion: "sort name asc"
-			prefixedSuggestions[i] = ":" + command + " " + firstArg + " " + suggestion
-		} else {
-			// Input: "sort name" (no trailing space) -> Suggestion: "sort name asc" (add space before direction)
-			prefixedSuggestions[i] = ":" + command + " " + firstArg + " " + suggestion
-		}
+		prefixedSuggestions[i] = ":" + command + " " + firstArg + " " + suggestion
 	}
 
 	return prefixedSuggestions

--- a/pkg/autocomplete/autocomplete_test.go
+++ b/pkg/autocomplete/autocomplete_test.go
@@ -325,6 +325,42 @@ func TestSortCommandRequiresDirection(t *testing.T) {
 	}
 }
 
+func TestEventsCommandAutocomplete(t *testing.T) {
+	engine := NewAutocompleteEngine()
+	state := createTestState()
+
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{":events ", []string{":events on", ":events off"}},
+		{":events o", []string{":events on", ":events off"}},
+		{":events on", []string{":events on always"}},
+		{":events off", []string{":events off always"}},
+		{":events on ", []string{":events on always"}},
+		{":events on al", []string{":events on always"}},
+		{":events on x", []string{}},
+	}
+
+	for _, test := range tests {
+		suggestions := engine.GetCommandAutocomplete(test.input, state)
+		if !reflect.DeepEqual(suggestions, test.expected) {
+			t.Errorf("input %q: expected %v, got %v", test.input, test.expected, suggestions)
+		}
+	}
+}
+
+func TestEventsCommandHasNoSingularAlias(t *testing.T) {
+	engine := NewAutocompleteEngine()
+
+	if got := engine.ResolveAlias("event"); got != "event" {
+		t.Errorf("'event' should not resolve to a command, resolved to %q", got)
+	}
+	if engine.GetCommandInfo("event") != nil {
+		t.Error("'event' should not be a known command")
+	}
+}
+
 func TestThemeCommandAutocomplete(t *testing.T) {
 	engine := NewAutocompleteEngine()
 	state := createTestState()

--- a/pkg/autocomplete/autocomplete_test.go
+++ b/pkg/autocomplete/autocomplete_test.go
@@ -340,6 +340,8 @@ func TestEventsCommandAutocomplete(t *testing.T) {
 		{":events on ", []string{":events on always"}},
 		{":events on al", []string{":events on always"}},
 		{":events on x", []string{}},
+		{":events foo ", nil},
+		{":events foo a", nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
`:events` autocomplete was dead: `ArgType` was empty, so `on`/`off` were never suggested and always rendered red, and second-arg suggestions were hardcoded to `:sort`.

- `on`/`off` and `always` are now suggested and colored valid; `on` first, so tab completes `:events on`
- the ghost hint reads `on|off` as soon as `events` is the completion, not only after the space
- bare `:events` is rejected as invalid; the singular `event` alias is dropped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added autocomplete suggestions for `:events on` and `:events off`.
  - Added support for the optional `always` argument.
  - Added prefix-aware suggestions for event settings and durations.
- **Bug Fixes**
  - Invalid or incomplete `:events` commands are now rejected with usage guidance.
  - Removed support for the singular `:event` command and alias.
- **Tests**
  - Added coverage for command validation, autocomplete suggestions, valid options, invalid input, and command-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->