### PR TITLE
feat: explain a sync waiting on prune confirmation

### DIFF
--- a/cmd/app/view_pane.go
+++ b/cmd/app/view_pane.go
@@ -210,6 +210,11 @@ func renderSyncStatusBody(details *model.SyncStatusDetails, width int, now time.
 		terminateHint = "[t] terminate"
 	}
 	field("Phase", details.Phase, lipgloss.NewStyle().Foreground(phaseColor), terminateHint)
+	// Argo CD parks the operation in Running with no message when a resource
+	// carries Prune=confirm, so the reason has to come from the resource list.
+	if details.AwaitingPruneConfirmation {
+		field("Waiting on", "prune confirmation", lipgloss.NewStyle().Foreground(currentPalette.Warning))
+	}
 	field("Started", humantime.AgoLong(details.StartedAt, now), text)
 	duration := details.FinishedAt.Sub(details.StartedAt)
 	if details.FinishedAt.IsZero() {

--- a/cmd/app/view_pane_operation_test.go
+++ b/cmd/app/view_pane_operation_test.go
@@ -50,3 +50,27 @@ func TestSyncStatusPane_PlainSyncCarriesNoQualifier(t *testing.T) {
 		t.Errorf("expected a bare Sync, got %q", line)
 	}
 }
+
+func TestSyncStatusPane_ExplainsASyncHeldOnPruneConfirmation(t *testing.T) {
+	lines := renderSyncStatusBody(&model.SyncStatusDetails{
+		Operation:                 "Sync",
+		Phase:                     "Running",
+		AwaitingPruneConfirmation: true,
+	}, 46, time.Now(), "")
+
+	out := stripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(out, "confirmation") {
+		t.Errorf("expected the pane to say the sync is waiting for confirmation, got:\n%s", out)
+	}
+}
+
+func TestSyncStatusPane_SaysNothingAboutConfirmationOnAnOrdinarySync(t *testing.T) {
+	lines := renderSyncStatusBody(&model.SyncStatusDetails{
+		Operation: "Sync",
+		Phase:     "Running",
+	}, 46, time.Now(), "")
+
+	if strings.Contains(stripANSI(strings.Join(lines, "\n")), "confirmation") {
+		t.Error("expected no confirmation notice on an ordinary running sync")
+	}
+}

--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -98,6 +98,7 @@ type SyncOperation struct {
 	// DryRun and Resources qualify what the operation actually did: a dry run
 	// applies nothing, and a non-empty Resources means only a subset was synced.
 	DryRun    bool                 `json:"dryRun,omitempty"`
+	Prune     bool                 `json:"prune,omitempty"`
 	Resources []SyncResourceTarget `json:"resources,omitempty"`
 }
 
@@ -668,17 +669,33 @@ func ConvertOperationState(argoApp ArgoApplication) *model.SyncStatusDetails {
 	}
 	operation, note := describeOperation(argoApp)
 	return &model.SyncStatusDetails{
-		Operation:     operation,
-		OperationNote: note,
-		Phase:         opState.Phase,
-		Message:       shortenShas(flattenWhitespace(opState.Message)),
-		StartedAt:     opState.StartedAt,
-		FinishedAt:    opState.FinishedAt,
-		Revision:      opState.resolvedRevision(),
-		InitiatedBy:   opState.Operation.InitiatedBy.Username,
-		Automated:     opState.Operation.InitiatedBy.Automated,
-		Resources:     resources,
+		AwaitingPruneConfirmation: awaitingPruneConfirmation(argoApp),
+		Operation:                 operation,
+		OperationNote:             note,
+		Phase:                     opState.Phase,
+		Message:                   shortenShas(flattenWhitespace(opState.Message)),
+		StartedAt:                 opState.StartedAt,
+		FinishedAt:                opState.FinishedAt,
+		Revision:                  opState.resolvedRevision(),
+		InitiatedBy:               opState.Operation.InitiatedBy.Username,
+		Automated:                 opState.Operation.InitiatedBy.Automated,
+		Resources:                 resources,
 	}
+}
+
+// awaitingPruneConfirmation reports a sync that has stopped and is waiting on
+// a human. Argo CD leaves such an operation in Running indefinitely with no
+// message, so without this the only visible state is a sync that never ends.
+func awaitingPruneConfirmation(argoApp ArgoApplication) bool {
+	if argoApp.Status.OperationState.Phase != "Running" {
+		return false
+	}
+	for _, r := range argoApp.Status.Resources {
+		if r.RequiresDeletionConfirmation {
+			return true
+		}
+	}
+	return false
 }
 
 // describeOperation names what the last operation actually was. Argo CD
@@ -788,6 +805,9 @@ type ResourceStatus struct {
 	Status    string          `json:"status"` // Sync status: "Synced", "OutOfSync"
 	Version   string          `json:"version"`
 	Health    *ResourceHealth `json:"health,omitempty"`
+	// RequiresDeletionConfirmation is set by Argo CD when the resource carries
+	// Prune=confirm or Delete=confirm: the sync stops and waits for a human.
+	RequiresDeletionConfirmation bool `json:"requiresDeletionConfirmation,omitempty"`
 }
 
 // GetResourceTree retrieves the resource tree for an application

--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -690,6 +690,10 @@ func awaitingPruneConfirmation(argoApp ArgoApplication) bool {
 	if argoApp.Status.OperationState.Phase != "Running" {
 		return false
 	}
+	sync := argoApp.Status.OperationState.Operation.Sync
+	if sync == nil || !sync.Prune {
+		return false
+	}
 	for _, r := range argoApp.Status.Resources {
 		if r.RequiresDeletionConfirmation {
 			return true

--- a/pkg/api/applications.go
+++ b/pkg/api/applications.go
@@ -695,7 +695,7 @@ func awaitingPruneConfirmation(argoApp ArgoApplication) bool {
 		return false
 	}
 	for _, r := range argoApp.Status.Resources {
-		if r.RequiresDeletionConfirmation {
+		if r.RequiresPruning && r.RequiresDeletionConfirmation {
 			return true
 		}
 	}
@@ -802,15 +802,16 @@ type ResourceTree struct {
 
 // ResourceStatus holds sync/health status for a managed resource (from Application.status.resources[])
 type ResourceStatus struct {
-	Group     string          `json:"group"`
-	Kind      string          `json:"kind"`
-	Name      string          `json:"name"`
-	Namespace string          `json:"namespace,omitempty"`
-	Status    string          `json:"status"` // Sync status: "Synced", "OutOfSync"
-	Version   string          `json:"version"`
-	Health    *ResourceHealth `json:"health,omitempty"`
+	Group           string          `json:"group"`
+	Kind            string          `json:"kind"`
+	Name            string          `json:"name"`
+	Namespace       string          `json:"namespace,omitempty"`
+	Status          string          `json:"status"` // Sync status: "Synced", "OutOfSync"
+	Version         string          `json:"version"`
+	Health          *ResourceHealth `json:"health,omitempty"`
+	RequiresPruning bool            `json:"requiresPruning,omitempty"`
 	// RequiresDeletionConfirmation is set by Argo CD when the resource carries
-	// Prune=confirm or Delete=confirm: the sync stops and waits for a human.
+	// Prune=confirm or Delete=confirm.
 	RequiresDeletionConfirmation bool `json:"requiresDeletionConfirmation,omitempty"`
 }
 

--- a/pkg/api/applications_prune_confirmation_test.go
+++ b/pkg/api/applications_prune_confirmation_test.go
@@ -1,0 +1,50 @@
+package api
+
+import "testing"
+
+func runningSyncOf(resources []ResourceStatus) ArgoApplication {
+	return ArgoApplication{
+		Metadata: ApplicationMetadata{Name: "demo-app"},
+		Status: ApplicationStatus{
+			Resources: resources,
+			OperationState: OperationState{
+				Phase:     "Running",
+				Operation: Operation{Sync: &SyncOperation{Prune: true}},
+			},
+		},
+	}
+}
+
+func TestConvertOperationState_SyncWaitingOnPruneConfirmation_SaysWhyItIsStuck(t *testing.T) {
+	app := runningSyncOf([]ResourceStatus{
+		{Kind: "ConfigMap", Name: "settings"},
+		{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true},
+	})
+
+	details := ConvertOperationState(app)
+
+	if !details.AwaitingPruneConfirmation {
+		t.Error("expected a sync held on prune confirmation to be reported as such")
+	}
+}
+
+func TestConvertOperationState_RunningSyncWithNothingToConfirm_IsJustRunning(t *testing.T) {
+	app := runningSyncOf([]ResourceStatus{{Kind: "ConfigMap", Name: "settings"}})
+
+	details := ConvertOperationState(app)
+
+	if details.AwaitingPruneConfirmation {
+		t.Error("expected no confirmation notice when no resource requires one")
+	}
+}
+
+func TestConvertOperationState_FinishedSync_IsNotWaitingOnAnything(t *testing.T) {
+	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
+	app.Status.OperationState.Phase = "Succeeded"
+
+	details := ConvertOperationState(app)
+
+	if details.AwaitingPruneConfirmation {
+		t.Error("expected a finished sync not to report waiting on confirmation")
+	}
+}

--- a/pkg/api/applications_prune_confirmation_test.go
+++ b/pkg/api/applications_prune_confirmation_test.go
@@ -18,7 +18,7 @@ func runningSyncOf(resources []ResourceStatus) ArgoApplication {
 func TestConvertOperationState_SyncWaitingOnPruneConfirmation_SaysWhyItIsStuck(t *testing.T) {
 	app := runningSyncOf([]ResourceStatus{
 		{Kind: "ConfigMap", Name: "settings"},
-		{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true},
+		{Kind: "Namespace", Name: "legacy", RequiresPruning: true, RequiresDeletionConfirmation: true},
 	})
 
 	details := ConvertOperationState(app)
@@ -39,7 +39,7 @@ func TestConvertOperationState_RunningSyncWithNothingToConfirm_IsJustRunning(t *
 }
 
 func TestConvertOperationState_NonSyncOperationIsNotWaitingOnPruneConfirmation(t *testing.T) {
-	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
+	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresPruning: true, RequiresDeletionConfirmation: true}})
 	app.Status.OperationState.Operation.Sync = nil
 
 	details := ConvertOperationState(app)
@@ -50,7 +50,7 @@ func TestConvertOperationState_NonSyncOperationIsNotWaitingOnPruneConfirmation(t
 }
 
 func TestConvertOperationState_SyncWithoutPruneIsNotWaitingOnPruneConfirmation(t *testing.T) {
-	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
+	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresPruning: true, RequiresDeletionConfirmation: true}})
 	app.Status.OperationState.Operation.Sync.Prune = false
 
 	details := ConvertOperationState(app)
@@ -60,8 +60,18 @@ func TestConvertOperationState_SyncWithoutPruneIsNotWaitingOnPruneConfirmation(t
 	}
 }
 
-func TestConvertOperationState_FinishedSync_IsNotWaitingOnAnything(t *testing.T) {
+func TestConvertOperationState_DeletionConfirmationWithoutPruningIsNotPruneConfirmation(t *testing.T) {
 	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
+
+	details := ConvertOperationState(app)
+
+	if details.AwaitingPruneConfirmation {
+		t.Error("expected deletion confirmation without pruning not to report waiting on prune confirmation")
+	}
+}
+
+func TestConvertOperationState_FinishedSync_IsNotWaitingOnAnything(t *testing.T) {
+	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresPruning: true, RequiresDeletionConfirmation: true}})
 	app.Status.OperationState.Phase = "Succeeded"
 
 	details := ConvertOperationState(app)

--- a/pkg/api/applications_prune_confirmation_test.go
+++ b/pkg/api/applications_prune_confirmation_test.go
@@ -38,6 +38,28 @@ func TestConvertOperationState_RunningSyncWithNothingToConfirm_IsJustRunning(t *
 	}
 }
 
+func TestConvertOperationState_NonSyncOperationIsNotWaitingOnPruneConfirmation(t *testing.T) {
+	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
+	app.Status.OperationState.Operation.Sync = nil
+
+	details := ConvertOperationState(app)
+
+	if details.AwaitingPruneConfirmation {
+		t.Error("expected a non-sync operation not to report waiting on prune confirmation")
+	}
+}
+
+func TestConvertOperationState_SyncWithoutPruneIsNotWaitingOnPruneConfirmation(t *testing.T) {
+	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
+	app.Status.OperationState.Operation.Sync.Prune = false
+
+	details := ConvertOperationState(app)
+
+	if details.AwaitingPruneConfirmation {
+		t.Error("expected a sync with pruning disabled not to report waiting on prune confirmation")
+	}
+}
+
 func TestConvertOperationState_FinishedSync_IsNotWaitingOnAnything(t *testing.T) {
 	app := runningSyncOf([]ResourceStatus{{Kind: "Namespace", Name: "legacy", RequiresDeletionConfirmation: true}})
 	app.Status.OperationState.Phase = "Succeeded"

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -74,16 +74,19 @@ type SyncResourceResult struct {
 // SyncStatusDetails is the full last-operation state shown in the
 // sync-status pane, including per-resource results.
 type SyncStatusDetails struct {
-	Phase         string               `json:"phase"`
-	Message       string               `json:"message"`
-	StartedAt     time.Time            `json:"startedAt"`
-	FinishedAt    time.Time            `json:"finishedAt"` // zero while the operation is running
-	Revision      string               `json:"revision"`
-	InitiatedBy   string               `json:"initiatedBy"`
-	Automated     bool                 `json:"automated"`
-	Operation     string               `json:"operation"`
-	OperationNote string               `json:"operationNote,omitempty"`
-	Resources     []SyncResourceResult `json:"resources"`
+	Phase         string    `json:"phase"`
+	Message       string    `json:"message"`
+	StartedAt     time.Time `json:"startedAt"`
+	FinishedAt    time.Time `json:"finishedAt"` // zero while the operation is running
+	Revision      string    `json:"revision"`
+	InitiatedBy   string    `json:"initiatedBy"`
+	Automated     bool      `json:"automated"`
+	Operation     string    `json:"operation"`
+	OperationNote string    `json:"operationNote,omitempty"`
+	// AwaitingPruneConfirmation explains an operation that would otherwise sit
+	// in Running forever with no visible reason.
+	AwaitingPruneConfirmation bool                 `json:"awaitingPruneConfirmation,omitempty"`
+	Resources                 []SyncResourceResult `json:"resources"`
 }
 
 // App represents an ArgoCD application


### PR DESCRIPTION
A resource carrying `Prune=confirm` stops the sync and waits for a human. Argo CD leaves the operation in `Running` indefinitely with no message, so the only visible state in argonaut was a sync that never ends — and the only exit on offer was terminate, which is the wrong answer.

The pane now reads:

```
Operation     Sync
Phase         Running  [t] terminate
Waiting on    prune confirmation
```

`requiresDeletionConfirmation` on `status.resources` was unmodelled. Detection is scoped to a Running operation, so a finished sync never shows the notice.

Confirming from argonaut is not in this PR — `argocd app confirm-deletion` or the Web UI for now. The Web UI shows a button but never explains the wait; this explains it.

Stacked on #279.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync status now indicates when an operation is waiting for prune confirmation.
  * Running syncs identify when resource deletion approval is required.

* **Bug Fixes**
  * Improved sync-state reporting for operations awaiting prune confirmation.
  * Completed syncs, non-sync operations, and syncs without pruning remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->