### PR TITLE
docs: correct auto-sync enabled field version to 3.1

### DIFF
--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -60,7 +60,7 @@ type SyncPolicy struct {
 }
 
 // AutomatedSyncPolicy mirrors spec.syncPolicy.automated; Enabled defaults to
-// true when the automated block is present (pre-2.13 servers have no field)
+// true when the automated block is present (pre-3.1 servers have no field)
 type AutomatedSyncPolicy struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }


### PR DESCRIPTION
`spec.syncPolicy.automated.enabled` landed in Argo CD 3.1, not 2.13.

Verified against upstream `pkg/apis/application/v1alpha1/types.go`: absent at v2.13.0 and v3.0.0, present at v3.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the compatibility note for automated synchronization settings on older servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->