### PR TITLE
ci: temporarily disable AUR publishing

### DIFF
--- a/.github/workflows/aur-git-publish.yml
+++ b/.github/workflows/aur-git-publish.yml
@@ -1,8 +1,9 @@
 name: aur-git-publish
 
 on:
-  push:
-    branches: [main]
+  # push trigger temporarily disabled: aur.archlinux.org has disabled uploads; revert when they re-enable
+  # push:
+  #   branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,6 +13,11 @@ on:
         description: "Existing tag to (re)build and upload assets for, e.g. v2.17.0"
         required: true
         type: string
+      skip:
+        description: "Comma-separated goreleaser pipes to skip, e.g. aur"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -78,7 +83,7 @@ jobs:
         with:
           distribution: goreleaser
           version: nightly
-          args: release --config .goreleaser.release.yml --clean
+          args: release --config .goreleaser.release.yml --clean ${{ inputs.skip != '' && format('--skip={0}', inputs.skip) || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}          # must have repo:status, repo:write
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }} # PAT with write on tap repo

--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -38,7 +38,8 @@ aurs:
     git_url: ssh://aur@aur.archlinux.org/argonaut-bin.git
     provides: [argonaut]
     conflicts: [argonaut]
-    skip_upload: false
+    # temporarily true: aur.archlinux.org has disabled uploads; revert when they re-enable
+    skip_upload: true
     commit_msg_template: "upgpkg: {{ .ProjectName }} {{ .Version }}"
     package: |
       _binname="argonaut"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ brew install darksworm/tap/argonaut
 <details>
   <summary><strong>AUR (Arch User Repository)</strong></summary>
 
+> [!WARNING]
+> AUR uploads are currently disabled on aur.archlinux.org, so these packages may lag behind the latest release until uploads are re-enabled.
+
 ```bash
 yay -S argonaut-bin
 ```

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ brew install darksworm/tap/argonaut
 <details>
   <summary><strong>AUR (Arch User Repository)</strong></summary>
 
-> [!WARNING]
-> AUR uploads are currently disabled on aur.archlinux.org, so these packages may lag behind the latest release until uploads are re-enabled.
+**⚠️ AUR uploads are currently disabled on aur.archlinux.org, so these packages may lag behind the latest release.** In the meantime, run `:upgrade` inside argonaut to update to the latest version.
 
 ```bash
 yay -S argonaut-bin


### PR DESCRIPTION
aur.archlinux.org has disabled uploads with no ETA, which breaks the release pipeline at the AUR publish step.

- `skip_upload: true` on the aurs publisher and the `argonaut-git` push trigger commented out — revert both when AUR re-enables uploads
- README warning that AUR packages may lag
- goreleaser workflow gains an optional `skip` dispatch input (used to finish the blocked v2.18.0 release with `--skip=aur`)
