### PR TITLE
ci: pin action SHAs and drop unused ghcr push perms

### DIFF
--- a/.github/workflows/aur-git-publish.yml
+++ b/.github/workflows/aur-git-publish.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'darksworm/argonaut'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -52,7 +52,7 @@ jobs:
 
       - name: Publish to AUR
         if: env.AUR_SSH_PRIVATE_KEY != ''
-        uses: KSXGitHub/github-actions-deploy-aur@v2.7.2
+        uses: KSXGitHub/github-actions-deploy-aur@9dfe151cf48f26a957bbd0379c120e79cb990e13 # v2.7.2
         with:
           pkgname: argonaut-git
           pkgbuild: dist/aur/PKGBUILD

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Fetch recent tags for GoReleaser changelog generation
           fetch-depth: 100
@@ -44,18 +44,18 @@ jobs:
           git config --global user.email "bot@goreleaser.com"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Setup SSH key for AUR
         if: env.AUR_SSH_PRIVATE_KEY != ''
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
         env:
@@ -71,7 +71,7 @@ jobs:
 
       - name: Import GPG key
         if: env.GPG_PRIVATE_KEY != ''
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
@@ -79,7 +79,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: nightly
@@ -92,14 +92,14 @@ jobs:
           TAG: ${{ inputs.tag }}
 
       - name: Upload GoReleaser artifacts for npm publishing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: goreleaser-dist-release
           path: dist/
           retention-days: 1
 
       - name: Publish release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           script: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
+          cache: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3

--- a/.github/workflows/pr-prerelease.yml
+++ b/.github/workflows/pr-prerelease.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ needs.check-release-pr.outputs.pr_sha }}
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -129,8 +130,6 @@ jobs:
           distribution: goreleaser
           version: nightly
           args: release --config .goreleaser.release.yml --snapshot --clean --skip=aur,nix
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Debug GoReleaser output
         run: |

--- a/.github/workflows/pr-prerelease.yml
+++ b/.github/workflows/pr-prerelease.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  packages: write
 
 jobs:
   check-release-pr:
@@ -31,7 +30,7 @@ jobs:
       - name: Get PR details for comment trigger
         id: pr-details
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -87,28 +86,21 @@ jobs:
       pre_version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
           ref: ${{ needs.check-release-pr.outputs.pr_sha }}
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Create snapshot version
         id: version
@@ -132,7 +124,7 @@ jobs:
           echo "Building pre-release version: $VERSION"
 
       - name: Run GoReleaser release with dev tags (no publishing)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: nightly
@@ -179,7 +171,7 @@ jobs:
           cd ..
 
       - name: Upload Linux binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: linux-binaries-${{ steps.version.outputs.version }}
           path: pr-artifacts/argonaut-linux-*
@@ -187,7 +179,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload macOS binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: macos-binaries-${{ steps.version.outputs.version }}
           path: pr-artifacts/argonaut-darwin-*
@@ -195,7 +187,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload DEB packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: deb-packages-${{ steps.version.outputs.version }}
           path: pr-artifacts/*.deb
@@ -203,7 +195,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload RPM packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpm-packages-${{ steps.version.outputs.version }}
           path: pr-artifacts/*.rpm
@@ -211,7 +203,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload APK packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: apk-packages-${{ steps.version.outputs.version }}
           path: pr-artifacts/*.apk
@@ -219,14 +211,14 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload checksums
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: checksums-${{ steps.version.outputs.version }}
           path: pr-artifacts/checksums.txt
           retention-days: 30
 
       - name: Comment on PR with download link
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PRE_VERSION: ${{ steps.version.outputs.version }}
           PR_NUMBER: ${{ needs.check-release-pr.outputs.pr_number }}

--- a/.github/workflows/pr-prerelease.yml
+++ b/.github/workflows/pr-prerelease.yml
@@ -280,11 +280,6 @@ jobs:
             ${artifactFiles.map(f => `- \`${f}\``).join('\n')}
             </details>
 
-            ### 🐳 Docker Image
-            \`\`\`bash
-            docker pull ghcr.io/${repoFullName}:${version}
-            \`\`\`
-
             ### 🔍 Checksums
             <details>
             <summary>Click to expand checksums</summary>

--- a/.github/workflows/pr-prerelease.yml
+++ b/.github/workflows/pr-prerelease.yml
@@ -96,6 +96,7 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
+          cache: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Test argonaut installation and functionality
         uses: ./.github/actions/test-argonaut-install
@@ -71,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Test argonaut AUR installation and functionality
         shell: bash

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: release
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
@@ -50,7 +50,7 @@ jobs:
           - manjarolinux/base:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Test argonaut installation and functionality
         uses: ./.github/actions/test-argonaut-install
@@ -70,7 +70,7 @@ jobs:
           - archlinux:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Test argonaut AUR installation and functionality
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25.x'
           check-latest: true
 
       - name: Cache Go build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/go-build
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload e2e test snapshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-test-snapshots
           path: e2e/test-snapshots/

--- a/.github/workflows/update-nix-vendorhash.yml
+++ b/.github/workflows/update-nix-vendorhash.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create pull request with updated vendorHash
         if: steps.diff.outputs.changed == 'true' && github.event_name == 'workflow_dispatch'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: "chore: update Nix vendor hash"
           branch: bot/update-nix-vendor-hash


### PR DESCRIPTION
Pin all third-party GitHub Actions to commit SHAs (version kept as `# vX` comment), and trim the PR pre-release job to the token it actually uses.

## Why
- Secret-bearing jobs (`goreleaser`, `aur-git-publish`) run third-party actions next to the AUR key, GPG key, and release PAT. A mutable tag lets that action's repo repoint `@vX` at malicious code. SHAs can't be moved.
- The `/prerelease` snapshot build never pushes to a registry (goreleaser `--snapshot` skips publishing), so its ghcr login step and `packages: write` were dead — and `packages: write` was the permission that would let an exfiltrated `GITHUB_TOKEN` poison the official ghcr image. Dropped both.

Local `./.github/...` refs left as-is. Version comments keep Dependabot/Renovate able to bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Pinned automation actions to immutable versions for more reliable and secure builds.
  * Reduced permissions and removed unnecessary container registry login steps from prerelease workflows.
* **Release Workflow**
  * Prerelease pull request comments no longer include Docker image pull instructions.
  * Existing build, test, packaging, and release behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->