### PR TITLE
fix: stop the pane asking Argo CD for an unnamed application

### DIFF
--- a/cmd/app/api_integration.go
+++ b/cmd/app/api_integration.go
@@ -730,6 +730,7 @@ func (m *Model) startLoadingResourceTree(app model.App) tea.Cmd {
 
 		return model.ResourceTreeLoadedMsg{
 			AppName:       app.Name,
+			AppNamespace:  appNamespace,
 			Health:        app.Health,
 			Sync:          app.Sync,
 			TreeJSON:      data,

--- a/cmd/app/events_pane.go
+++ b/cmd/app/events_pane.go
@@ -230,6 +230,14 @@ func (m *Model) handleShowEvents() (tea.Model, tea.Cmd) {
 // paneFetchCmds returns the fetches the open pane still needs.
 func (m *Model) paneFetchCmds() tea.Cmd {
 	st := m.state.Events
+	// The pane can open before the resource tree has loaded, and until it has,
+	// the tree cannot name the app. Fetching anyway asks Argo CD for
+	// /api/v1/applications/ with no name, which answers 403 — surfacing as a
+	// bare "permission denied" that reads like an RBAC problem. The loading
+	// flags stay set, so the refresh armed alongside this retries.
+	if st.Target.AppName == "" {
+		return nil
+	}
 	var cmds []tea.Cmd
 	if st.Loading {
 		cmds = append(cmds, m.loadEvents(st.Target, st.LoadSeq))

--- a/cmd/app/events_pane.go
+++ b/cmd/app/events_pane.go
@@ -94,8 +94,9 @@ func (m *Model) paneCanFetch() bool {
 	return m.state.Events != nil && m.state.Events.Target.AppName != ""
 }
 
-// paneRefreshCmds returns the background refetches for the open pane:
-// details always, events unless the target cannot have any.
+// paneRefreshCmds returns no commands until the pane has a fetchable target.
+// Otherwise it refetches details always, and events unless the target cannot
+// have any.
 func (m *Model) paneRefreshCmds() tea.Cmd {
 	st := m.state.Events
 	if !m.paneCanFetch() {

--- a/cmd/app/events_pane.go
+++ b/cmd/app/events_pane.go
@@ -85,10 +85,22 @@ func (m *Model) schedulePaneRefresh(loadSeq int) tea.Cmd {
 	})
 }
 
+// paneCanFetch reports whether the pane knows which application it is showing.
+// It can be open before the resource tree has loaded, and until it has, the
+// tree cannot name the app: fetching anyway asks Argo CD for
+// /api/v1/applications/ with no name, which answers 403 — surfacing as a bare
+// "permission denied" that reads like an RBAC problem.
+func (m *Model) paneCanFetch() bool {
+	return m.state.Events != nil && m.state.Events.Target.AppName != ""
+}
+
 // paneRefreshCmds returns the background refetches for the open pane:
 // details always, events unless the target cannot have any.
 func (m *Model) paneRefreshCmds() tea.Cmd {
 	st := m.state.Events
+	if !m.paneCanFetch() {
+		return nil
+	}
 	cmds := []tea.Cmd{m.loadSyncStatus(model.SyncStatusTarget{
 		AppName:      st.Target.AppName,
 		AppNamespace: st.Target.AppNamespace,
@@ -230,12 +242,9 @@ func (m *Model) handleShowEvents() (tea.Model, tea.Cmd) {
 // paneFetchCmds returns the fetches the open pane still needs.
 func (m *Model) paneFetchCmds() tea.Cmd {
 	st := m.state.Events
-	// The pane can open before the resource tree has loaded, and until it has,
-	// the tree cannot name the app. Fetching anyway asks Argo CD for
-	// /api/v1/applications/ with no name, which answers 403 — surfacing as a
-	// bare "permission denied" that reads like an RBAC problem. The loading
-	// flags stay set, so the refresh armed alongside this retries.
-	if st.Target.AppName == "" {
+	// The loading flags stay set, so the refresh armed alongside this retries
+	// once the tree has named the app.
+	if !m.paneCanFetch() {
 		return nil
 	}
 	var cmds []tea.Cmd

--- a/cmd/app/events_pane_empty_app_test.go
+++ b/cmd/app/events_pane_empty_app_test.go
@@ -95,7 +95,7 @@ func TestResourceTreeLoaded_NamesAndFetchesAnAlreadyOpenPane(t *testing.T) {
 	}
 
 	teaModel, cmd := m.Update(model.ResourceTreeLoadedMsg{
-		AppName: "test-app", SwitchEpoch: m.switchEpoch,
+		AppName: "test-app", AppNamespace: "test-namespace", SwitchEpoch: m.switchEpoch,
 	})
 	mm := teaModel.(*Model)
 
@@ -105,5 +105,36 @@ func TestResourceTreeLoaded_NamesAndFetchesAnAlreadyOpenPane(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Error("expected the named pane to start its pending fetches")
+	}
+}
+
+func TestResourceTreeLoaded_OutOfOrderSameNameOnlyNamesMatchingPane(t *testing.T) {
+	m := buildEventsPaneTestModel()
+	m.state.Events = &model.EventsState{
+		Loading:        true,
+		DetailsLoading: true,
+		LoadSeq:        1,
+	}
+
+	// Two same-named applications are loading concurrently. The completion
+	// from the other namespace arrives first and must not claim this pane.
+	teaModel, cmd := m.Update(model.ResourceTreeLoadedMsg{
+		AppName: "test-app", AppNamespace: "other-namespace", SwitchEpoch: m.switchEpoch,
+	})
+	m = teaModel.(*Model)
+	if m.state.Events.Target.AppName != "" || cmd != nil {
+		t.Fatalf("expected the other namespace's completion to leave the unnamed pane pending, got target %+v", m.state.Events.Target)
+	}
+
+	teaModel, cmd = m.Update(model.ResourceTreeLoadedMsg{
+		AppName: "test-app", AppNamespace: "test-namespace", SwitchEpoch: m.switchEpoch,
+	})
+	m = teaModel.(*Model)
+	want := model.EventsTarget{AppName: "test-app", AppNamespace: "test-namespace"}
+	if m.state.Events.Target != want {
+		t.Errorf("expected the matching completion to name the pane target %+v, got %+v", want, m.state.Events.Target)
+	}
+	if cmd == nil {
+		t.Error("expected the matching completion to start the pending fetches")
 	}
 }

--- a/cmd/app/events_pane_empty_app_test.go
+++ b/cmd/app/events_pane_empty_app_test.go
@@ -80,3 +80,30 @@ func TestPaneRefresh_WithAnAppName_Fetches(t *testing.T) {
 		t.Error("expected the refresh to fetch once the app is known")
 	}
 }
+
+// A pane opened before the resource tree arrives starts with an unnamed
+// target. The tree load must name that existing pane and start its pending
+// requests; waiting for a scheduled refresh is not sufficient when refresh is
+// disabled.
+func TestResourceTreeLoaded_NamesAndFetchesAnAlreadyOpenPane(t *testing.T) {
+	m := buildEventsPaneTestModel()
+	m.state.Events = &model.EventsState{
+		Target:         model.EventsTarget{},
+		Loading:        true,
+		DetailsLoading: true,
+		LoadSeq:        1,
+	}
+
+	teaModel, cmd := m.Update(model.ResourceTreeLoadedMsg{
+		AppName: "test-app", SwitchEpoch: m.switchEpoch,
+	})
+	mm := teaModel.(*Model)
+
+	want := model.EventsTarget{AppName: "test-app", AppNamespace: "test-namespace"}
+	if mm.state.Events.Target != want {
+		t.Errorf("expected the loaded tree to name the pane target %+v, got %+v", want, mm.state.Events.Target)
+	}
+	if cmd == nil {
+		t.Error("expected the named pane to start its pending fetches")
+	}
+}

--- a/cmd/app/events_pane_empty_app_test.go
+++ b/cmd/app/events_pane_empty_app_test.go
@@ -54,3 +54,29 @@ func TestPaneFetch_WithoutAnAppName_StaysLoadingSoTheRefreshRetries(t *testing.T
 		t.Error("expected the pane to remain loading so the next refresh picks the app up")
 	}
 }
+
+// The refresh is the retry the initial skip relies on, so it needs the same
+// guard: until the tree names the app, it would fetch the unnamed application.
+func TestPaneRefresh_WithoutAnAppName_FetchesNothing(t *testing.T) {
+	m := buildBaseModel(100, 30)
+	m.state.Events = &model.EventsState{
+		Target:  model.EventsTarget{},
+		LoadSeq: 1,
+	}
+
+	if cmd := m.paneRefreshCmds(); cmd != nil {
+		t.Error("expected the scheduled refresh to skip an unnamed application")
+	}
+}
+
+func TestPaneRefresh_WithAnAppName_Fetches(t *testing.T) {
+	m := buildBaseModel(100, 30)
+	m.state.Events = &model.EventsState{
+		Target:  model.EventsTarget{AppName: "demo-app"},
+		LoadSeq: 1,
+	}
+
+	if cmd := m.paneRefreshCmds(); cmd == nil {
+		t.Error("expected the refresh to fetch once the app is known")
+	}
+}

--- a/cmd/app/events_pane_empty_app_test.go
+++ b/cmd/app/events_pane_empty_app_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/darksworm/argonaut/pkg/model"
+)
+
+// The pane can be opened before the resource tree has loaded, and until it
+// has, the tree cannot name the app the cursor sits in.
+func TestPaneFetch_WithoutAnAppName_FetchesNothing(t *testing.T) {
+	m := buildBaseModel(100, 30)
+	m.state.Events = &model.EventsState{
+		Target:         model.EventsTarget{},
+		Loading:        true,
+		DetailsLoading: true,
+		LoadSeq:        1,
+	}
+
+	if cmd := m.paneFetchCmds(); cmd != nil {
+		t.Error("expected no request while the app is unknown: it would GET /api/v1/applications/ " +
+			"and the server's 403 surfaces as a bare \"permission denied\"")
+	}
+}
+
+func TestPaneFetch_WithAnAppName_Fetches(t *testing.T) {
+	m := buildBaseModel(100, 30)
+	m.state.Events = &model.EventsState{
+		Target:         model.EventsTarget{AppName: "demo-app"},
+		Loading:        true,
+		DetailsLoading: true,
+		LoadSeq:        1,
+	}
+
+	if cmd := m.paneFetchCmds(); cmd == nil {
+		t.Error("expected the pane to fetch once the app is known")
+	}
+}
+
+// The pane stays in its loading state so the already-armed refresh retries
+// once the tree has named the app.
+func TestPaneFetch_WithoutAnAppName_StaysLoadingSoTheRefreshRetries(t *testing.T) {
+	m := buildBaseModel(100, 30)
+	m.state.Events = &model.EventsState{
+		Target:         model.EventsTarget{},
+		Loading:        true,
+		DetailsLoading: true,
+		LoadSeq:        1,
+	}
+
+	m.paneFetchCmds()
+
+	if !m.state.Events.Loading || !m.state.Events.DetailsLoading {
+		t.Error("expected the pane to remain loading so the next refresh picks the app up")
+	}
+}

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -631,12 +631,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Clear loading overlay once initial tree is loaded
 		m.treeLoading = false
 		// The pane can be opened while the tree is still loading, before its
-		// target has an application name. Complete that pending target from the
-		// tree response and start the fetches whose loading flags remain set.
+		// target has an application name. Only the completion for the current
+		// single-app tree may complete that pending target: concurrent loads can
+		// finish out of order, including same-named apps in other namespaces.
 		if st := m.state.Events; st != nil && st.Target.AppName == "" {
-			st.Target.AppName = msg.AppName
-			st.Target.AppNamespace = m.resolveAppNamespace(msg.AppName)
-			return m, m.paneFetchCmds()
+			treeApp := m.state.UI.TreeApp
+			treeAppNamespace := ""
+			if treeApp != nil && treeApp.AppNamespace != nil {
+				treeAppNamespace = *treeApp.AppNamespace
+			}
+			if treeApp != nil && treeApp.Name == msg.AppName && treeAppNamespace == msg.AppNamespace {
+				st.Target.AppName = msg.AppName
+				st.Target.AppNamespace = msg.AppNamespace
+				return m, m.paneFetchCmds()
+			}
 		}
 		// The pane is part of the tree view: open it over the first loaded
 		// tree unless the user configured it away (or it is already open)

--- a/cmd/app/model.go
+++ b/cmd/app/model.go
@@ -630,6 +630,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Clear loading overlay once initial tree is loaded
 		m.treeLoading = false
+		// The pane can be opened while the tree is still loading, before its
+		// target has an application name. Complete that pending target from the
+		// tree response and start the fetches whose loading flags remain set.
+		if st := m.state.Events; st != nil && st.Target.AppName == "" {
+			st.Target.AppName = msg.AppName
+			st.Target.AppNamespace = m.resolveAppNamespace(msg.AppName)
+			return m, m.paneFetchCmds()
+		}
 		// The pane is part of the tree view: open it over the first loaded
 		// tree unless the user configured it away (or it is already open)
 		if m.canAutoOpenPane() && m.eventsAutoOpenEnabled() {

--- a/pkg/model/messages.go
+++ b/pkg/model/messages.go
@@ -498,6 +498,7 @@ type RollbackExecutedMsg struct {
 // ResourceTreeLoadedMsg is sent when a resource tree is loaded for an app
 type ResourceTreeLoadedMsg struct {
 	AppName       string
+	AppNamespace  string
 	Health        string
 	Sync          string
 	TreeJSON      []byte


### PR DESCRIPTION
Opening the tree view against a real Argo CD showed a pane reading `permission denied` in both its sections:

```
╭─ Application ─────────────╮
│ permission denied         │
│ EVENTS                    │
│ permission denied         │
```

It reads like an RBAC problem. It is not. The pane auto-opens as the tree view is entered, before `ResourceTreeLoadedMsg` has told the tree which app it is showing — so `SelectedNodeApp()` returns `""`, and argonaut asks for `GET /api/v1/applications/` with no name. Argo CD answers 403 `permission denied`, and that string goes straight to the pane. Debug log from the repro:

```
ERRO http error url=https://localhost:8080/api/v1/applications/ status=403
ERRO Failed to get application component=sync-status app=""
```

Both fetch paths now ask `paneCanFetch()` first: `paneFetchCmds` (auto-open and `e`) and `paneRefreshCmds` (the scheduled refresh). The loading flags stay set on the skip, so the refresh armed beside it retries once the tree names the app.

The mock e2e suite never caught this because the mock answers 200 for `/applications/`; only a real server rejects it.

Found while writing the horizontal e2e (#281), which is also where the fix was verified.

**Correction to an earlier version of this description:** it claimed one guard in `paneFetchCmds` covered every path. It did not — `paneRefreshCmds` builds its loads separately and was still unguarded, which mattered because that refresh *is* the retry the skip depends on. Caught in review; both paths now share `paneCanFetch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary event requests when the selected application is not yet known.
  * Preserved the loading state so event data automatically retries once the application becomes available.
  * Ensured already-open event panes begin loading after the application and namespace are identified.
  * Prevented responses from similarly named applications in other namespaces from loading the wrong event pane.

* **Tests**
  * Added coverage for delayed, populated, and namespace-matched application selections.
  * Verified loading indicators remain active while waiting to retry.
  * Confirmed open panes load only after receiving matching application details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->